### PR TITLE
Remove swiftformat conflicting swiftlint rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,3 +1,23 @@
+# SwiftFormat (see Mintfile / `.swiftformat`) owns mechanical layout and spacing.
+# Disable SwiftLint rules that duplicate it — especially correctable ones, or
+# `swiftlint --fix` after SwiftFormat will fight the formatter (e.g. trailing_comma).
+disabled_rules:
+  - closing_brace
+  - colon
+  - comma
+  - empty_parentheses_with_trailing_closure
+  - function_name_whitespace
+  - leading_whitespace
+  - opening_brace
+  - redundant_void_return
+  - return_arrow_whitespace
+  - trailing_comma
+  - trailing_newline
+  - trailing_semicolon
+  - trailing_whitespace
+  - vertical_whitespace
+  - void_return
+
 included:
   - Brew
   - BrewTests


### PR DESCRIPTION
# PR: Remove SwiftLint rules that conflict with SwiftFormat

## Summary

Removes SwiftLint rules that overlap or conflict with SwiftFormat so linting and formatting no longer fight each other. This keeps local checks consistent and reduces non-actionable lint noise.

## Changes

- Updated `.swiftlint.yml` to remove SwiftFormat-conflicting SwiftLint rules.

## Why this split (optional)

This is a focused lint-configuration cleanup that can be reviewed and landed independently of feature work.

## Testing

- [ ] Run `swiftlint` locally and confirm no regressions from removed rules.
- [ ] Run formatting/lint workflow and verify rule conflicts are resolved.

## PR checklist

- [ ] Have you followed this repository's contribution and workflow guidance?
- [ ] Have you explained what changed and why this should land now?
- [ ] Have you run relevant local checks for the changed scope?
- [ ] Are changes scoped and free of unrelated modifications?

-----

- [ ] AI was used to generate or assist with generating this PR.
- [ ] If yes, describe exactly how AI was used and what manual verification was performed.

-----

## Follow-ups (optional)

If additional lint/format overlap appears, do a second pass to keep `.swiftlint.yml` focused on non-formatting rules.