### PR TITLE
Improve Installed loading shell UX

### DIFF
--- a/Brew/Features/Installed/InstalledShellView.swift
+++ b/Brew/Features/Installed/InstalledShellView.swift
@@ -35,39 +35,35 @@ struct InstalledShellView: View {
             }
 
             ZStack {
-                ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 0) {
-                        if viewModel.shouldShowFormulaeSection {
-                            installedSection(
-                                title: "Formulae",
-                                rows: viewModel.formulaRows,
-                            )
-                        }
-
-                        if viewModel.shouldShowInterSectionDivider {
-                            Divider()
-                                .overlay(Color.brewBorderSeparator)
-                                .padding(.vertical, BrewSpacing.md)
-                        }
-
-                        if viewModel.shouldShowCasksSection {
-                            installedSection(
-                                title: "Casks",
-                                rows: viewModel.caskRows,
-                            )
-                        }
-                    }
-                    .padding(.horizontal, BrewSpacing.lg)
-                    .padding(.bottom, BrewSpacing.xl)
-                }
-                .accessibilityLabel("Installed packages")
-
                 if viewModel.shouldShowInitialLoadingIndicator {
-                    ProgressView()
-                        .controlSize(.large)
-                        .accessibilityLabel(
-                            String(localized: "Loading packages", comment: "Installed tab loading a11y"),
-                        )
+                    loadingSkeletonList
+                } else {
+                    ScrollView {
+                        LazyVStack(alignment: .leading, spacing: 0) {
+                            if viewModel.shouldShowFormulaeSection {
+                                installedSection(
+                                    title: "Formulae",
+                                    rows: viewModel.formulaRows,
+                                )
+                            }
+
+                            if viewModel.shouldShowInterSectionDivider {
+                                Divider()
+                                    .overlay(Color.brewBorderSeparator)
+                                    .padding(.vertical, BrewSpacing.md)
+                            }
+
+                            if viewModel.shouldShowCasksSection {
+                                installedSection(
+                                    title: "Casks",
+                                    rows: viewModel.caskRows,
+                                )
+                            }
+                        }
+                        .padding(.horizontal, BrewSpacing.lg)
+                        .padding(.bottom, BrewSpacing.xl)
+                    }
+                    .accessibilityLabel("Installed packages")
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -86,6 +82,57 @@ struct InstalledShellView: View {
                 InstalledListRowView(row: row)
             }
         }
+    }
+
+    private var loadingSkeletonList: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                InstalledSectionHeader(title: "Formulae", count: 3)
+                ForEach(0 ..< 3, id: \.self) { _ in
+                    InstalledSkeletonRowView()
+                }
+
+                Divider()
+                    .overlay(Color.brewBorderSeparator)
+                    .padding(.vertical, BrewSpacing.md)
+
+                InstalledSectionHeader(title: "Casks", count: 2)
+                ForEach(0 ..< 2, id: \.self) { _ in
+                    InstalledSkeletonRowView()
+                }
+            }
+            .padding(.horizontal, BrewSpacing.lg)
+            .padding(.bottom, BrewSpacing.xl)
+        }
+        .redacted(reason: .placeholder)
+        .allowsHitTesting(false)
+        .accessibilityLabel("Loading package list")
+    }
+}
+
+private struct InstalledSkeletonRowView: View {
+    var body: some View {
+        HStack(alignment: .top, spacing: BrewSpacing.md) {
+            Circle()
+                .fill(Color.brewSurfaceElevated)
+                .frame(width: 36, height: 36)
+
+            VStack(alignment: .leading, spacing: BrewSpacing.xs) {
+                RoundedRectangle(cornerRadius: BrewRadius.sm)
+                    .fill(Color.brewSurfaceElevated)
+                    .frame(width: 180, height: 16)
+
+                RoundedRectangle(cornerRadius: BrewRadius.sm)
+                    .fill(Color.brewSurfaceElevated)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 12)
+
+                RoundedRectangle(cornerRadius: BrewRadius.sm)
+                    .fill(Color.brewSurfaceElevated)
+                    .frame(width: 90, height: 10)
+            }
+        }
+        .padding(.vertical, BrewSpacing.sm)
     }
 }
 


### PR DESCRIPTION
# PR: Improve Installed loading shell UX

## Summary

This PR replaces the Installed tab's initial full-screen spinner with a sectioned skeleton loading state that better matches the final content layout. The goal is to reduce perceived jank and provide clearer visual structure while package data is loading.

## Changes

- Updated `Brew/Features/Installed/InstalledShellView.swift` to render a dedicated loading skeleton list when `shouldShowInitialLoadingIndicator` is true.
- Added a new `loadingSkeletonList` view that mirrors real Installed content sections (`Formulae` and `Casks`) with placeholder rows.
- Added `InstalledSkeletonRowView` to provide reusable placeholder row visuals (icon + text lines) using design-system spacing, radius, and color tokens.
- Removed the previous overlaid `ProgressView` loading treatment in favor of in-flow placeholder content.
- Added loading-state accessibility label for the placeholder list (`"Loading package list"`).

## Testing

- [ ] Run app and open Installed tab to verify skeleton appears during initial load.
- [ ] Verify transition from skeleton to actual package rows when data loads.

## PR checklist

- [x] Have you followed this repository's contribution and workflow guidance?
- [x] Have you explained what changed and why this should land now?
- [ ] Have you run relevant local checks for the changed scope?
- [x] Are changes scoped and free of unrelated modifications?

-----

- [x] AI was used to generate or assist with generating this PR.
- [x] If yes, describe exactly how AI was used and what manual verification was performed.
  - AI was used to draft this PR description from the current branch diff and commit history.
  - Manual verification still required: local UI run-through and relevant checks listed above.
