### PR TITLE
Cache Mint packages

### DIFF
--- a/.github/workflows/swift_quality.yml
+++ b/.github/workflows/swift_quality.yml
@@ -30,6 +30,8 @@ jobs:
   swift-quality:
     name: SwiftFormat + SwiftLint
     runs-on: macos-26
+    env:
+      MINT_PATH: ${{ github.workspace }}/mint
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -41,7 +43,17 @@ jobs:
           uninstall: true
           workflow-key: swift-quality
 
+      - name: Cache Mint packages
+        id: mint-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/mint
+          key: ${{ runner.os }}-mint-${{ hashFiles('**/Mintfile') }}
+          restore-keys: |
+            ${{ runner.os }}-mint-
+
       - name: Install Mintfile packages
+        if: steps.mint-cache.outputs.cache-hit != 'true'
         run: mint bootstrap --mintfile Mintfile
 
       - name: Check formatting


### PR DESCRIPTION
# PR: Cache Mint packages in swift quality CI

## Summary

This PR speeds up `swift_quality` CI by caching Mint-installed tooling between runs. It reduces repeated `mint bootstrap` work on unchanged `Mintfile` dependencies while keeping the existing lint/format behavior intact.

## Changes

- Add job-level `MINT_PATH` in `.github/workflows/swift_quality.yml` set to `${{ github.workspace }}/mint` so Mint installs into a deterministic, cacheable location.
- Add a `Cache Mint packages` step using `actions/cache@v4` (with `id: mint-cache`) before Mint bootstrap.
- Cache path `${{ github.workspace }}/mint` with key `${{ runner.os }}-mint-${{ hashFiles('**/Mintfile') }}` and restore key `${{ runner.os }}-mint-`.
- Guard `Install Mintfile packages` so `mint bootstrap --mintfile Mintfile` only runs on cache miss using `if: steps.mint-cache.outputs.cache-hit != 'true'`.

## Testing

- [ ] Run `swift_quality` in CI and confirm cache is saved on first run.
- [ ] Re-run `swift_quality` and confirm `Cache Mint packages` reports a hit.
- [ ] Confirm `Install Mintfile packages` is skipped on cache hit.
- [ ] Confirm `mint run swiftformat --lint .` and `mint run swiftlint lint --strict` still execute successfully.

## PR checklist

- [x] Have you followed this repository's contribution and workflow guidance?
- [x] Have you explained what changed and why this should land now?
- [x] Have you run relevant local checks for the changed scope?
- [x] Are changes scoped and free of unrelated modifications?

-----

- [x] AI was used to generate or assist with generating this PR.
- [x] If yes, describe exactly how AI was used and what manual verification was performed.

  **AI use:** I used Cursor’s coding agent to draft this PR description from the workflow diff and template. I manually reviewed the final text against `.github/workflows/swift_quality.yml` and validated that the listed checks match this PR’s scope.