### PR TITLE
BrewCommandCenter for app-wide brew operations

### DIFF
--- a/.ai/memory.md
+++ b/.ai/memory.md
@@ -155,4 +155,15 @@
 ## 2026-04-27 — Brew command pipe-drain fix
 
 - `BrewCommandService` now starts concurrent stdout/stderr readers immediately after process launch and only then waits for process termination, avoiding wait-before-read deadlocks on large command output.
-- Added `BrewCommandServiceTests` including a large output regression case (250k chars on each stream) to protect command execution paths used by installed list and details loading.
+- Added `BrewCommandServiceTests` including a large output regression case (250k chars on each stream) to protect command execution paths used for installed list and details loading.
+
+## 2026-05-03 — BrewCommandCenter + operation IDs
+
+- **Protocol `BrewCommandCenter`:** `actor` protocol — `submit(id:command:)`, `phase(for:)`, `phaseByID()` (full snapshot map), `isActive(id:)` (all `async` from callers).
+- **`BrewMutatingCommand`:** `Sendable` command pattern — `var operationKind`, `func run(in: BrewCommandExecutionContext) async throws` (no caller closures; kind is not duplicated at `submit`).
+- **`BrewCommandExecutionContext`:** `commandRunner` (`BrewCommandRunning`) + `brewExecutableURL()` via `locator` (`BrewExecutableLocating`).
+- **`SerialBrewCommandCenter`:** `actor`; **`SerialBrewWorkQueue`** inner actor ensures **one mutating command at a time** across `await`; duplicate **`BrewOperationID`** coalesces via shared **`Task`** handle.
+- **`OperationFailure`:** `Sendable` `enum` (`.brewCommand`, `.brewLaunchFailed`, `.brewExecutableNotFound`, `.generic`) for **`BrewOperationPhase.failed(reason:)`**; `init(catching:)` maps `BrewCommandError`, `BrewLookupError`, and other errors to cases; **`userFacingMessage`** is a derived line for UI.
+- **Transport types (`BrewOperationModels.swift`):** `BrewOperationKind`, `BrewOperationID`, `BrewOperationPhase`.
+- **Domain package discriminator:** `HomebrewPackageKind`; `InstalledPackageKind` typealias; **`BrewOperationID.init(kind:name:)`** in **`BrewOperationID+Homebrew.swift`**.
+- **Composition:** **`SerialBrewCommandCenter`** is not wired in **`BrewApp`** yet — shell view models (**`MainWindowViewModel`**, **`InstalledViewModel`**) omit **`BrewCommandCenter`** until upgrade/mutating UX injects it at the composition root. Command-center unit tests construct **`SerialBrewCommandCenter`** or **`NoopBrewCommandCenter.forTesting()`** directly; previews that need a noop center use **`NoopBrewCommandCenter.preview()`** (both noop factories wire **`BrewCommandExecutionContext.noopForTestingAndPreviews()`**).

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -45,6 +45,7 @@ Guiding patterns:
 - **Repositories:** CRUD-shaped access to a **data source** (CLI output, API, storage, in-memory). Swap the implementation, keep the contract.
 - **Interactors:** One **use case** each — not generic CRUD (e.g. doctor run, config snapshot). Prefer protocols + real/mock impls for tests.
 - **Services:** Infrastructure — e.g. `BrewCommandService` (subprocess, streaming, cancellation), `JSONAPIService` (fetch/decode).
+- **Command center:** `BrewCommandCenter` (actor protocol; app default `SerialBrewCommandCenter`) — **serializes** mutating `brew` work, tracks **in-flight / failed** **operation** state (`BrewOperationID` + `BrewOperationPhase`) for UI across surfaces, and runs **small `BrewMutatingCommand` types** that call `BrewCommandRunning` + the brew locator. It does **not** own **read/parsing** of `brew list` / `brew info` output — that stays in **repositories**. Feature-scoped executors (e.g. upgrade helpers) should stay **thin** and be invoked **from** commands the center schedules, not as a second parallel pipeline.
 - **Models:** Shared types (`Formula`, jobs, config, …) and pure parsing/helpers where it keeps UI layers thin.
 
 ## File organisation

--- a/Brew/BrewApp.swift
+++ b/Brew/BrewApp.swift
@@ -9,6 +9,12 @@ import SwiftUI
 
 @main
 struct BrewApp: App {
+    private let commandCenter: SerialBrewCommandCenter
+
+    init() {
+        commandCenter = SerialBrewCommandCenter(executionContext: .live())
+    }
+
     var body: some Scene {
         WindowGroup {
             MainWindowView(

--- a/Brew/Models/BrewOperationID+Homebrew.swift
+++ b/Brew/Models/BrewOperationID+Homebrew.swift
@@ -1,0 +1,13 @@
+//
+//  BrewOperationID+Homebrew.swift
+//  Brew
+//
+
+import Foundation
+
+extension BrewOperationID {
+    /// Stable id from domain package kind + name (`kind:name`, matches Homebrew list-stable strings).
+    init(kind: HomebrewPackageKind, name: String) {
+        rawValue = "\(kind.rawValue):\(name)"
+    }
+}

--- a/Brew/Models/HomebrewPackageKind.swift
+++ b/Brew/Models/HomebrewPackageKind.swift
@@ -1,0 +1,15 @@
+//
+//  HomebrewPackageKind.swift
+//  Brew
+//
+
+import Foundation
+
+/// Whether an installed Homebrew unit is a formula or a cask — domain-level discriminator (repositories, operations, presentation).
+enum HomebrewPackageKind: String, Hashable {
+    case formula
+    case cask
+}
+
+/// Stable synonym used across the Installed feature and tests — identical to ``HomebrewPackageKind``.
+typealias InstalledPackageKind = HomebrewPackageKind

--- a/Brew/Models/InstalledPackageRow.swift
+++ b/Brew/Models/InstalledPackageRow.swift
@@ -5,12 +5,6 @@
 
 import Foundation
 
-/// Homebrew package kind for installed list presentation.
-enum InstalledPackageKind: String, Hashable {
-    case formula
-    case cask
-}
-
 /// One row in the Installed list (presentation model; map from domain later).
 struct InstalledPackageRow: Identifiable, Hashable {
     /// Stable across reloads so list identity stays predictable.

--- a/Brew/Models/PackageKindChrome.swift
+++ b/Brew/Models/PackageKindChrome.swift
@@ -23,7 +23,7 @@ struct PackageKindChrome: Equatable {
     var iconBackground: PackageKindIconBackgroundToken
 }
 
-extension InstalledPackageKind {
+extension HomebrewPackageKind {
     var chrome: PackageKindChrome {
         switch self {
         case .formula:

--- a/Brew/Services/BrewCommandCenter.swift
+++ b/Brew/Services/BrewCommandCenter.swift
@@ -1,0 +1,29 @@
+//
+//  BrewCommandCenter.swift
+//  Brew
+//
+
+import Foundation
+
+/// Coordinates mutating `brew` operations and cross-surface visibility (`ARCHITECTURE.md` — command execution).
+protocol BrewCommandCenter: Actor {
+    /// Snapshot for UI — ``BrewOperationPhase/idle`` when no state is tracked for `id`.
+    func phase(for id: BrewOperationID) async -> BrewOperationPhase
+
+    /// All tracked phases keyed by ``BrewOperationID``. Missing keys are equivalent to ``BrewOperationPhase/idle``.
+    func phaseByID() async -> [BrewOperationID: BrewOperationPhase]
+
+    /// `true` while work for `id` is actively running (not failed-only).
+    func isActive(id: BrewOperationID) async -> Bool
+
+    /// Enqueue mutating work keyed by `id`.
+    ///
+    /// **Concurrency:** Conforming types such as ``SerialBrewCommandCenter`` run work **serially** (one mutating operation at a time).
+    /// **Idempotence:** A second `submit` for the same `id` while the first is in flight awaits the same result;
+    /// the command runs once.
+    /// **Phase:** Running visibility uses ``BrewMutatingCommand/operationKind`` from `command` (no separate kind argument).
+    func submit(
+        id: BrewOperationID,
+        command: any BrewMutatingCommand,
+    ) async throws
+}

--- a/Brew/Services/BrewCommandExecutionContext+Preview.swift
+++ b/Brew/Services/BrewCommandExecutionContext+Preview.swift
@@ -1,0 +1,22 @@
+//
+//  BrewCommandExecutionContext+Preview.swift
+//  Brew
+//
+
+import Foundation
+
+extension BrewCommandExecutionContext {
+    /// Runner returns empty success without touching disk; locator yields a dummy `brew` URL for callers that resolve it.
+    static func noopForTestingAndPreviews() -> BrewCommandExecutionContext {
+        BrewCommandExecutionContext(
+            commandRunner: ImmediateSuccessCommandRunner(),
+            locator: BrewExecutableLocator(overrideURL: URL(fileURLWithPath: "/opt/homebrew/bin/brew")),
+        )
+    }
+}
+
+private struct ImmediateSuccessCommandRunner: BrewCommandRunning {
+    func run(executableURL _: URL, arguments _: [String]) async throws -> CommandOutput {
+        CommandOutput(standardOutput: "", standardError: "", terminationStatus: 0)
+    }
+}

--- a/Brew/Services/BrewCommandExecutionContext.swift
+++ b/Brew/Services/BrewCommandExecutionContext.swift
@@ -1,0 +1,26 @@
+//
+//  BrewCommandExecutionContext.swift
+//  Brew
+//
+
+import Foundation
+
+/// Dependencies for mutating `brew` subprocess work passed into ``BrewMutatingCommand/run(in:)``.
+struct BrewCommandExecutionContext {
+    var commandRunner: BrewCommandRunning
+    var locator: BrewExecutableLocating
+
+    func brewExecutableURL() throws -> URL {
+        try locator.findBrewExecutable()
+    }
+}
+
+extension BrewCommandExecutionContext {
+    /// Production wiring: real subprocess runner + default `brew` lookup (same pairing as ``BrewInstalledPackagesRepository/live()``).
+    static func live() -> BrewCommandExecutionContext {
+        BrewCommandExecutionContext(
+            commandRunner: BrewCommandService(),
+            locator: BrewExecutableLocator(),
+        )
+    }
+}

--- a/Brew/Services/BrewMutatingCommand.swift
+++ b/Brew/Services/BrewMutatingCommand.swift
@@ -1,0 +1,14 @@
+//
+//  BrewMutatingCommand.swift
+//  Brew
+//
+
+import Foundation
+
+/// One schedulable unit of mutating Homebrew work (command pattern); implemented by small `Sendable` types with `run(in:)`.
+protocol BrewMutatingCommand: Sendable {
+    /// Kind of mutating work — drives ``BrewOperationPhase/running(_:)`` when this command is scheduled.
+    nonisolated var operationKind: BrewOperationKind { get }
+
+    func run(in context: BrewCommandExecutionContext) async throws
+}

--- a/Brew/Services/BrewOperationModels.swift
+++ b/Brew/Services/BrewOperationModels.swift
@@ -1,0 +1,29 @@
+//
+//  BrewOperationModels.swift
+//  Brew
+//
+
+import Foundation
+
+/// Mutating Homebrew work the command center may schedule (extend as features grow).
+enum BrewOperationKind: String, Hashable {
+    case upgradeFormula
+    case upgradeCask
+}
+
+/// Stable opaque identity for in-flight mutating work (e.g. upgrades). Conventionally `formula:<name>` or `cask:<name>` to align with Homebrew package identity strings — see ``BrewOperationID`` helpers in the Models layer.
+struct BrewOperationID: Hashable, Identifiable {
+    var id: String {
+        rawValue
+    }
+
+    let rawValue: String
+}
+
+/// Visibility for UI and tests — mutually exclusive with “absent” represented by ``BrewCommandCenter/phase(for:)``
+/// returning ``BrewOperationPhase/idle`` when the center has no record for that id.
+enum BrewOperationPhase: Equatable {
+    case idle
+    case running(BrewOperationKind)
+    case failed(reason: OperationFailure)
+}

--- a/Brew/Services/NoopBrewCommandCenter.swift
+++ b/Brew/Services/NoopBrewCommandCenter.swift
@@ -1,0 +1,47 @@
+//
+//  NoopBrewCommandCenter.swift
+//  Brew
+//
+
+import Foundation
+
+/// Pass-through center for previews and tests: runs commands immediately with no phase bookkeeping or queuing.
+actor NoopBrewCommandCenter: BrewCommandCenter {
+    private let executionContext: BrewCommandExecutionContext
+
+    init(executionContext: BrewCommandExecutionContext) {
+        self.executionContext = executionContext
+    }
+
+    /// Preconfigured noop center for SwiftUI previews (immediate execution, standard noop context).
+    static func preview() -> NoopBrewCommandCenter {
+        NoopBrewCommandCenter(executionContext: .noopForTestingAndPreviews())
+    }
+
+    /// Preconfigured noop center for unit tests (same wiring as ``preview()``).
+    static func forTesting() -> NoopBrewCommandCenter {
+        NoopBrewCommandCenter(executionContext: .noopForTestingAndPreviews())
+    }
+
+    func phase(for id: BrewOperationID) async -> BrewOperationPhase {
+        _ = id
+        return .idle
+    }
+
+    func phaseByID() async -> [BrewOperationID: BrewOperationPhase] {
+        [:]
+    }
+
+    func isActive(id: BrewOperationID) async -> Bool {
+        _ = id
+        return false
+    }
+
+    func submit(
+        id: BrewOperationID,
+        command: any BrewMutatingCommand,
+    ) async throws {
+        _ = id
+        try await command.run(in: executionContext)
+    }
+}

--- a/Brew/Services/OperationFailure.swift
+++ b/Brew/Services/OperationFailure.swift
@@ -1,0 +1,65 @@
+//
+//  OperationFailure.swift
+//  Brew
+//
+
+import Foundation
+
+/// User-visible and diagnostic failure surfaced through ``BrewOperationPhase/failed(reason:)`` (`Sendable` for actor-isolated state).
+enum OperationFailure: Equatable, Sendable {
+    /// `brew` ran but exited non-zero; stderr is the primary user-visible detail when present.
+    case brewCommand(exitCode: Int32, stderr: String)
+
+    /// Could not launch `brew` (POSIX / process spawn failure before exit status).
+    case brewLaunchFailed(diagnostic: String)
+
+    /// Locator could not find `brew` in supported prefixes (`AGENTS.md`).
+    case brewExecutableNotFound
+
+    /// Fallback for arbitrary errors: localized/user text plus optional diagnostic string.
+    case generic(userFacing: String, diagnostic: String?)
+
+    /// Primary line for UI and accessibility (derived per case).
+    var userFacingMessage: String {
+        switch self {
+        case let .brewCommand(_, stderr):
+            let trimmed = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return trimmed
+            }
+            return String(localized: "Homebrew command failed.", comment: "Shown when brew exits non-zero with no stderr")
+
+        case let .brewLaunchFailed(diagnostic):
+            return diagnostic
+
+        case .brewExecutableNotFound:
+            return String(localized: "Could not find the brew executable.", comment: "Shown when brew binary is missing")
+
+        case let .generic(userFacing, _):
+            return userFacing
+        }
+    }
+
+    init(userFacingMessage: String, diagnosticDescription: String? = nil) {
+        self = .generic(userFacing: userFacingMessage, diagnostic: diagnosticDescription)
+    }
+
+    init(catching error: Error) {
+        switch error {
+        case let brewCommandError as BrewCommandError:
+            switch brewCommandError {
+            case let .failed(exitCode, stderr):
+                self = .brewCommand(exitCode: exitCode, stderr: stderr)
+            case let .launchFailed(underlying):
+                self = .brewLaunchFailed(diagnostic: underlying)
+            }
+
+        case BrewLookupError.executableNotFound:
+            self = .brewExecutableNotFound
+
+        default:
+            let userFacing = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            self = .generic(userFacing: userFacing, diagnostic: String(describing: error))
+        }
+    }
+}

--- a/Brew/Services/OperationFailure.swift
+++ b/Brew/Services/OperationFailure.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /// User-visible and diagnostic failure surfaced through ``BrewOperationPhase/failed(reason:)`` (`Sendable` for actor-isolated state).
-enum OperationFailure: Equatable, Sendable {
+enum OperationFailure: Equatable {
     /// `brew` ran but exited non-zero; stderr is the primary user-visible detail when present.
     case brewCommand(exitCode: Int32, stderr: String)
 
@@ -27,13 +27,19 @@ enum OperationFailure: Equatable, Sendable {
             if !trimmed.isEmpty {
                 return trimmed
             }
-            return String(localized: "Homebrew command failed.", comment: "Shown when brew exits non-zero with no stderr")
+            return String(
+                localized: "Homebrew command failed.",
+                comment: "Shown when brew exits non-zero with no stderr",
+            )
 
         case let .brewLaunchFailed(diagnostic):
             return diagnostic
 
         case .brewExecutableNotFound:
-            return String(localized: "Could not find the brew executable.", comment: "Shown when brew binary is missing")
+            return String(
+                localized: "Could not find the brew executable.",
+                comment: "Shown when brew binary is missing",
+            )
 
         case let .generic(userFacing, _):
             return userFacing

--- a/Brew/Services/SerialBrewCommandCenter.swift
+++ b/Brew/Services/SerialBrewCommandCenter.swift
@@ -1,0 +1,72 @@
+//
+//  SerialBrewCommandCenter.swift
+//  Brew
+//
+
+import Foundation
+
+/// Runs async mutating work strictly one-at-a-time, including across `await` inside commands (serial policy).
+private actor SerialBrewWorkQueue {
+    func run(_ work: @Sendable @escaping () async throws -> Void) async rethrows {
+        try await work()
+    }
+}
+
+/// Default app implementation: serializes mutating `brew` subprocess work and exposes per-operation phase for UI.
+actor SerialBrewCommandCenter: BrewCommandCenter {
+    private let executionContext: BrewCommandExecutionContext
+    private let workQueue = SerialBrewWorkQueue()
+
+    private var trackedPhasesByID: [BrewOperationID: BrewOperationPhase] = [:]
+    private var inflightByID: [BrewOperationID: Task<Void, Error>] = [:]
+
+    init(executionContext: BrewCommandExecutionContext) {
+        self.executionContext = executionContext
+    }
+
+    func phase(for id: BrewOperationID) async -> BrewOperationPhase {
+        trackedPhasesByID[id] ?? .idle
+    }
+
+    func phaseByID() async -> [BrewOperationID: BrewOperationPhase] {
+        trackedPhasesByID
+    }
+
+    func isActive(id: BrewOperationID) async -> Bool {
+        if case .running = trackedPhasesByID[id] ?? .idle {
+            return true
+        }
+        return false
+    }
+
+    func submit(
+        id: BrewOperationID,
+        command: any BrewMutatingCommand,
+    ) async throws {
+        if let existing = inflightByID[id] {
+            try await existing.value
+            return
+        }
+
+        let kind = command.operationKind
+        let queue = workQueue
+        let ctx = executionContext
+        let task = Task<Void, Error> {
+            try await queue.run {
+                try await command.run(in: ctx)
+            }
+        }
+
+        inflightByID[id] = task
+        defer { inflightByID[id] = nil }
+
+        trackedPhasesByID[id] = .running(kind)
+        do {
+            try await task.value
+            trackedPhasesByID[id] = nil
+        } catch {
+            trackedPhasesByID[id] = .failed(reason: OperationFailure(catching: error))
+            throw error
+        }
+    }
+}

--- a/BrewTests/NoopBrewCommandCenterTests.swift
+++ b/BrewTests/NoopBrewCommandCenterTests.swift
@@ -1,0 +1,74 @@
+//
+//  NoopBrewCommandCenterTests.swift
+//  BrewTests
+//
+
+@testable import Brew
+import Foundation
+import Testing
+
+struct NoopBrewCommandCenterTests {
+    @Test func `phase and activity stay empty while idle`() async {
+        let center = NoopBrewCommandCenter.forTesting()
+        let id = BrewOperationID(kind: .formula, name: "hello")
+
+        #expect(await center.phase(for: id) == .idle)
+        #expect(await center.phaseByID().isEmpty)
+        #expect(await !center.isActive(id: id))
+    }
+
+    @Test func `submit runs command without tracking phase`() async throws {
+        let center = NoopBrewCommandCenter.forTesting()
+        let id = BrewOperationID(kind: .cask, name: "slack")
+        let counter = InvocationCounter()
+
+        try await center.submit(id: id, command: IncrementOnceCommand(counter: counter))
+
+        #expect(await counter.value == 1)
+        #expect(await center.phase(for: id) == .idle)
+        #expect(await center.phaseByID().isEmpty)
+        #expect(await !center.isActive(id: id))
+    }
+
+    @Test func `submit propagates thrown errors`() async {
+        let center = NoopBrewCommandCenter.forTesting()
+        let id = BrewOperationID(rawValue: "formula:broken")
+
+        await #expect(throws: NoopThrowingCommand.TestError.self) {
+            try await center.submit(id: id, command: NoopThrowingCommand())
+        }
+        #expect(await center.phase(for: id) == .idle)
+    }
+}
+
+// MARK: - Commands
+
+private struct IncrementOnceCommand: BrewMutatingCommand {
+    let counter: InvocationCounter
+
+    nonisolated var operationKind: BrewOperationKind { .upgradeFormula }
+
+    func run(in context: BrewCommandExecutionContext) async throws {
+        _ = context
+        await counter.increment()
+    }
+}
+
+private struct NoopThrowingCommand: BrewMutatingCommand {
+    struct TestError: Error {}
+
+    nonisolated var operationKind: BrewOperationKind { .upgradeCask }
+
+    func run(in context: BrewCommandExecutionContext) async throws {
+        _ = context
+        throw TestError()
+    }
+}
+
+private actor InvocationCounter {
+    private(set) var value = 0
+
+    func increment() {
+        value += 1
+    }
+}

--- a/BrewTests/NoopBrewCommandCenterTests.swift
+++ b/BrewTests/NoopBrewCommandCenterTests.swift
@@ -46,7 +46,9 @@ struct NoopBrewCommandCenterTests {
 private struct IncrementOnceCommand: BrewMutatingCommand {
     let counter: InvocationCounter
 
-    nonisolated var operationKind: BrewOperationKind { .upgradeFormula }
+    nonisolated var operationKind: BrewOperationKind {
+        .upgradeFormula
+    }
 
     func run(in context: BrewCommandExecutionContext) async throws {
         _ = context
@@ -57,7 +59,9 @@ private struct IncrementOnceCommand: BrewMutatingCommand {
 private struct NoopThrowingCommand: BrewMutatingCommand {
     struct TestError: Error {}
 
-    nonisolated var operationKind: BrewOperationKind { .upgradeCask }
+    nonisolated var operationKind: BrewOperationKind {
+        .upgradeCask
+    }
 
     func run(in context: BrewCommandExecutionContext) async throws {
         _ = context

--- a/BrewTests/SerialBrewCommandCenterTests.swift
+++ b/BrewTests/SerialBrewCommandCenterTests.swift
@@ -1,0 +1,188 @@
+//
+//  SerialBrewCommandCenterTests.swift
+//  BrewTests
+//
+
+@testable import Brew
+import Foundation
+import Testing
+
+struct SerialBrewCommandCenterTests {
+    private func makeCenter() -> SerialBrewCommandCenter {
+        let ctx = BrewCommandExecutionContext(
+            commandRunner: MockBrewCommandRunner(responses: [:]),
+            locator: BrewExecutableLocator(overrideURL: URL(fileURLWithPath: "/fake/brew")),
+        )
+        return SerialBrewCommandCenter(executionContext: ctx)
+    }
+
+    @Test func `serializes operations so second runs after first`() async throws {
+        let center = makeCenter()
+        let idA = BrewOperationID(kind: .formula, name: "a")
+        let idB = BrewOperationID(kind: .formula, name: "b")
+        let collector = OrderCollector()
+
+        try await center.submit(
+            id: idA,
+            command: OrderingSleepCommand(collector: collector, prefix: "a"),
+        )
+        try await center.submit(
+            id: idB,
+            command: AppendTokenCommand(collector: collector, token: "b"),
+        )
+
+        let order = await collector.snapshot()
+        #expect(order == ["a-start", "a-end", "b"])
+    }
+
+    @Test func `duplicate id coalesces to a single command body`() async throws {
+        let center = makeCenter()
+        let id = BrewOperationID(kind: .formula, name: "git")
+        let counter = InvocationCounter()
+
+        let first = Task {
+            try await center.submit(
+                id: id,
+                command: SlowIncrementCommand(counter: counter),
+            )
+        }
+        try await Task.sleep(for: .milliseconds(5))
+        let second = Task {
+            try await center.submit(
+                id: id,
+                command: SlowIncrementCommand(counter: counter),
+            )
+        }
+
+        try await first.value
+        try await second.value
+        let count = await counter.value
+        #expect(count == 1)
+    }
+
+    @Test func `clears running phase on success`() async throws {
+        let center = makeCenter()
+        let id = BrewOperationID(rawValue: "formula:ok")
+        #expect(await center.phase(for: id) == .idle)
+
+        try await center.submit(id: id, command: EmptyMutatingCommand())
+
+        #expect(await center.phase(for: id) == .idle)
+        #expect(await !center.isActive(id: id))
+    }
+
+    @Test func `records failure with OperationFailure and clears in flight slot`() async throws {
+        let center = makeCenter()
+        let id = BrewOperationID(rawValue: "formula:bad")
+
+        do {
+            try await center.submit(id: id, command: ThrowingMutatingCommand())
+            Issue.record("expected submit to throw")
+        } catch {
+            _ = error
+        }
+
+        let phase = await center.phase(for: id)
+        guard case let .failed(reason: failure) = phase else {
+            Issue.record("expected failed phase")
+            return
+        }
+        #expect(!failure.userFacingMessage.isEmpty)
+        #expect(await !center.isActive(id: id))
+    }
+
+    @Test func `phaseByID exposes tracked entries`() async throws {
+        let center = makeCenter()
+        let id = BrewOperationID(rawValue: "formula:snapshot")
+        #expect(await center.phaseByID().isEmpty)
+
+        do {
+            try await center.submit(id: id, command: ThrowingMutatingCommand())
+        } catch {
+            _ = error
+        }
+
+        let map = await center.phaseByID()
+        #expect(map[id] != nil)
+        #expect(await center.phase(for: id) == map[id])
+    }
+}
+
+// MARK: - Test commands
+
+private struct EmptyMutatingCommand: BrewMutatingCommand {
+    nonisolated var operationKind: BrewOperationKind { .upgradeFormula }
+
+    func run(in context: BrewCommandExecutionContext) async throws {
+        _ = context
+    }
+}
+
+private struct ThrowingMutatingCommand: BrewMutatingCommand {
+    struct TestError: Error {}
+
+    nonisolated var operationKind: BrewOperationKind { .upgradeFormula }
+
+    func run(in context: BrewCommandExecutionContext) async throws {
+        _ = context
+        throw TestError()
+    }
+}
+
+private actor OrderCollector {
+    private var order: [String] = []
+
+    func append(_ token: String) {
+        order.append(token)
+    }
+
+    func snapshot() -> [String] {
+        order
+    }
+}
+
+private struct OrderingSleepCommand: BrewMutatingCommand {
+    let collector: OrderCollector
+    let prefix: String
+
+    nonisolated var operationKind: BrewOperationKind { .upgradeFormula }
+
+    func run(in context: BrewCommandExecutionContext) async throws {
+        _ = context
+        await collector.append("\(prefix)-start")
+        try await Task.sleep(for: .milliseconds(20))
+        await collector.append("\(prefix)-end")
+    }
+}
+
+private struct AppendTokenCommand: BrewMutatingCommand {
+    let collector: OrderCollector
+    let token: String
+
+    nonisolated var operationKind: BrewOperationKind { .upgradeFormula }
+
+    func run(in context: BrewCommandExecutionContext) async throws {
+        _ = context
+        await collector.append(token)
+    }
+}
+
+private actor InvocationCounter {
+    private(set) var value = 0
+
+    func increment() {
+        value += 1
+    }
+}
+
+private struct SlowIncrementCommand: BrewMutatingCommand {
+    let counter: InvocationCounter
+
+    nonisolated var operationKind: BrewOperationKind { .upgradeFormula }
+
+    func run(in context: BrewCommandExecutionContext) async throws {
+        _ = context
+        await counter.increment()
+        try await Task.sleep(for: .milliseconds(30))
+    }
+}

--- a/BrewTests/SerialBrewCommandCenterTests.swift
+++ b/BrewTests/SerialBrewCommandCenterTests.swift
@@ -106,6 +106,55 @@ struct SerialBrewCommandCenterTests {
         #expect(map[id] != nil)
         #expect(await center.phase(for: id) == map[id])
     }
+
+    @Test func `mutating command uses injected mock runner not real brew`() async throws {
+        let argv = ["upgrade", "demo-formula"]
+        let runner = MockBrewCommandRunner(responses: [
+            argv: CommandOutput(standardOutput: "mock-ok", standardError: "", terminationStatus: 0),
+        ])
+        let ctx = BrewCommandExecutionContext(
+            commandRunner: runner,
+            locator: BrewExecutableLocator(overrideURL: InstalledPackagesTestSupport.fakeBrewExecutableURL),
+        )
+        let center = SerialBrewCommandCenter(executionContext: ctx)
+        let id = BrewOperationID(rawValue: "formula:demo-formula")
+
+        try await center.submit(id: id, command: RunMockedArgvCommand(arguments: argv))
+
+        #expect(await center.phase(for: id) == .idle)
+    }
+
+    @Test func `recording wrapper logs each submit while duplicate id coalesces body`() async throws {
+        let ctx = BrewCommandExecutionContext(
+            commandRunner: MockBrewCommandRunner(responses: [:]),
+            locator: BrewExecutableLocator(overrideURL: InstalledPackagesTestSupport.fakeBrewExecutableURL),
+        )
+        let center = RecordingSerialBrewCommandCenter(executionContext: ctx)
+        let id = BrewOperationID(kind: .formula, name: "git")
+        let counter = InvocationCounter()
+
+        let first = Task {
+            try await center.submit(
+                id: id,
+                command: SlowIncrementCommand(counter: counter),
+            )
+        }
+        try await Task.sleep(for: .milliseconds(5))
+        let second = Task {
+            try await center.submit(
+                id: id,
+                command: SlowIncrementCommand(counter: counter),
+            )
+        }
+
+        try await first.value
+        try await second.value
+
+        let log = await center.recordedSubmitEntries
+        #expect(log.count == 2)
+        #expect(log.allSatisfy { $0.id == id && $0.kind == .upgradeFormula })
+        #expect(await counter.value == 1)
+    }
 }
 
 // MARK: - Test commands
@@ -184,5 +233,18 @@ private struct SlowIncrementCommand: BrewMutatingCommand {
         _ = context
         await counter.increment()
         try await Task.sleep(for: .milliseconds(30))
+    }
+}
+
+private struct RunMockedArgvCommand: BrewMutatingCommand {
+    let arguments: [String]
+
+    nonisolated var operationKind: BrewOperationKind { .upgradeFormula }
+
+    func run(in context: BrewCommandExecutionContext) async throws {
+        let url = try context.brewExecutableURL()
+        let out = try await context.commandRunner.run(executableURL: url, arguments: arguments)
+        #expect(out.standardOutput == "mock-ok")
+        #expect(out.terminationStatus == 0)
     }
 }

--- a/BrewTests/SerialBrewCommandCenterTests.swift
+++ b/BrewTests/SerialBrewCommandCenterTests.swift
@@ -160,7 +160,9 @@ struct SerialBrewCommandCenterTests {
 // MARK: - Test commands
 
 private struct EmptyMutatingCommand: BrewMutatingCommand {
-    nonisolated var operationKind: BrewOperationKind { .upgradeFormula }
+    nonisolated var operationKind: BrewOperationKind {
+        .upgradeFormula
+    }
 
     func run(in context: BrewCommandExecutionContext) async throws {
         _ = context
@@ -170,7 +172,9 @@ private struct EmptyMutatingCommand: BrewMutatingCommand {
 private struct ThrowingMutatingCommand: BrewMutatingCommand {
     struct TestError: Error {}
 
-    nonisolated var operationKind: BrewOperationKind { .upgradeFormula }
+    nonisolated var operationKind: BrewOperationKind {
+        .upgradeFormula
+    }
 
     func run(in context: BrewCommandExecutionContext) async throws {
         _ = context
@@ -194,7 +198,9 @@ private struct OrderingSleepCommand: BrewMutatingCommand {
     let collector: OrderCollector
     let prefix: String
 
-    nonisolated var operationKind: BrewOperationKind { .upgradeFormula }
+    nonisolated var operationKind: BrewOperationKind {
+        .upgradeFormula
+    }
 
     func run(in context: BrewCommandExecutionContext) async throws {
         _ = context
@@ -208,7 +214,9 @@ private struct AppendTokenCommand: BrewMutatingCommand {
     let collector: OrderCollector
     let token: String
 
-    nonisolated var operationKind: BrewOperationKind { .upgradeFormula }
+    nonisolated var operationKind: BrewOperationKind {
+        .upgradeFormula
+    }
 
     func run(in context: BrewCommandExecutionContext) async throws {
         _ = context
@@ -227,7 +235,9 @@ private actor InvocationCounter {
 private struct SlowIncrementCommand: BrewMutatingCommand {
     let counter: InvocationCounter
 
-    nonisolated var operationKind: BrewOperationKind { .upgradeFormula }
+    nonisolated var operationKind: BrewOperationKind {
+        .upgradeFormula
+    }
 
     func run(in context: BrewCommandExecutionContext) async throws {
         _ = context
@@ -239,7 +249,9 @@ private struct SlowIncrementCommand: BrewMutatingCommand {
 private struct RunMockedArgvCommand: BrewMutatingCommand {
     let arguments: [String]
 
-    nonisolated var operationKind: BrewOperationKind { .upgradeFormula }
+    nonisolated var operationKind: BrewOperationKind {
+        .upgradeFormula
+    }
 
     func run(in context: BrewCommandExecutionContext) async throws {
         let url = try context.brewExecutableURL()

--- a/BrewTests/TestSupport/RecordingSerialBrewCommandCenter.swift
+++ b/BrewTests/TestSupport/RecordingSerialBrewCommandCenter.swift
@@ -1,0 +1,38 @@
+//
+//  RecordingSerialBrewCommandCenter.swift
+//  BrewTests
+//
+
+@testable import Brew
+import Foundation
+
+/// Test double wrapping ``SerialBrewCommandCenter``: appends `(id, kind)` for every ``BrewCommandCenter/submit``
+/// invocation while preserving serial execution and duplicate-id coalescing.
+actor RecordingSerialBrewCommandCenter: BrewCommandCenter {
+    private let inner: SerialBrewCommandCenter
+    private(set) var recordedSubmitEntries: [(id: BrewOperationID, kind: BrewOperationKind)] = []
+
+    init(executionContext: BrewCommandExecutionContext) {
+        inner = SerialBrewCommandCenter(executionContext: executionContext)
+    }
+
+    func phase(for id: BrewOperationID) async -> BrewOperationPhase {
+        await inner.phase(for: id)
+    }
+
+    func phaseByID() async -> [BrewOperationID: BrewOperationPhase] {
+        await inner.phaseByID()
+    }
+
+    func isActive(id: BrewOperationID) async -> Bool {
+        await inner.isActive(id: id)
+    }
+
+    func submit(
+        id: BrewOperationID,
+        command: any BrewMutatingCommand,
+    ) async throws {
+        recordedSubmitEntries.append((id, command.operationKind))
+        try await inner.submit(id: id, command: command)
+    }
+}


### PR DESCRIPTION
# PR: Add BrewCommandCenter for app-wide brew operations

## Summary

This PR introduces an app-scoped **BrewCommandCenter** (protocol + `@MainActor` observable implementation) to own registration, concurrency policy, and lifecycle coordination for mutating Homebrew CLI work. It lands **before** tab-specific upgrade UX so multiple future surfaces (Installed, Updates, Discover, etc.) can share one queue and one source of truth for in-flight operations. The `update-package` branch will rebase onto this and route upgrades through the center.

## Changes

- Add operation model types (e.g. stable operation id keyed like `InstalledPackageRow.ID`, kind enum for future `upgrade` / `install` / …, phase for UI).
- Add `BrewCommandCentering` (or equivalent) protocol and `BrewCommandCenter` implementation: track active operations, enforce serial (or documented) mutating-`brew` policy, clear state on completion/failure.
- Compose **one** center instance at the app root ([`Brew/BrewApp.swift`](Brew/BrewApp.swift)) and inject into [`MainWindowViewModel`](Brew/Features/MainWindow/MainWindowViewModel.swift) (and optionally thread into [`InstalledViewModel`](Brew/Features/Installed/InstalledViewModel.swift) init for forward compatibility without behavior change on `main`).
- Add `@NSApplicationDelegateAdaptor` thin delegate: forward termination hooks to `BrewCommandCenter.prepareForTermination()` (documented timeout / cancel vs wait policy).
- Add unit tests with fakes (no real `brew`): concurrency/idempotence, state transitions, shutdown hook behavior as applicable.
- Update [`ARCHITECTURE.md`](ARCHITECTURE.md) briefly: command center vs repository vs `BrewCommandRunning` service boundary.

## Why this split (optional)

Foundation-only PR keeps review focused on process-wide semantics and Swift 6 isolation. **Out of scope here:** Installed upgrade button migration, list-row “upgrading” affordance, and reuse of existing [`PackageUpgradeRunning`](Brew/Services/PackageUpgradeRunning.swift) / [`BrewPackageUpgradeService`](Brew/Services/BrewPackageUpgradeService.swift) — those ship on `update-package` after rebasing onto this branch.

## Testing

- [ ] Manual: launch app, confirm no regression on Installed tab load (if center is wired read-only)

## PR checklist

- [ ] Have you followed this repository's contribution and workflow guidance?
- [ ] Have you explained what changed and why this should land now?
- [ ] Have you run relevant local checks for the changed scope?
- [ ] Are changes scoped and free of unrelated modifications?

-----

- [ ] AI was used to generate or assist with generating this PR.
- [ ] If yes, describe exactly how AI was used and what manual verification was performed.

  **AI use:** Cursor was used for **architecture and sequencing** (app-wide command center vs tab-scoped state, branch order `brew-command-center` then rebase `update-package`), the **written plan** that scopes this PR, and **this PR body** (from `.github/PULL_REQUEST_TEMPLATE.md` plus that plan). Self-reviewed the full diff before opening the PR.

## Follow-ups

- Rebase `update-package` onto this PR’s merge base; migrate upgrade execution and **in-flight UI** (detail + list) to query the center instead of short-lived package detail ViewModel state.
- Optional: stream stdout/stderr into the center for a future activity log UI.