### PR TITLE
Add installed dependency/dependent navigation

### DIFF
--- a/.ai/memory.md
+++ b/.ai/memory.md
@@ -254,3 +254,15 @@
 - **Cache:** In-memory `InstalledInventoryCache` actor stores `InstalledInventorySnapshot` (packages + `PackageDependencyGraph`) populated by `BrewInstalledPackagesRepository` after successful `brew info --installed --json=v2`. `BrewApp` creates one cache per app lifetime and injects it via SwiftUI environment (`InstalledInventoryEnvironment.swift`); feature roots construct `BrewInstalledPackagesRepository` / `BrewInstalledDependentsRepository` from that shared cache. Previews and tests construct isolated caches with `InstalledInventoryCache()` when needed.
 - **TTL:** Snapshots are stale after 3600 seconds; `load()` may return cached packages when fresh; `refresh()` passes `forceRefresh: true` to bypass TTL after mutating brew work.
 - **Used by:** Detail dependents come from reverse dependency edges among installed packages; per-selection `brew uses` was removed.
+
+## 2026-05-15 — Installed inventory visibility (tests-only pass)
+
+- **Visibility:** New inventory types are module-internal; graph storage and JSON mapping helpers are `private`. Protocols `InstalledDependentsRepository` / `InstalledInventoryReading` stay internal as DI boundaries.
+- **Follow-up (production, separate PR):** `InstalledInventoryCache.packages()` has no call sites (prefer `cachedPackages()`). `EmptyInstalledDependentsRepository` / `EmptyInstalledInventoryReading` are unused in production — used only from `makeInstalledDetailsViewModel` in BrewTests; decide whether to delete, wire in previews, or keep for tests only.
+- **Tests:** `makeInstalledDetailsViewModel` in `InstalledDetailsViewModelTestsSupport` supplies empty repo defaults for non-inventory tests; production inits remain four explicit parameters.
+
+## 2026-05-15 — Dead-symbol cleanup applied
+
+- Removed dead installed-inventory API surface from app target: `InstalledInventoryCache.packages()`, `InstalledInventoryReading.installedPackages(for:)`, `BrewInstalledPackagesRepository.installedPackages(for:)`, and `BrewPackage.reference`.
+- Moved test-only empty inventory/dependents stubs out of `Brew/Repositories` into `BrewTests/TestSupport` (`EmptyInstalledInventoryReading`, `EmptyInstalledDependentsRepository`) so production DI paths remain explicit.
+- Pruned unused test support helpers `localizedHomebrewCommandFailedMessage()` and `packageInfoJSONResponse(...)` from `InstalledPackagesRepositoryTestSupport`.

--- a/.ai/memory.md
+++ b/.ai/memory.md
@@ -248,3 +248,9 @@
 - **Symptom:** `vale docs/` fails with `lstat docs/../Gemfile: no such file or directory` when `docs/Gemfile` is missing.
 - **Cause:** Vale 3 treats `Rakefile` and `Brewfile` (among others) as Ruby-format prose under `[formats] rb = md` in `.vale.ini`. For those paths it expects a resolvable `Gemfile` next to the Ruby project layout; this repo had `docs/Gemfile.lock` and Jekyll binstubs but no `docs/Gemfile`, unlike `Homebrew/brew` where `docs/` is a full Jekyll tree including `Gemfile`.
 - **Fix:** Commit `docs/Gemfile` (matching upstream brew docs, consistent with the lockfile) and `docs/.ruby-version` so Vale and later `bundle exec` steps in `.github/workflows/docs.yml` both succeed.
+
+## 2026-05-13 — Installed inventory cache
+
+- **Cache:** In-memory `InstalledInventoryCache` actor stores `InstalledInventorySnapshot` (packages + `PackageDependencyGraph`) populated by `BrewInstalledPackagesRepository` after successful `brew info --installed --json=v2`. `BrewApp` creates one cache per app lifetime and injects it via SwiftUI environment (`InstalledInventoryEnvironment.swift`); feature roots construct `BrewInstalledPackagesRepository` / `BrewInstalledDependentsRepository` from that shared cache. Previews and tests construct isolated caches with `InstalledInventoryCache()` when needed.
+- **TTL:** Snapshots are stale after 3600 seconds; `load()` may return cached packages when fresh; `refresh()` passes `forceRefresh: true` to bypass TTL after mutating brew work.
+- **Used by:** Detail dependents come from reverse dependency edges among installed packages; per-selection `brew uses` was removed.

--- a/Brew/BrewApp.swift
+++ b/Brew/BrewApp.swift
@@ -10,8 +10,10 @@ import SwiftUI
 @main
 struct BrewApp: App {
     private let commandCenter: SerialBrewCommandCenter
+    private let installedInventoryCache: InstalledInventoryCache
 
     init() {
+        installedInventoryCache = InstalledInventoryCache()
         commandCenter = SerialBrewCommandCenter(executionContext: .live())
     }
 
@@ -19,6 +21,7 @@ struct BrewApp: App {
         WindowGroup {
             MainWindowView()
                 .environment(\.brewCommandCenter, commandCenter)
+                .environment(\.installedInventoryCache, installedInventoryCache)
         }
         .defaultSize(
             width: BrewLayout.minWindowWidth,

--- a/Brew/Features/Installed/InstalledColumns.swift
+++ b/Brew/Features/Installed/InstalledColumns.swift
@@ -1,15 +1,13 @@
 import SwiftUI
 
 struct InstalledColumnsRoot: View {
-    @Environment(\.brewCommandCenter) var brewCommandCenter
-    @State var repository: BrewInstalledPackagesRepository = .init(
-        commandRunner: BrewCommandService(),
-        locator: BrewExecutableLocator(),
-    )
+    @Environment(\.brewCommandCenter) private var brewCommandCenter
+    @Environment(\.installedInventoryCache) private var installedInventoryCache
 
     var body: some View {
+        let installedPackagesRepository = BrewInstalledPackagesRepository.live(cache: installedInventoryCache)
         InstalledColumns(
-            repository: repository,
+            installedPackagesRepository: installedPackagesRepository,
             brewCommandCenter: brewCommandCenter,
         )
     }
@@ -19,10 +17,13 @@ struct InstalledColumnsRoot: View {
 struct InstalledColumns: View {
     @State var viewModel: InstalledViewModel
 
-    init(repository: InstalledPackagesRepository, brewCommandCenter: BrewCommandCenter) {
+    init(
+        installedPackagesRepository: any InstalledPackagesRepository,
+        brewCommandCenter: BrewCommandCenter,
+    ) {
         _viewModel = State(
             initialValue: .init(
-                repository: repository,
+                repository: installedPackagesRepository,
                 brewCommandCenter: brewCommandCenter,
             ),
         )
@@ -45,6 +46,7 @@ struct InstalledColumns: View {
                 if let selectedPackage = viewModel.selectedPackage {
                     InstalledPackageDetailRoot(
                         selectedPackage: selectedPackage,
+                        onSelectInstalledPackage: { viewModel.selectInstalledPackage(id: $0) },
                     )
                 } else {
                     InstalledPackageDetailPlaceholder()

--- a/Brew/Features/Installed/InstalledDetailsViewModel.swift
+++ b/Brew/Features/Installed/InstalledDetailsViewModel.swift
@@ -10,6 +10,8 @@ import Observation
 @MainActor
 final class InstalledDetailsViewModel {
     private let brewCommandCenter: any BrewCommandCenter
+    private let installedDependentsRepository: any InstalledDependentsRepository
+    private let installedInventoryReading: any InstalledInventoryReading
     private var upgradeTask: Task<Void, Never>?
 
     private(set) var package: BrewPackage
@@ -28,6 +30,10 @@ final class InstalledDetailsViewModel {
     var packageKind: InstalledPackageKind {
         package.kind
     }
+
+    private(set) var dependencyRelationships: [PackageRelationshipItem] = []
+
+    private(set) var dependentRelationships: [PackageRelationshipItem] = []
 
     /// User-facing command for the currently selected package details.
     var displayCommand: String {
@@ -56,9 +62,26 @@ final class InstalledDetailsViewModel {
     init(
         package: BrewPackage,
         brewCommandCenter: any BrewCommandCenter,
+        installedDependentsRepository: any InstalledDependentsRepository,
+        installedInventoryReading: any InstalledInventoryReading,
     ) {
         self.package = package
         self.brewCommandCenter = brewCommandCenter
+        self.installedDependentsRepository = installedDependentsRepository
+        self.installedInventoryReading = installedInventoryReading
+    }
+
+    func refreshDependents() async {
+        let dependents = await installedDependentsRepository.installedDependents(for: package.id)
+        dependentRelationships = PackageRelationshipItem.dependents(dependents)
+    }
+
+    func refreshDependencies() async {
+        let installedPackageIDs = await installedInventoryReading.installedPackageIDs()
+        dependencyRelationships = PackageRelationshipItem.dependencies(
+            package.dependencies,
+            installedPackageIDs: installedPackageIDs,
+        )
     }
 
     /// Syncs snapshot data for this row (`InstalledListRowViewModel/update(package:)` pattern).
@@ -67,6 +90,8 @@ final class InstalledDetailsViewModel {
             return
         }
         package = newPackage
+        dependencyRelationships = []
+        dependentRelationships = []
         upgradeErrorMessage = nil
     }
 

--- a/Brew/Features/Installed/InstalledPackageDetailSubviewSections.swift
+++ b/Brew/Features/Installed/InstalledPackageDetailSubviewSections.swift
@@ -1,0 +1,362 @@
+//
+//  InstalledPackageDetailSubviewSections.swift
+//  Brew
+//
+
+import AppKit
+import SwiftUI
+
+struct InstalledPackageDetailSectionHeading: View {
+    let title: String
+
+    var body: some View {
+        Text(title)
+            .font(.brewSubheadline.weight(.semibold))
+            .foregroundStyle(Color.brewTextPrimary)
+    }
+}
+
+struct InstalledPackageDetailSectionDivider: View {
+    var body: some View {
+        Divider()
+            .overlay(Color.brewBorderSeparator)
+    }
+}
+
+struct InstalledPackageDetailHeroSection: View {
+    let viewModel: InstalledDetailsViewModel
+
+    var body: some View {
+        HStack(alignment: .top, spacing: BrewSpacing.md) {
+            ZStack {
+                RoundedRectangle(cornerRadius: BrewRadius.lg)
+                    .fill(Color.brewBrandTint)
+                    .frame(width: 44, height: 44)
+                Image(systemName: "cube.box.fill")
+                    .font(.title2)
+                    .foregroundStyle(Color.brewBrandPrimary)
+            }
+            .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: BrewSpacing.xs) {
+                HStack(spacing: BrewSpacing.sm) {
+                    Text(viewModel.packageName)
+                        .font(.brewTitle1)
+                        .foregroundStyle(Color.brewTextPrimary)
+
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.brewTitle3)
+                        .foregroundStyle(Color.brewStatusSuccess)
+                        .accessibilityLabel("Installed")
+
+                    Text(viewModel.packageKind.chrome.badgeLabel)
+                        .font(.brewCaption2)
+                        .foregroundStyle(Color.brewBrandPrimary)
+                        .padding(.horizontal, BrewSpacing.xs)
+                        .padding(.vertical, BrewSpacing.xxs)
+                        .background(Color.brewBrandTint)
+                        .clipShape(RoundedRectangle(cornerRadius: BrewRadius.sm))
+                }
+
+                if let subtitle = heroSubtitle {
+                    Text(subtitle)
+                        .font(.brewSubheadline)
+                        .foregroundStyle(Color.brewTextSecondary)
+                }
+            }
+        }
+    }
+
+    private var heroSubtitle: String? {
+        let trimmed = viewModel.package.description.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+struct InstalledPackageDetailMetadataSection: View {
+    let package: BrewPackage
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: BrewSpacing.sm) {
+            InstalledPackageDetailSectionHeading(title: "Details")
+            detailRow(label: "Version", value: versionColumnValue(package.latestVersion))
+            detailRow(label: "Installed", value: installedValue(package))
+            if let homepageURL = package.homepageURL {
+                homepageRow(url: homepageURL)
+            }
+        }
+    }
+
+    private func versionColumnValue(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "—" : trimmed
+    }
+
+    private func installedValue(_ package: BrewPackage) -> String {
+        if package.installedVersions.isEmpty {
+            return "—"
+        }
+        return package.installedVersions.joined(separator: ", ")
+    }
+
+    private func detailRow(label: String, value: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: BrewSpacing.sm) {
+            Text(label)
+                .font(.brewCallout)
+                .foregroundStyle(Color.brewTextSecondary)
+                .frame(width: 100, alignment: .leading)
+            Text(value)
+                .font(.brewCallout.weight(.medium))
+                .foregroundStyle(Color.brewTextPrimary)
+                .textSelection(.enabled)
+            Spacer(minLength: 0)
+        }
+    }
+
+    private func homepageRow(url: URL) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: BrewSpacing.sm) {
+            Text("Homepage")
+                .font(.brewCallout)
+                .foregroundStyle(Color.brewTextSecondary)
+                .frame(width: 100, alignment: .leading)
+            Link(destination: url) {
+                HStack(spacing: BrewSpacing.xxs) {
+                    Text(homepageLinkTitle(for: url))
+                        .font(.brewCallout.weight(.medium))
+                    Image(systemName: "arrow.up.right")
+                        .font(.brewCaption2)
+                }
+                .foregroundStyle(Color.brewBrandPrimary)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, BrewSpacing.xs)
+    }
+
+    private func homepageLinkTitle(for url: URL) -> String {
+        if let host = url.host?.trimmingCharacters(in: .whitespacesAndNewlines), !host.isEmpty {
+            return host
+        }
+        return url.absoluteString
+    }
+}
+
+struct InstalledPackageDetailUsedBySection: View {
+    let viewModel: InstalledDetailsViewModel
+    let collapsedRelationshipCount: Int
+    let onSelectInstalledPackage: (BrewPackage.ID) -> Void
+    @Binding var isExpanded: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: BrewSpacing.sm) {
+            InstalledPackageDetailSectionHeading(title: "Used by")
+            if viewModel.dependentRelationships.isEmpty {
+                Text("No installed packages use this package.")
+                    .font(.brewCallout)
+                    .foregroundStyle(Color.brewTextSecondary)
+            } else {
+                InstalledPackageDetailRelationshipList(
+                    title: "Used by",
+                    relationships: viewModel.dependentRelationships,
+                    dotStyle: .warning,
+                    isExpanded: $isExpanded,
+                    showsHeading: false,
+                    collapsedRelationshipCount: collapsedRelationshipCount,
+                    onSelectInstalledPackage: onSelectInstalledPackage,
+                )
+                if !viewModel.dependentRelationships.isEmpty {
+                    usedByCallout
+                }
+            }
+        }
+    }
+
+    private var usedByCallout: some View {
+        HStack(alignment: .top, spacing: BrewSpacing.sm) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.brewSubheadline)
+                .foregroundStyle(Color.brewBrandPrimary)
+            Text("Other installed packages depend on this. Removing it may break them.")
+                .font(.brewCallout)
+                .foregroundStyle(Color.brewTextPrimary)
+        }
+        .padding(BrewSpacing.sm)
+        .background(Color.brewBrandTint)
+        .clipShape(RoundedRectangle(cornerRadius: BrewRadius.md))
+    }
+}
+
+struct InstalledPackageDetailRelationshipList: View {
+    let title: String
+    let relationships: [PackageRelationshipItem]
+    let dotStyle: PackageRelationshipDotStyle
+    let collapsedRelationshipCount: Int
+    let onSelectInstalledPackage: (BrewPackage.ID) -> Void
+    let showsHeading: Bool
+    @Binding var isExpanded: Bool
+
+    init(
+        title: String,
+        relationships: [PackageRelationshipItem],
+        dotStyle: PackageRelationshipDotStyle,
+        isExpanded: Binding<Bool>,
+        showsHeading: Bool = true,
+        collapsedRelationshipCount: Int,
+        onSelectInstalledPackage: @escaping (BrewPackage.ID) -> Void,
+    ) {
+        self.title = title
+        self.relationships = relationships
+        self.dotStyle = dotStyle
+        _isExpanded = isExpanded
+        self.showsHeading = showsHeading
+        self.collapsedRelationshipCount = collapsedRelationshipCount
+        self.onSelectInstalledPackage = onSelectInstalledPackage
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: BrewSpacing.xs) {
+            if showsHeading {
+                InstalledPackageDetailSectionHeading(title: title)
+            }
+            if relationships.isEmpty {
+                Text("No \(title.lowercased()).")
+                    .font(.brewCallout)
+                    .foregroundStyle(Color.brewTextSecondary)
+            } else {
+                let visibleRelationships = visibleRelationships(relationships, isExpanded: isExpanded)
+                ForEach(visibleRelationships) { relationship in
+                    relationshipRow(relationship)
+                }
+                if relationships.count > collapsedRelationshipCount {
+                    Button {
+                        isExpanded.toggle()
+                    } label: {
+                        Text(
+                            isExpanded
+                                ? "Show less"
+                                : "+\(relationships.count - collapsedRelationshipCount) more…",
+                        )
+                        .font(.brewCallout)
+                        .foregroundStyle(Color.brewBrandPrimary)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    private func relationshipRow(_ relationship: PackageRelationshipItem) -> some View {
+        let isInstalled = relationship.isInstalledInInventory
+        return Button {
+            if let installedPackageID = relationship.installedPackageID {
+                onSelectInstalledPackage(installedPackageID)
+            }
+        } label: {
+            HStack(spacing: BrewSpacing.sm) {
+                Circle()
+                    .fill(dotStyle.color)
+                    .frame(width: 6, height: 6)
+                Text(relationship.displayName)
+                    .font(.brewCode)
+                    .foregroundStyle(Color.brewTextPrimary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                if isInstalled {
+                    Image(systemName: "chevron.right")
+                        .font(.brewCaption)
+                        .foregroundStyle(Color.brewTextTertiary)
+                }
+            }
+            .padding(.vertical, BrewSpacing.xs)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!isInstalled)
+        .accessibilityLabel(
+            isInstalled
+                ? "Open installed package \(relationship.displayName)"
+                : "\(relationship.displayName), not installed",
+        )
+    }
+
+    private func visibleRelationships(
+        _ relationships: [PackageRelationshipItem],
+        isExpanded: Bool,
+    ) -> [PackageRelationshipItem] {
+        guard !isExpanded, relationships.count > collapsedRelationshipCount else {
+            return relationships
+        }
+        return Array(relationships.prefix(collapsedRelationshipCount))
+    }
+}
+
+struct InstalledPackageDetailInfoCommandSection: View {
+    let title: String
+    let command: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: BrewSpacing.sm) {
+            InstalledPackageDetailSectionHeading(title: title)
+            commandConsole
+        }
+    }
+
+    private var commandConsole: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Label("Terminal command", systemImage: "terminal")
+                    .font(.brewCaption)
+                    .foregroundStyle(Color.brewTextSecondary)
+                Spacer()
+                Button("Copy", systemImage: "doc.on.doc") {
+                    copyCommandToPasteboard(command)
+                }
+                .font(.brewCaption)
+                .foregroundStyle(Color.brewTextSecondary)
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, BrewSpacing.md)
+            .padding(.vertical, BrewSpacing.sm)
+            .background(Color.brewSurfaceRecessed)
+
+            Text(command)
+                .font(.brewCode)
+                .foregroundStyle(Color.brewCodeDefault)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(BrewSpacing.md)
+                .background(Color.brewTerminal)
+                .textSelection(.enabled)
+
+            Text("Shows detailed information about this package")
+                .font(.brewCaption)
+                .foregroundStyle(Color.brewTextTertiary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, BrewSpacing.md)
+                .padding(.vertical, BrewSpacing.sm)
+                .background(Color.brewSurfaceRecessed)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: BrewRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: BrewRadius.md)
+                .stroke(Color.brewBorderDefault, lineWidth: 1),
+        )
+    }
+
+    private func copyCommandToPasteboard(_ command: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(command, forType: .string)
+    }
+}
+
+enum PackageRelationshipDotStyle {
+    case neutral
+    case warning
+
+    var color: Color {
+        switch self {
+        case .neutral:
+            Color.brewTextTertiary
+        case .warning:
+            Color.brewStatusWarning
+        }
+    }
+}

--- a/Brew/Features/Installed/InstalledPackageDetailView.swift
+++ b/Brew/Features/Installed/InstalledPackageDetailView.swift
@@ -3,17 +3,23 @@
 //  Brew
 //
 
+import AppKit
 import SwiftUI
 
-/// Root view for the selected row; detail content reads ``EnvironmentValues/brewCommandCenter`` to build its view model.
+/// Root view for the selected row; detail content reads ``EnvironmentValues/brewCommandCenter`` and builds relationship repositories from ``EnvironmentValues/installedInventoryCache``.
 struct InstalledPackageDetailRoot: View {
     let selectedPackage: BrewPackage
+    let onSelectInstalledPackage: (BrewPackage.ID) -> Void
     @Environment(\.brewCommandCenter) private var brewCommandCenter
+    @Environment(\.installedInventoryCache) private var installedInventoryCache
 
     var body: some View {
         InstalledPackageDetailView(
             package: selectedPackage,
             brewCommandCenter: brewCommandCenter,
+            installedDependentsRepository: BrewInstalledDependentsRepository(cache: installedInventoryCache),
+            installedInventoryReading: BrewInstalledPackagesRepository.live(cache: installedInventoryCache),
+            onSelectInstalledPackage: onSelectInstalledPackage,
         )
     }
 }
@@ -21,14 +27,28 @@ struct InstalledPackageDetailRoot: View {
 /// Right-hand column: detail for the selected installed package.
 struct InstalledPackageDetailView: View {
     let package: BrewPackage
+    let onSelectInstalledPackage: (BrewPackage.ID) -> Void
     @State private var viewModel: InstalledDetailsViewModel
+    @State private var expandedDependencies = false
+    @State private var expandedDependents = false
 
-    init(package: BrewPackage, brewCommandCenter: BrewCommandCenter) {
+    private let collapsedRelationshipCount = 3
+
+    init(
+        package: BrewPackage,
+        brewCommandCenter: BrewCommandCenter,
+        installedDependentsRepository: any InstalledDependentsRepository,
+        installedInventoryReading: any InstalledInventoryReading,
+        onSelectInstalledPackage: @escaping (BrewPackage.ID) -> Void = { _ in },
+    ) {
         self.package = package
+        self.onSelectInstalledPackage = onSelectInstalledPackage
         _viewModel = State(
             initialValue: InstalledDetailsViewModel(
                 package: package,
                 brewCommandCenter: brewCommandCenter,
+                installedDependentsRepository: installedDependentsRepository,
+                installedInventoryReading: installedInventoryReading,
             ),
         )
     }
@@ -39,18 +59,25 @@ struct InstalledPackageDetailView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .task(id: package.id) {
+            await viewModel.refreshDependencies()
+            await viewModel.refreshDependents()
             await viewModel.observeRowUpdates()
         }
         .onChange(of: package) { _, newPackage in
             viewModel.update(package: newPackage)
+            expandedDependencies = false
+            expandedDependents = false
+            Task {
+                await viewModel.refreshDependencies()
+                await viewModel.refreshDependents()
+            }
         }
     }
 
     private func detailScrollContent(viewModel: InstalledDetailsViewModel) -> some View {
         ScrollView {
             VStack(alignment: .leading, spacing: BrewSpacing.xl) {
-                packageHeader(viewModel: viewModel)
-
+                InstalledPackageDetailHeroSection(viewModel: viewModel)
                 packageDetailsSections(viewModel: viewModel)
 
                 if viewModel.showsUpgradeChrome {
@@ -65,166 +92,34 @@ struct InstalledPackageDetailView: View {
 
     private func upgradeFooter(viewModel: InstalledDetailsViewModel) -> some View {
         VStack(alignment: .leading, spacing: BrewSpacing.md) {
-            Divider()
-                .overlay(Color.brewBorderSeparator)
+            InstalledPackageDetailSectionDivider()
             InstalledPackageDetailUpgradeChrome(viewModel: viewModel)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private func packageHeader(viewModel: InstalledDetailsViewModel) -> some View {
-        HStack(alignment: .center, spacing: BrewSpacing.sm) {
-            Text(viewModel.packageName)
-                .font(.brewTitle1)
-                .foregroundStyle(Color.brewTextPrimary)
-
-            Text(viewModel.packageKind.rawValue.uppercased())
-                .font(.brewCaption2)
-                .foregroundStyle(Color.brewTextSecondary)
-                .padding(.horizontal, BrewSpacing.xs)
-                .padding(.vertical, BrewSpacing.xxs)
-                .background(Color.brewSurfaceElevated)
-                .clipShape(Capsule())
-        }
-    }
-
     @ViewBuilder
     private func packageDetailsSections(viewModel: InstalledDetailsViewModel) -> some View {
         let package = viewModel.package
-        descriptionSection(package: package)
-        detailsSection(package: package)
-        dependenciesSection(package: package)
-        commandSection(viewModel: viewModel)
-    }
-
-    private func descriptionSection(package: BrewPackage) -> some View {
-        VStack(alignment: .leading, spacing: BrewSpacing.sm) {
-            Text("Description")
-                .font(.brewSubheadline)
-                .foregroundStyle(Color.brewTextSecondary)
-            Text(descriptionText(package))
-                .font(.brewBody)
-                .foregroundStyle(Color.brewTextPrimary)
-        }
-    }
-
-    private func detailsSection(package: BrewPackage) -> some View {
-        VStack(alignment: .leading, spacing: BrewSpacing.sm) {
-            Text("Details")
-                .font(.brewSubheadline)
-                .foregroundStyle(Color.brewTextSecondary)
-            detailRow(label: "Version", value: versionColumnValue(package.latestVersion))
-            detailRow(label: "Installed", value: installedValue(package))
-            if let homepageURL = package.homepageURL {
-                homepageRow(url: homepageURL)
-            }
-        }
-    }
-
-    private func dependenciesSection(package: BrewPackage) -> some View {
-        VStack(alignment: .leading, spacing: BrewSpacing.sm) {
-            Text("Dependencies")
-                .font(.brewSubheadline)
-                .foregroundStyle(Color.brewTextSecondary)
-            if package.dependencies.isEmpty {
-                Text("No dependencies")
-                    .font(.brewCallout)
-                    .foregroundStyle(Color.brewTextSecondary)
-            } else {
-                dependencyGrid(package.dependencies)
-            }
-        }
-    }
-
-    private func dependencyGrid(_ dependencies: [String]) -> some View {
-        LazyVGrid(
-            columns: [GridItem(.adaptive(minimum: 120), spacing: BrewSpacing.sm)],
-            spacing: BrewSpacing.sm,
-        ) {
-            ForEach(dependencies, id: \.self) { dependency in
-                Text(dependency)
-                    .font(.brewCaption)
-                    .foregroundStyle(Color.brewTextPrimary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, BrewSpacing.sm)
-                    .padding(.vertical, BrewSpacing.xs)
-                    .background(Color.brewSurfaceElevated)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: BrewRadius.sm)
-                            .stroke(Color.brewBorderDefault, lineWidth: 1),
-                    )
-                    .clipShape(RoundedRectangle(cornerRadius: BrewRadius.sm))
-            }
-        }
-    }
-
-    private func commandSection(viewModel: InstalledDetailsViewModel) -> some View {
-        VStack(alignment: .leading, spacing: BrewSpacing.sm) {
-            Text("Command")
-                .font(.brewSubheadline)
-                .foregroundStyle(Color.brewTextSecondary)
-            Text(viewModel.displayCommand)
-                .font(.brewCode)
-                .foregroundStyle(Color.brewCodeDefault)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(BrewSpacing.md)
-                .background(Color.brewTerminal)
-                .clipShape(RoundedRectangle(cornerRadius: BrewRadius.md))
-                .textSelection(.enabled)
-        }
-    }
-
-    private func versionColumnValue(_ raw: String) -> String {
-        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? "—" : trimmed
-    }
-
-    private func detailRow(label: String, value: String) -> some View {
-        HStack(alignment: .firstTextBaseline, spacing: BrewSpacing.sm) {
-            Text(label)
-                .font(.brewCallout)
-                .foregroundStyle(Color.brewTextSecondary)
-                .frame(width: 70, alignment: .leading)
-            detailValueView(value)
-            Spacer(minLength: 0)
-        }
-    }
-
-    private func homepageRow(url: URL) -> some View {
-        HStack(alignment: .firstTextBaseline, spacing: BrewSpacing.sm) {
-            Text("Homepage")
-                .font(.brewCallout)
-                .foregroundStyle(Color.brewTextSecondary)
-                .frame(width: 70, alignment: .leading)
-            Link(destination: url) {
-                Text(url.absoluteString)
-                    .font(.brewCallout)
-            }
-            Spacer(minLength: 0)
-        }
-    }
-
-    private func detailValueView(_ value: String) -> some View {
-        Text(value)
-            .font(.brewCallout)
-            .foregroundStyle(Color.brewTextPrimary)
-            .textSelection(.enabled)
-    }
-
-    private func descriptionText(_ package: BrewPackage) -> String {
-        let fallback = String(
-            localized: "No description available.",
-            comment: "Installed detail fallback description when no summary is available",
+        InstalledPackageDetailMetadataSection(package: package)
+        InstalledPackageDetailSectionDivider()
+        InstalledPackageDetailRelationshipList(
+            title: "Dependencies",
+            relationships: viewModel.dependencyRelationships,
+            dotStyle: .neutral,
+            isExpanded: $expandedDependencies,
+            collapsedRelationshipCount: collapsedRelationshipCount,
+            onSelectInstalledPackage: onSelectInstalledPackage,
         )
-        let trimmed = package.description.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? fallback : trimmed
-    }
-
-    private func installedValue(_ package: BrewPackage) -> String {
-        if package.installedVersions.isEmpty {
-            return "—"
-        }
-        return package.installedVersions.joined(separator: ", ")
+        InstalledPackageDetailSectionDivider()
+        InstalledPackageDetailUsedBySection(
+            viewModel: viewModel,
+            collapsedRelationshipCount: collapsedRelationshipCount,
+            onSelectInstalledPackage: onSelectInstalledPackage,
+            isExpanded: $expandedDependents,
+        )
+        InstalledPackageDetailSectionDivider()
+        InstalledPackageDetailInfoCommandSection(title: "Command", command: viewModel.displayCommand)
     }
 }
 
@@ -235,46 +130,80 @@ private struct InstalledPackageDetailUpgradeChrome: View {
     var body: some View {
         VStack(alignment: .leading, spacing: BrewSpacing.sm) {
             Text("Upgrade")
-                .font(.brewSubheadline)
-                .foregroundStyle(Color.brewTextSecondary)
+                .font(.brewSubheadline.weight(.semibold))
+                .foregroundStyle(Color.brewTextPrimary)
 
-            if let title = viewModel.upgradePrimaryButtonTitle {
-                HStack(spacing: BrewSpacing.sm) {
-                    Button {
-                        viewModel.upgradeSelectedPackage()
-                    } label: {
-                        if viewModel.isUpgrading {
-                            ProgressView()
-                                .controlSize(.small)
-                                .frame(minWidth: 120)
-                        } else {
-                            Text(title)
+            VStack(alignment: .leading, spacing: BrewSpacing.md) {
+                upgradeCommandConsole
+
+                if let title = viewModel.upgradePrimaryButtonTitle {
+                    HStack(spacing: BrewSpacing.sm) {
+                        Button {
+                            viewModel.upgradeSelectedPackage()
+                        } label: {
+                            if viewModel.isUpgrading {
+                                ProgressView()
+                                    .controlSize(.small)
+                                    .frame(minWidth: 120)
+                            } else {
+                                Text(title)
+                            }
                         }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(viewModel.isUpgrading)
+                        .accessibilityLabel(title)
                     }
-                    .buttonStyle(.borderedProminent)
-                    .disabled(viewModel.isUpgrading)
-                    .accessibilityLabel(title)
+                }
+                if let upgradeError = viewModel.upgradeErrorMessage {
+                    Text(upgradeError)
+                        .font(.brewCallout)
+                        .foregroundStyle(Color.brewStatusError)
+                        .textSelection(.enabled)
                 }
             }
+        }
+    }
 
-            Text("Command")
-                .font(.brewSubheadline)
+    private var upgradeCommandConsole: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Label("Terminal command", systemImage: "terminal")
+                    .font(.brewCaption)
+                    .foregroundStyle(Color.brewTextSecondary)
+                Spacer()
+                Button("Copy", systemImage: "doc.on.doc") {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(viewModel.upgradeDisplayCommand, forType: .string)
+                }
+                .font(.brewCaption)
                 .foregroundStyle(Color.brewTextSecondary)
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, BrewSpacing.md)
+            .padding(.vertical, BrewSpacing.sm)
+            .background(Color.brewSurfaceRecessed)
+
             Text(viewModel.upgradeDisplayCommand)
                 .font(.brewCode)
                 .foregroundStyle(Color.brewCodeDefault)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(BrewSpacing.md)
                 .background(Color.brewTerminal)
-                .clipShape(RoundedRectangle(cornerRadius: BrewRadius.md))
                 .textSelection(.enabled)
 
-            if let upgradeError = viewModel.upgradeErrorMessage {
-                Text(upgradeError)
-                    .font(.brewCallout)
-                    .foregroundStyle(Color.brewStatusError)
-            }
+            Text("Upgrades this package to the latest available version")
+                .font(.brewCaption)
+                .foregroundStyle(Color.brewTextTertiary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, BrewSpacing.md)
+                .padding(.vertical, BrewSpacing.sm)
+                .background(Color.brewSurfaceRecessed)
         }
+        .clipShape(RoundedRectangle(cornerRadius: BrewRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: BrewRadius.md)
+                .stroke(Color.brewBorderDefault, lineWidth: 1),
+        )
     }
 }
 

--- a/Brew/Features/Installed/InstalledPackagesView+Previews.swift
+++ b/Brew/Features/Installed/InstalledPackagesView+Previews.swift
@@ -2,14 +2,16 @@ import SwiftUI
 
 #Preview("List column") {
     let commandCenter = NoopBrewCommandCenter.preview()
+    let inventoryCache = InstalledInventoryCache()
     let viewModel = InstalledViewModel(
-        repository: PreviewInstalledPackagesRepository(),
+        repository: BrewInstalledPackagesRepository.live(cache: inventoryCache),
         brewCommandCenter: commandCenter,
     )
     InstalledPackagesView(
         viewModel: viewModel,
     )
     .environment(\.brewCommandCenter, commandCenter)
+    .environment(\.installedInventoryCache, inventoryCache)
     .task {
         await viewModel.load()
     }
@@ -18,6 +20,7 @@ import SwiftUI
 
 #Preview("Detail") {
     let commandCenter = NoopBrewCommandCenter.preview()
+    let inventoryCache = InstalledInventoryCache()
     let package = BrewPackage(
         name: "git",
         kind: .formula,
@@ -28,6 +31,11 @@ import SwiftUI
         dependencies: [],
         outdated: true,
     )
-    InstalledPackageDetailView(package: package, brewCommandCenter: commandCenter)
-        .frame(minWidth: 280, minHeight: 200)
+    InstalledPackageDetailView(
+        package: package,
+        brewCommandCenter: commandCenter,
+        installedDependentsRepository: BrewInstalledDependentsRepository(cache: inventoryCache),
+        installedInventoryReading: BrewInstalledPackagesRepository.live(cache: inventoryCache),
+    )
+    .frame(minWidth: 280, minHeight: 200)
 }

--- a/Brew/Features/Installed/InstalledPackagesView.swift
+++ b/Brew/Features/Installed/InstalledPackagesView.swift
@@ -43,46 +43,72 @@ struct InstalledPackagesView: View {
     }
 
     private func installedList(_ content: InstalledPackagesContent) -> some View {
-        List {
-            if content.shouldShowFormulaeSection {
-                Section("Formulae") {
-                    ForEach(content.formulaPackages) { package in
-                        listRow(for: package)
-                            .contentShape(Rectangle())
-                            .onTapGesture {
-                                viewModel.setSelection(package.id)
-                            }
-                            .listRowBackground(
-                                viewModel.activeSelectedPackageID == package.id ? Color.brewBrandTint : Color.clear,
-                            )
+        ScrollViewReader { proxy in
+            List {
+                if content.shouldShowFormulaeSection {
+                    Section("Formulae") {
+                        ForEach(content.formulaPackages) { package in
+                            listRow(for: package)
+                                .id(package.id)
+                                .contentShape(Rectangle())
+                                .onTapGesture {
+                                    viewModel.setSelection(package.id)
+                                }
+                                .listRowBackground(
+                                    viewModel.activeSelectedPackageID == package.id ? Color.brewBrandTint : Color.clear,
+                                )
+                        }
                     }
                 }
-            }
 
-            if content.shouldShowCasksSection {
-                Section("Casks") {
-                    ForEach(content.caskPackages) { package in
-                        listRow(for: package)
-                            .contentShape(Rectangle())
-                            .onTapGesture {
-                                viewModel.setSelection(package.id)
-                            }
-                            .listRowBackground(
-                                viewModel.activeSelectedPackageID == package.id ? Color.brewBrandTint : Color.clear,
-                            )
+                if content.shouldShowCasksSection {
+                    Section("Casks") {
+                        ForEach(content.caskPackages) { package in
+                            listRow(for: package)
+                                .id(package.id)
+                                .contentShape(Rectangle())
+                                .onTapGesture {
+                                    viewModel.setSelection(package.id)
+                                }
+                                .listRowBackground(
+                                    viewModel.activeSelectedPackageID == package.id ? Color.brewBrandTint : Color.clear,
+                                )
+                        }
                     }
                 }
             }
-        }
-        .listStyle(.plain)
-        .accessibilityLabel("Installed packages")
-        .onExitCommand {
-            viewModel.clearSelection()
+            .listStyle(.plain)
+            .accessibilityLabel("Installed packages")
+            .onAppear {
+                scrollToSelection(viewModel.activeSelectedPackageID, in: content, with: proxy)
+            }
+            .onChange(of: viewModel.activeSelectedPackageID) { _, selectedID in
+                scrollToSelection(selectedID, in: content, with: proxy)
+            }
+            .onChange(of: content.packages.map(\.id)) { _, _ in
+                scrollToSelection(viewModel.activeSelectedPackageID, in: content, with: proxy)
+            }
+            .onExitCommand {
+                viewModel.clearSelection()
+            }
         }
     }
 
     private func listRow(for package: BrewPackage) -> some View {
         InstalledListRowRoot(package: package)
+    }
+
+    private func scrollToSelection(
+        _ selectedID: BrewPackage.ID?,
+        in content: InstalledPackagesContent,
+        with proxy: ScrollViewProxy,
+    ) {
+        guard let selectedID, content.packages.contains(where: { $0.id == selectedID }) else {
+            return
+        }
+        withAnimation(.brewFast) {
+            proxy.scrollTo(selectedID, anchor: .center)
+        }
     }
 
     private var loadingSkeletonList: some View {

--- a/Brew/Features/Installed/InstalledViewModel.swift
+++ b/Brew/Features/Installed/InstalledViewModel.swift
@@ -99,7 +99,10 @@ final class InstalledViewModel {
     }
 
     /// Loads from Homebrew via the repository (`ARCHITECTURE.md`: View → ViewModel → Repository → Service).
-    init(repository: InstalledPackagesRepository, brewCommandCenter: any BrewCommandCenter) {
+    init(
+        repository: InstalledPackagesRepository,
+        brewCommandCenter: any BrewCommandCenter,
+    ) {
         self.repository = repository
         self.brewCommandCenter = brewCommandCenter
         observerTask = Task { @MainActor [weak self] in
@@ -131,7 +134,7 @@ final class InstalledViewModel {
             return
         }
         do {
-            let snapshot = try await repository.loadInstalledPackages()
+            let snapshot = try await repository.loadInstalledPackages(forceRefresh: true)
             loadedContent = Self.packagesContent(from: snapshot)
             applyLoadedStateForCurrentQuery()
         } catch {
@@ -168,6 +171,13 @@ final class InstalledViewModel {
     func clearSelection() {
         selectedPackageID = firstVisibleRowID()
         searchPreviewSelectedPackageID = nil
+    }
+
+    func selectInstalledPackage(id: BrewPackage.ID) {
+        guard allRows.contains(where: { $0.id == id }) else {
+            return
+        }
+        setSelection(id)
     }
 
     private var isSearchActive: Bool {

--- a/Brew/Models/BrewInfoJSON+Mapping.swift
+++ b/Brew/Models/BrewInfoJSON+Mapping.swift
@@ -22,10 +22,7 @@ private extension BrewInfoFormula {
         let installedVersions = installed
             .compactMap(\.version)
             .compactMap(BrewInfoJSON.trimmedOrNil(_:))
-        let allDependencies = dependencies +
-            buildDependencies +
-            recommendedDependencies +
-            optionalDependencies
+        let runtimeDependencies = dependencies
         return BrewPackage(
             name: name,
             kind: .formula,
@@ -33,7 +30,7 @@ private extension BrewInfoFormula {
             homepage: BrewInfoJSON.trimmedOrEmpty(homepage),
             latestVersion: BrewInfoJSON.trimmedOrEmpty(versions.stable),
             installedVersions: installedVersions,
-            dependencies: BrewInfoJSON.uniqueNonEmpty(allDependencies),
+            dependencies: HomebrewPackageReference.formulaDependencies(from: runtimeDependencies),
             outdated: outdated,
         )
     }
@@ -50,7 +47,7 @@ private extension BrewInfoCask {
             homepage: BrewInfoJSON.trimmedOrEmpty(homepage),
             latestVersion: latest,
             installedVersions: installed,
-            dependencies: BrewInfoJSON.uniqueNonEmpty(dependencies),
+            dependencies: HomebrewPackageReference.uniqueReferences(dependencies),
             outdated: outdated,
         )
     }

--- a/Brew/Models/BrewInfoJSON.swift
+++ b/Brew/Models/BrewInfoJSON.swift
@@ -81,7 +81,7 @@ struct BrewInfoCask: Decodable {
     /// Nested stable when present in JSON (current Homebrew `--json=v2` casks omit this; formulae-style mirror).
     var versions: BrewInfoFormulaVersions
     var installedVersions: [String]
-    var dependencies: [String]
+    var dependencies: [HomebrewPackageReference]
     var outdated: Bool
 
     init(from decoder: Decoder) throws {
@@ -93,7 +93,9 @@ struct BrewInfoCask: Decodable {
         versions = (try? container.decode(BrewInfoFormulaVersions.self, forKey: .versions))
             ?? BrewInfoFormulaVersions(stable: nil)
         installedVersions = container.decodeInstalledVersions(forKey: .installed)
-        dependencies = container.decodeCaskDependencies(forKey: .dependencies)
+        dependencies = container.decodeCaskDependencyReferences(
+            forKeys: [.dependencies, .dependsOn],
+        )
         outdated = (try? container.decode(Bool.self, forKey: .outdated)) ?? false
     }
 
@@ -105,6 +107,7 @@ struct BrewInfoCask: Decodable {
         case versions
         case installed
         case dependencies
+        case dependsOn = "depends_on"
         case outdated
     }
 }
@@ -130,23 +133,44 @@ private extension KeyedDecodingContainer {
         return []
     }
 
-    func decodeCaskDependencies(forKey key: Key) -> [String] {
+    func decodeCaskDependencyReferences(forKeys keys: [Key]) -> [HomebrewPackageReference] {
+        for key in keys {
+            let references = decodeCaskDependencyReferences(forKey: key)
+            if !references.isEmpty {
+                return references
+            }
+        }
+        return []
+    }
+
+    func decodeCaskDependencyReferences(forKey key: Key) -> [HomebrewPackageReference] {
         if let array = try? decode([String].self, forKey: key) {
-            return array
+            return HomebrewPackageReference.formulaDependencies(from: array)
         }
         if let single = try? decode(String.self, forKey: key), !single.isEmpty {
-            return [single]
+            return HomebrewPackageReference.formulaDependencies(from: [single])
         }
         guard let nested = try? nestedContainer(keyedBy: AnyCodingKey.self, forKey: key) else {
             return []
         }
 
-        var merged: [String] = []
+        var merged: [HomebrewPackageReference] = []
         for nestedKey in nested.allKeys {
-            let values = nested.decodeStringArray(forKey: nestedKey)
-            merged.append(contentsOf: values)
+            switch nestedKey.stringValue {
+            case "formula":
+                merged.append(
+                    contentsOf: HomebrewPackageReference.formulaDependencies(
+                        from: nested.decodeStringArray(forKey: nestedKey),
+                    ),
+                )
+            case "cask":
+                let caskTokens = nested.decodeStringArray(forKey: nestedKey)
+                merged.append(contentsOf: caskTokens.map { HomebrewPackageReference.cask(token: $0) })
+            default:
+                continue
+            }
         }
-        return merged
+        return HomebrewPackageReference.uniqueReferences(merged)
     }
 }
 

--- a/Brew/Models/BrewPackage.swift
+++ b/Brew/Models/BrewPackage.swift
@@ -12,7 +12,7 @@ struct BrewPackage: Identifiable, Hashable {
     var homepage: String
     var latestVersion: String
     var installedVersions: [String]
-    var dependencies: [String]
+    var dependencies: [HomebrewPackageReference]
     var outdated: Bool
 
     var id: String {

--- a/Brew/Models/HomebrewPackageReference.swift
+++ b/Brew/Models/HomebrewPackageReference.swift
@@ -1,0 +1,84 @@
+//
+//  HomebrewPackageReference.swift
+//  Brew
+//
+
+import Foundation
+
+/// Kind-qualified reference to a Homebrew formula name or cask token.
+enum HomebrewPackageReference: Hashable {
+    case formula(name: String)
+    case cask(token: String)
+
+    var kind: HomebrewPackageKind {
+        switch self {
+        case .formula:
+            .formula
+        case .cask:
+            .cask
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case let .formula(name):
+            name
+        case let .cask(token):
+            token
+        }
+    }
+
+    var packageID: BrewPackage.ID {
+        switch self {
+        case let .formula(name):
+            "\(HomebrewPackageKind.formula.rawValue):\(name)"
+        case let .cask(token):
+            "\(HomebrewPackageKind.cask.rawValue):\(token)"
+        }
+    }
+
+    init(package: BrewPackage) {
+        switch package.kind {
+        case .formula:
+            self = .formula(name: package.name)
+        case .cask:
+            self = .cask(token: package.name)
+        }
+    }
+}
+
+extension HomebrewPackageReference {
+    static func formulaDependencies(from names: [String]) -> [HomebrewPackageReference] {
+        uniqueReferences(names.map { .formula(name: $0) })
+    }
+
+    static func uniqueReferences(_ references: [HomebrewPackageReference]) -> [HomebrewPackageReference] {
+        var seen: Set<HomebrewPackageReference> = []
+        var result: [HomebrewPackageReference] = []
+        for reference in references {
+            guard let normalized = reference.normalized, !seen.contains(normalized) else {
+                continue
+            }
+            seen.insert(normalized)
+            result.append(normalized)
+        }
+        return result
+    }
+
+    private var normalized: HomebrewPackageReference? {
+        switch self {
+        case let .formula(name):
+            let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else {
+                return nil
+            }
+            return .formula(name: trimmed)
+        case let .cask(token):
+            let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else {
+                return nil
+            }
+            return .cask(token: trimmed)
+        }
+    }
+}

--- a/Brew/Models/InstalledInventorySnapshot.swift
+++ b/Brew/Models/InstalledInventorySnapshot.swift
@@ -1,0 +1,24 @@
+//
+//  InstalledInventorySnapshot.swift
+//  Brew
+//
+
+import Foundation
+
+struct InstalledInventorySnapshot: Equatable {
+    nonisolated static let defaultTTL: TimeInterval = 3600
+
+    var fetchedAt: Date
+    let packages: [BrewPackage]
+    let graph: PackageDependencyGraph
+
+    init(fetchedAt: Date, packages: [BrewPackage]) {
+        self.fetchedAt = fetchedAt
+        self.packages = packages
+        graph = PackageDependencyGraph(packages: packages)
+    }
+
+    nonisolated func isStale(relativeTo now: Date = .now, ttl: TimeInterval = Self.defaultTTL) -> Bool {
+        now.timeIntervalSince(fetchedAt) >= ttl
+    }
+}

--- a/Brew/Models/PackageDependencyGraph.swift
+++ b/Brew/Models/PackageDependencyGraph.swift
@@ -1,0 +1,35 @@
+//
+//  PackageDependencyGraph.swift
+//  Brew
+//
+
+import Foundation
+
+/// Reverse dependency lookups over one installed-inventory snapshot.
+struct PackageDependencyGraph: Equatable {
+    private let packagesByID: [BrewPackage.ID: BrewPackage]
+    private let dependentsByDependencyPackageID: [BrewPackage.ID: [BrewPackage.ID]]
+
+    init(packages: [BrewPackage]) {
+        var byID: [BrewPackage.ID: BrewPackage] = [:]
+        var reverse: [BrewPackage.ID: [BrewPackage.ID]] = [:]
+
+        for package in packages {
+            byID[package.id] = package
+            for dependency in package.dependencies {
+                reverse[dependency.packageID, default: []].append(package.id)
+            }
+        }
+
+        packagesByID = byID
+        dependentsByDependencyPackageID = reverse
+    }
+
+    func installedDependents(for packageID: BrewPackage.ID) -> [BrewPackage] {
+        (dependentsByDependencyPackageID[packageID] ?? [])
+            .compactMap { packagesByID[$0] }
+            .sorted {
+                $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+            }
+    }
+}

--- a/Brew/Models/PackageRelationshipItem.swift
+++ b/Brew/Models/PackageRelationshipItem.swift
@@ -1,0 +1,57 @@
+//
+//  PackageRelationshipItem.swift
+//  Brew
+//
+
+import Foundation
+
+/// One dependency or dependent row in installed package detail.
+struct PackageRelationshipItem: Identifiable, Hashable {
+    let displayName: String
+    let packageKind: HomebrewPackageKind
+    let targetPackageID: BrewPackage.ID
+    let installedPackageID: BrewPackage.ID?
+
+    var id: String {
+        installedPackageID ?? "relationship:\(targetPackageID)"
+    }
+
+    var isInstalledInInventory: Bool {
+        installedPackageID != nil
+    }
+}
+
+@MainActor
+extension PackageRelationshipItem {
+    static func dependency(
+        _ reference: HomebrewPackageReference,
+        installedPackageIDs: Set<BrewPackage.ID>,
+    ) -> PackageRelationshipItem {
+        PackageRelationshipItem(
+            displayName: reference.displayName,
+            packageKind: reference.kind,
+            targetPackageID: reference.packageID,
+            installedPackageID: installedPackageIDs.contains(reference.packageID) ? reference.packageID : nil,
+        )
+    }
+
+    static func dependent(_ package: BrewPackage) -> PackageRelationshipItem {
+        PackageRelationshipItem(
+            displayName: package.name,
+            packageKind: package.kind,
+            targetPackageID: package.id,
+            installedPackageID: package.id,
+        )
+    }
+
+    static func dependencies(
+        _ references: [HomebrewPackageReference],
+        installedPackageIDs: Set<BrewPackage.ID>,
+    ) -> [PackageRelationshipItem] {
+        references.map { dependency($0, installedPackageIDs: installedPackageIDs) }
+    }
+
+    static func dependents(_ packages: [BrewPackage]) -> [PackageRelationshipItem] {
+        packages.map(dependent)
+    }
+}

--- a/Brew/PreviewData/InstalledPreviewRepositories.swift
+++ b/Brew/PreviewData/InstalledPreviewRepositories.swift
@@ -56,7 +56,7 @@ private enum InstalledPreviewData {
 }
 
 struct PreviewInstalledPackagesRepository: InstalledPackagesRepository {
-    func loadInstalledPackages() async throws -> [BrewPackage] {
+    func loadInstalledPackages(forceRefresh _: Bool) async throws -> [BrewPackage] {
         InstalledPreviewData.snapshot
     }
 }

--- a/Brew/Repositories/BrewInstalledDependentsRepository.swift
+++ b/Brew/Repositories/BrewInstalledDependentsRepository.swift
@@ -1,0 +1,21 @@
+//
+//  BrewInstalledDependentsRepository.swift
+//  Brew
+//
+
+import Foundation
+
+struct BrewInstalledDependentsRepository: InstalledDependentsRepository {
+    private let cache: InstalledInventoryCache
+
+    init(cache: InstalledInventoryCache) {
+        self.cache = cache
+    }
+
+    func installedDependents(for packageID: BrewPackage.ID) async -> [BrewPackage] {
+        guard let snapshot = await cache.currentSnapshot() else {
+            return []
+        }
+        return snapshot.graph.installedDependents(for: packageID)
+    }
+}

--- a/Brew/Repositories/BrewInstalledPackagesRepository.swift
+++ b/Brew/Repositories/BrewInstalledPackagesRepository.swift
@@ -5,28 +5,58 @@
 
 import Foundation
 
-struct BrewInstalledPackagesRepository: InstalledPackagesRepository {
+struct BrewInstalledPackagesRepository: InstalledPackagesRepository, InstalledInventoryReading {
     private let commandRunner: BrewCommandRunning
     private let locator: any BrewExecutableLocating
+    private let cache: InstalledInventoryCache
 
-    init(commandRunner: BrewCommandRunning, locator: any BrewExecutableLocating) {
+    init(
+        commandRunner: BrewCommandRunning,
+        locator: any BrewExecutableLocating,
+        cache: InstalledInventoryCache,
+    ) {
         self.commandRunner = commandRunner
         self.locator = locator
+        self.cache = cache
     }
 
     /// Production wiring: real subprocess + default `brew` lookup.
-    static func live() -> BrewInstalledPackagesRepository {
+    static func live(cache: InstalledInventoryCache) -> BrewInstalledPackagesRepository {
         BrewInstalledPackagesRepository(
             commandRunner: BrewCommandService(),
             locator: BrewExecutableLocator(),
+            cache: cache,
         )
     }
 
-    func loadInstalledPackages() async throws -> [BrewPackage] {
+    func loadInstalledPackages(forceRefresh: Bool = false) async throws -> [BrewPackage] {
+        guard !forceRefresh else {
+            return try await fetchInstalledPackages()
+        }
+
+        switch await cache.cachedPackages() {
+        case let .fresh(packages):
+            return packages
+        case .stale, .empty:
+            return try await fetchInstalledPackages()
+        }
+    }
+
+    func installedPackageIDs() async -> Set<BrewPackage.ID> {
+        guard let snapshot = await cache.currentSnapshot() else {
+            return []
+        }
+        return Set(snapshot.packages.map(\.id))
+    }
+
+    private func fetchInstalledPackages() async throws -> [BrewPackage] {
         let brew = try locator.findBrewExecutable()
         let output = try await runInstalledInfoJSON(executable: brew)
         let payload = try decodeInfoJSON(from: output)
-        return payload.installedPackages()
+        let packages = payload.installedPackages()
+        let snapshot = InstalledInventorySnapshot(fetchedAt: .now, packages: packages)
+        await cache.replace(snapshot)
+        return packages
     }
 
     private func runInstalledInfoJSON(executable: URL) async throws -> String {

--- a/Brew/Repositories/InstalledDependentsRepository.swift
+++ b/Brew/Repositories/InstalledDependentsRepository.swift
@@ -1,0 +1,12 @@
+//
+//  InstalledDependentsRepository.swift
+//  Brew
+//
+
+import Foundation
+
+/// Reverse dependency lookups over the installed inventory snapshot.
+@MainActor
+protocol InstalledDependentsRepository: Sendable {
+    func installedDependents(for packageID: BrewPackage.ID) async -> [BrewPackage]
+}

--- a/Brew/Repositories/InstalledInventoryReading.swift
+++ b/Brew/Repositories/InstalledInventoryReading.swift
@@ -1,0 +1,12 @@
+//
+//  InstalledInventoryReading.swift
+//  Brew
+//
+
+import Foundation
+
+/// Read-only access to the cached installed inventory snapshot.
+@MainActor
+protocol InstalledInventoryReading: Sendable {
+    func installedPackageIDs() async -> Set<BrewPackage.ID>
+}

--- a/Brew/Repositories/InstalledPackagesRepository.swift
+++ b/Brew/Repositories/InstalledPackagesRepository.swift
@@ -6,6 +6,13 @@
 import Foundation
 
 /// Loads installed formulae and casks — swap `BrewInstalledPackagesRepository` / test doubles (`CONVENTIONS.md` — Testing).
+@MainActor
 protocol InstalledPackagesRepository: Sendable {
-    func loadInstalledPackages() async throws -> [BrewPackage]
+    func loadInstalledPackages(forceRefresh: Bool) async throws -> [BrewPackage]
+}
+
+extension InstalledPackagesRepository {
+    func loadInstalledPackages() async throws -> [BrewPackage] {
+        try await loadInstalledPackages(forceRefresh: false)
+    }
 }

--- a/Brew/Services/InstalledInventoryCache.swift
+++ b/Brew/Services/InstalledInventoryCache.swift
@@ -1,0 +1,30 @@
+//
+//  InstalledInventoryCache.swift
+//  Brew
+//
+
+import Foundation
+
+/// Shared installed-inventory storage with TTL semantics. Domain reads (packages, dependents) go through repositories, not this actor.
+actor InstalledInventoryCache {
+    enum CacheResult {
+        case fresh([BrewPackage])
+        case stale([BrewPackage])
+        case empty
+    }
+
+    private var snapshot: InstalledInventorySnapshot?
+
+    func replace(_ snapshot: InstalledInventorySnapshot) {
+        self.snapshot = snapshot
+    }
+
+    func currentSnapshot() -> InstalledInventorySnapshot? {
+        snapshot
+    }
+
+    func cachedPackages() -> CacheResult {
+        guard let snapshot else { return .empty }
+        return snapshot.isStale() ? .stale(snapshot.packages) : .fresh(snapshot.packages)
+    }
+}

--- a/Brew/Services/InstalledInventoryEnvironment.swift
+++ b/Brew/Services/InstalledInventoryEnvironment.swift
@@ -1,0 +1,11 @@
+//
+//  InstalledInventoryEnvironment.swift
+//  Brew
+//
+
+import SwiftUI
+
+extension EnvironmentValues {
+    /// Inject from ``BrewApp``; otherwise a default cache is created for previews and unscoped subtrees.
+    @Entry var installedInventoryCache = InstalledInventoryCache()
+}

--- a/BrewTests/BrewInstalledDependentsRepositoryTests.swift
+++ b/BrewTests/BrewInstalledDependentsRepositoryTests.swift
@@ -1,0 +1,41 @@
+//
+//  BrewInstalledDependentsRepositoryTests.swift
+//  BrewTests
+//
+
+@testable import Brew
+import Foundation
+import Testing
+
+struct BrewInstalledDependentsRepositoryTests {
+    @Test @MainActor func `installedDependents resolves reverse dependencies from cached snapshot`() async {
+        let cache = InstalledInventoryCache()
+        let snapshot = InstalledInventorySnapshot(
+            fetchedAt: .now,
+            packages: [
+                .fixture(name: "openssl@3", kind: .formula, dependencies: []),
+                .fixture(name: "node", kind: .formula, dependencies: [.formula(name: "openssl@3")]),
+            ],
+        )
+        await cache.replace(snapshot)
+        let repository = BrewInstalledDependentsRepository(cache: cache)
+        let openssl = snapshot.packages.first(where: { $0.name == "openssl@3" })
+        guard let openssl else {
+            Issue.record("expected openssl@3 in snapshot")
+            return
+        }
+
+        let dependents = await repository.installedDependents(for: openssl.id)
+
+        #expect(dependents.map(\.name) == ["node"])
+    }
+
+    @Test @MainActor func `installedDependents returns empty when cache has no snapshot`() async {
+        let cache = InstalledInventoryCache()
+        let repository = BrewInstalledDependentsRepository(cache: cache)
+
+        let dependents = await repository.installedDependents(for: "formula:openssl@3")
+
+        #expect(dependents.isEmpty)
+    }
+}

--- a/BrewTests/BrewInstalledPackagesCacheTests.swift
+++ b/BrewTests/BrewInstalledPackagesCacheTests.swift
@@ -1,0 +1,89 @@
+//
+//  BrewInstalledPackagesCacheTests.swift
+//  BrewTests
+//
+
+@testable import Brew
+import Foundation
+import Testing
+
+struct BrewInstalledPackagesCacheTests {
+    @Test @MainActor func `load returns cached packages when snapshot is fresh`() async throws {
+        let cache = InstalledInventoryCache()
+        let runner = CountingInstalledInfoJSONRunner()
+        let repository = InstalledPackagesTestSupport.repository(commandRunner: runner, cache: cache)
+
+        let first = try await repository.loadInstalledPackages()
+        let second = try await repository.loadInstalledPackages()
+
+        #expect(first.map(\.name) == ["git"])
+        #expect(second.map(\.name) == ["git"])
+        #expect(runner.loadCallCount == 1)
+    }
+
+    @Test @MainActor func `load refetches when forceRefresh is true`() async throws {
+        let cache = InstalledInventoryCache()
+        let runner = CountingInstalledInfoJSONRunner()
+        let repository = InstalledPackagesTestSupport.repository(commandRunner: runner, cache: cache)
+
+        _ = try await repository.loadInstalledPackages()
+        _ = try await repository.loadInstalledPackages(forceRefresh: true)
+
+        #expect(runner.loadCallCount == 2)
+    }
+
+    @Test @MainActor func `load refetches when snapshot is stale`() async throws {
+        let cache = InstalledInventoryCache()
+        let runner = CountingInstalledInfoJSONRunner()
+        let repository = InstalledPackagesTestSupport.repository(commandRunner: runner, cache: cache)
+        let staleSnapshot = InstalledInventorySnapshot(
+            fetchedAt: Date(timeIntervalSince1970: 0),
+            packages: [.fixture(name: "stale", kind: .formula)],
+        )
+        await cache.replace(staleSnapshot)
+
+        let packages = try await repository.loadInstalledPackages()
+
+        #expect(packages.map(\.name) == ["git"])
+        #expect(runner.loadCallCount == 1)
+    }
+
+    @Test @MainActor func `inventory reading exposes cached ids`() async {
+        let cache = InstalledInventoryCache()
+        let packages = [
+            BrewPackage.fixture(name: "openssl@3", kind: .formula),
+            BrewPackage.fixture(name: "wget", kind: .formula, dependencies: [.formula(name: "openssl@3")]),
+        ]
+        await cache.replace(InstalledInventorySnapshot(fetchedAt: .now, packages: packages))
+        let repository = InstalledPackagesTestSupport.repository(
+            commandRunner: MockBrewCommandRunner(responses: [:]),
+            cache: cache,
+        )
+
+        let installedIDs = await repository.installedPackageIDs()
+        #expect(installedIDs == Set(packages.map(\.id)))
+    }
+}
+
+private final class CountingInstalledInfoJSONRunner: BrewCommandRunning, @unchecked Sendable {
+    private(set) var loadCallCount = 0
+
+    func run(executableURL _: URL, arguments: [String]) async throws -> CommandOutput {
+        guard arguments == ["info", "--installed", "--json=v2"] else {
+            throw BrewCommandError.failed(exitCode: 99, stderr: "unmocked: \(arguments.joined(separator: " "))")
+        }
+        loadCallCount += 1
+        return CommandOutput(
+            standardOutput: """
+            {
+              "formulae": [
+                { "name": "git", "versions": { "stable": "2.0.0" }, "installed": [{ "version": "1.0.0" }] }
+              ],
+              "casks": []
+            }
+            """,
+            standardError: "",
+            terminationStatus: 0,
+        )
+    }
+}

--- a/BrewTests/BrewInstalledPackagesRepositoryTests.swift
+++ b/BrewTests/BrewInstalledPackagesRepositoryTests.swift
@@ -138,13 +138,50 @@ struct BrewInstalledPackagesRepositoryTests {
         let formula = try #require(package(named: "deps-formula", in: packages))
         #expect(formula.description == "formula desc")
         #expect(formula.homepage == "https://example.com")
-        #expect(formula.dependencies == ["openssl", "make", "curl", "sqlite"])
+        #expect(formula.dependencies == [.formula(name: "openssl")])
 
         let cask = try #require(package(named: "deps-cask", in: packages))
         #expect(cask.description == "cask desc")
         #expect(cask.homepage == "https://example.org")
-        #expect(Set(cask.dependencies) == Set(["git", "docker"]))
-        #expect(cask.dependencies.count == 2)
+        #expect(Set(cask.dependencies) == Set([.formula(name: "git"), .cask(token: "docker"), .cask(token: "git")]))
+        #expect(cask.dependencies.count == 3)
+    }
+
+    @Test @MainActor func `load maps cask depends_on formula and cask keys and ignores macos`() async throws {
+        let json = """
+        {
+          "formulae": [],
+          "casks": [
+            {
+              "token": "beid-viewer",
+              "installed": ["1.0.0"],
+              "depends_on": {
+                "macos": {},
+                "cask": ["beid-token"]
+              }
+            },
+            {
+              "token": "beutl",
+              "installed": ["2.0.0"],
+              "depends_on": {
+                "macos": { ">=": ["12"] },
+                "formula": ["ffmpeg@6"]
+              }
+            }
+          ]
+        }
+        """
+        let runner = MockBrewCommandRunner(
+            responses: InstalledPackagesTestSupport.installedInfoJSONResponse(standardOutput: json),
+        )
+        let repo = InstalledPackagesTestSupport.repository(commandRunner: runner)
+        let packages = try await repo.loadInstalledPackages()
+
+        let beidViewer = try #require(package(named: "beid-viewer", in: packages))
+        #expect(beidViewer.dependencies == [.cask(token: "beid-token")])
+
+        let beutl = try #require(package(named: "beutl", in: packages))
+        #expect(beutl.dependencies == [.formula(name: "ffmpeg@6")])
     }
 
     @Test @MainActor func `load tolerates optional and missing fields in json payload`() async throws {

--- a/BrewTests/HomebrewPackageReferenceTests.swift
+++ b/BrewTests/HomebrewPackageReferenceTests.swift
@@ -1,0 +1,54 @@
+//
+//  HomebrewPackageReferenceTests.swift
+//  BrewTests
+//
+
+@testable import Brew
+import Testing
+
+struct HomebrewPackageReferenceTests {
+    @Test func `packageID encodes formula and cask references`() {
+        #expect(HomebrewPackageReference.formula(name: "openssl@3").packageID == "formula:openssl@3")
+        #expect(HomebrewPackageReference.cask(token: "docker").packageID == "cask:docker")
+    }
+
+    @Test func `uniqueReferences trims whitespace and drops empty names`() {
+        let references = HomebrewPackageReference.uniqueReferences([
+            .formula(name: "  openssl@3  "),
+            .formula(name: ""),
+            .formula(name: "   "),
+            .cask(token: " docker "),
+        ])
+
+        #expect(references == [.formula(name: "openssl@3"), .cask(token: "docker")])
+    }
+
+    @Test func `uniqueReferences deduplicates by kind and name`() {
+        let references = HomebrewPackageReference.uniqueReferences([
+            .formula(name: "openssl@3"),
+            .formula(name: "openssl@3"),
+            .cask(token: "docker"),
+            .cask(token: "docker"),
+        ])
+
+        #expect(references == [.formula(name: "openssl@3"), .cask(token: "docker")])
+    }
+
+    @Test func `formulaDependencies applies uniqueReferences`() {
+        let references = HomebrewPackageReference.formulaDependencies(from: [
+            "openssl@3",
+            " openssl@3 ",
+            "",
+        ])
+
+        #expect(references == [.formula(name: "openssl@3")])
+    }
+
+    @Test func `init from package preserves kind and name`() {
+        let formula = BrewPackage.fixture(name: "wget", kind: .formula)
+        let cask = BrewPackage.fixture(name: "docker", kind: .cask)
+
+        #expect(HomebrewPackageReference(package: formula) == .formula(name: "wget"))
+        #expect(HomebrewPackageReference(package: cask) == .cask(token: "docker"))
+    }
+}

--- a/BrewTests/InstalledDetailsViewModelTests.swift
+++ b/BrewTests/InstalledDetailsViewModelTests.swift
@@ -9,7 +9,7 @@ import Testing
 
 struct InstalledDetailsViewModelTests {
     @Test @MainActor func `displayCommand uses package name`() {
-        let viewModel = InstalledDetailsViewModel(
+        let viewModel = makeInstalledDetailsViewModel(
             package: .fixture(name: "wget", kind: .formula),
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
@@ -17,7 +17,7 @@ struct InstalledDetailsViewModelTests {
     }
 
     @Test @MainActor func `displayCommand updates when package changes via update`() {
-        let viewModel = InstalledDetailsViewModel(
+        let viewModel = makeInstalledDetailsViewModel(
             package: .fixture(name: "wget", kind: .formula),
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
@@ -28,7 +28,7 @@ struct InstalledDetailsViewModelTests {
     @Test @MainActor func `homepageURL returns valid http URL from package`() {
         var loadedDetails = details(name: "wget")
         loadedDetails.homepage = "https://example.com"
-        let viewModel = InstalledDetailsViewModel(
+        let viewModel = makeInstalledDetailsViewModel(
             package: loadedDetails,
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
@@ -38,7 +38,7 @@ struct InstalledDetailsViewModelTests {
     @Test @MainActor func `homepageURL returns nil for invalid homepage`() {
         var loadedDetails = details(name: "wget")
         loadedDetails.homepage = "not-a-url"
-        let viewModel = InstalledDetailsViewModel(
+        let viewModel = makeInstalledDetailsViewModel(
             package: loadedDetails,
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
@@ -46,7 +46,7 @@ struct InstalledDetailsViewModelTests {
     }
 
     @Test @MainActor func `homepageURL returns nil when homepage empty`() {
-        let viewModel = InstalledDetailsViewModel(
+        let viewModel = makeInstalledDetailsViewModel(
             package: details(name: "wget"),
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
@@ -54,7 +54,7 @@ struct InstalledDetailsViewModelTests {
     }
 
     @Test @MainActor func `upgradeDisplayCommand reflects formula name`() {
-        let viewModel = InstalledDetailsViewModel(
+        let viewModel = makeInstalledDetailsViewModel(
             package: .fixture(name: "wget", kind: .formula),
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
@@ -62,7 +62,7 @@ struct InstalledDetailsViewModelTests {
     }
 
     @Test @MainActor func `upgradeDisplayCommand uses cask terminal flags`() {
-        let viewModel = InstalledDetailsViewModel(
+        let viewModel = makeInstalledDetailsViewModel(
             package: .fixture(name: "docker", kind: .cask),
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
@@ -70,7 +70,7 @@ struct InstalledDetailsViewModelTests {
     }
 
     @Test @MainActor func `upgradeDisplayCommand updates when package name changes`() {
-        let viewModel = InstalledDetailsViewModel(
+        let viewModel = makeInstalledDetailsViewModel(
             package: .fixture(name: "wget", kind: .formula),
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
@@ -81,7 +81,7 @@ struct InstalledDetailsViewModelTests {
     @Test @MainActor func `showsUpgradeChrome follows package outdated flag`() {
         var outdatedDetails = details(name: "wget")
         outdatedDetails.outdated = true
-        let outdatedVM = InstalledDetailsViewModel(
+        let outdatedVM = makeInstalledDetailsViewModel(
             package: outdatedDetails,
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
@@ -89,7 +89,7 @@ struct InstalledDetailsViewModelTests {
 
         var currentDetails = details(name: "wget")
         currentDetails.outdated = false
-        let currentVM = InstalledDetailsViewModel(
+        let currentVM = makeInstalledDetailsViewModel(
             package: currentDetails,
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
@@ -97,7 +97,7 @@ struct InstalledDetailsViewModelTests {
     }
 
     @Test @MainActor func `upgradePrimaryButtonTitle is nil when package is current`() {
-        let viewModel = InstalledDetailsViewModel(
+        let viewModel = makeInstalledDetailsViewModel(
             package: details(name: "wget"),
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
@@ -108,7 +108,7 @@ struct InstalledDetailsViewModelTests {
         var outdatedDetails = details(name: "wget")
         outdatedDetails.outdated = true
         outdatedDetails.latestVersion = "9.9.9"
-        let viewModel = InstalledDetailsViewModel(
+        let viewModel = makeInstalledDetailsViewModel(
             package: outdatedDetails,
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
@@ -116,7 +116,7 @@ struct InstalledDetailsViewModelTests {
     }
 
     @Test @MainActor func `update package mutates derived presentation for upgrade button`() {
-        let viewModel = InstalledDetailsViewModel(
+        let viewModel = makeInstalledDetailsViewModel(
             package: details(name: "wget", version: "1.0.0"),
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
@@ -130,17 +130,102 @@ struct InstalledDetailsViewModelTests {
     }
 
     @Test @MainActor func `detail row is not upgrading before observeRowUpdates runs`() {
-        let viewModel = InstalledDetailsViewModel(
+        let viewModel = makeInstalledDetailsViewModel(
             package: details(name: "wget"),
             brewCommandCenter: ConstantPhaseCommandCenter(phase: .running(.upgradeFormula)),
         )
         #expect(!viewModel.isUpgrading)
     }
+
+    @Test @MainActor func `dependents uses injected repository for current package`() async {
+        let package = details(name: "openssl@3")
+        let viewModel = makeInstalledDetailsViewModel(
+            package: package,
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
+            installedDependentsRepository: StubInstalledDependentsRepository { packageID in
+                packageID == package.id
+                    ? [.fixture(name: "curl"), .fixture(name: "node")]
+                    : []
+            },
+        )
+        await viewModel.refreshDependents()
+        #expect(viewModel.dependentRelationships.map(\.displayName) == ["curl", "node"])
+        #expect(viewModel.dependentRelationships.map(\.packageKind) == [.formula, .formula])
+        #expect(viewModel.dependentRelationships.map(\.isInstalledInInventory) == [true, true])
+    }
+
+    @Test @MainActor func `update package refreshes dependents from repository`() async {
+        let openssl = details(name: "openssl@3")
+        let wget = details(name: "wget")
+        let viewModel = makeInstalledDetailsViewModel(
+            package: openssl,
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
+            installedDependentsRepository: StubInstalledDependentsRepository { packageID in
+                packageID == wget.id ? [.fixture(name: "curl")] : []
+            },
+        )
+        await viewModel.refreshDependents()
+        viewModel.update(package: wget)
+        await viewModel.refreshDependents()
+        #expect(viewModel.dependentRelationships.map(\.displayName) == ["curl"])
+    }
+
+    @Test @MainActor func `refreshDependencies marks installed and missing dependency refs`() async {
+        let package = BrewPackage.fixture(
+            name: "wget",
+            kind: .formula,
+            dependencies: [.formula(name: "openssl@3"), .formula(name: "zlib")],
+        )
+        let viewModel = makeInstalledDetailsViewModel(
+            package: package,
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
+            installedInventoryReading: StubInstalledInventoryReading(installedIDs: ["formula:openssl@3"]),
+        )
+
+        await viewModel.refreshDependencies()
+
+        #expect(viewModel.dependencyRelationships.count == 2)
+        #expect(viewModel.dependencyRelationships[0].displayName == "openssl@3")
+        #expect(viewModel.dependencyRelationships[0].packageKind == .formula)
+        #expect(viewModel.dependencyRelationships[0].isInstalledInInventory)
+        #expect(viewModel.dependencyRelationships[1].displayName == "zlib")
+        #expect(viewModel.dependencyRelationships[1].packageKind == .formula)
+        #expect(!viewModel.dependencyRelationships[1].isInstalledInInventory)
+    }
+
+    @Test @MainActor func `update package clears dependency relationships`() async {
+        let viewModel = makeInstalledDetailsViewModel(
+            package: BrewPackage.fixture(
+                name: "wget",
+                kind: .formula,
+                dependencies: [.formula(name: "openssl@3")],
+            ),
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
+            installedInventoryReading: StubInstalledInventoryReading(installedIDs: ["formula:openssl@3"]),
+        )
+        await viewModel.refreshDependencies()
+        viewModel.update(package: BrewPackage.fixture(name: "curl", kind: .formula))
+        #expect(viewModel.dependencyRelationships.isEmpty)
+    }
+
+    @Test @MainActor func `update package clears dependent relationships`() async {
+        let package = details(name: "openssl@3")
+        let viewModel = makeInstalledDetailsViewModel(
+            package: package,
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
+            installedDependentsRepository: StubInstalledDependentsRepository { packageID in
+                packageID == package.id ? [.fixture(name: "curl")] : []
+            },
+        )
+        await viewModel.refreshDependents()
+        viewModel.update(package: BrewPackage.fixture(name: "wget", kind: .formula))
+        #expect(viewModel.dependentRelationships.isEmpty)
+    }
 }
 
 struct InstalledDetailsViewModelUpgradeTests {
     @Test @MainActor func `upgrade completes with idle phase and no error using noop center`() async {
-        let viewModel = InstalledDetailsViewModel(
+        let viewModel = makeInstalledDetailsViewModel(
             package: details(name: "wget"),
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
@@ -153,7 +238,7 @@ struct InstalledDetailsViewModelUpgradeTests {
     }
 
     @Test @MainActor func `upgrade failure sets upgrade error message`() async {
-        let viewModel = InstalledDetailsViewModel(
+        let viewModel = makeInstalledDetailsViewModel(
             package: details(name: "wget"),
             brewCommandCenter: ThrowingSubmitCommandCenter(
                 error: BrewCommandError.failed(exitCode: 1, stderr: "upgrade blocked"),
@@ -169,7 +254,7 @@ struct InstalledDetailsViewModelUpgradeTests {
 
     @Test @MainActor func `upgrade ignores reentry while already upgrading`() async {
         let center = RunningSubmitCountingCommandCenter()
-        let viewModel = InstalledDetailsViewModel(
+        let viewModel = makeInstalledDetailsViewModel(
             package: details(name: "wget"),
             brewCommandCenter: center,
         )
@@ -185,7 +270,7 @@ struct InstalledDetailsViewModelUpgradeTests {
     }
 
     @Test @MainActor func `upgrade failure maps missing brew to user facing message`() async {
-        let viewModel = InstalledDetailsViewModel(
+        let viewModel = makeInstalledDetailsViewModel(
             package: details(name: "wget"),
             brewCommandCenter: ThrowingSubmitCommandCenter(
                 error: BrewLookupError.executableNotFound,
@@ -203,7 +288,7 @@ struct InstalledDetailsViewModelUpgradeTests {
     }
 
     @Test @MainActor func `upgrade failure maps launch failure to underlying message`() async {
-        let viewModel = InstalledDetailsViewModel(
+        let viewModel = makeInstalledDetailsViewModel(
             package: details(name: "wget"),
             brewCommandCenter: ThrowingSubmitCommandCenter(
                 error: BrewCommandError.launchFailed(underlying: "spawn failed"),
@@ -218,7 +303,7 @@ struct InstalledDetailsViewModelUpgradeTests {
     }
 
     @Test @MainActor func `upgrade failure maps unknown errors to generic message`() async {
-        let viewModel = InstalledDetailsViewModel(
+        let viewModel = makeInstalledDetailsViewModel(
             package: details(name: "wget"),
             brewCommandCenter: ThrowingSubmitCommandCenter(
                 error: GenericUpgradeError(),
@@ -234,7 +319,7 @@ struct InstalledDetailsViewModelUpgradeTests {
 
     @Test @MainActor func `upgrade submit continues after caller task cancellation`() async {
         let center = DeferredSubmitCommandCenter()
-        let viewModel = InstalledDetailsViewModel(
+        let viewModel = makeInstalledDetailsViewModel(
             package: details(name: "wget"),
             brewCommandCenter: center,
         )

--- a/BrewTests/InstalledDetailsViewModelTestsSupport.swift
+++ b/BrewTests/InstalledDetailsViewModelTestsSupport.swift
@@ -193,6 +193,21 @@ func withInstalledDetailPhaseObservation(
     await body()
 }
 
+@MainActor
+func makeInstalledDetailsViewModel(
+    package: BrewPackage,
+    brewCommandCenter: any BrewCommandCenter = NoopBrewCommandCenter.forTesting(),
+    installedDependentsRepository: (any InstalledDependentsRepository)? = nil,
+    installedInventoryReading: (any InstalledInventoryReading)? = nil,
+) -> InstalledDetailsViewModel {
+    InstalledDetailsViewModel(
+        package: package,
+        brewCommandCenter: brewCommandCenter,
+        installedDependentsRepository: installedDependentsRepository ?? EmptyInstalledDependentsRepository(),
+        installedInventoryReading: installedInventoryReading ?? EmptyInstalledInventoryReading(),
+    )
+}
+
 func details(
     name: String,
     kind: InstalledPackageKind = .formula,

--- a/BrewTests/InstalledInventorySnapshotTests.swift
+++ b/BrewTests/InstalledInventorySnapshotTests.swift
@@ -1,0 +1,47 @@
+//
+//  InstalledInventorySnapshotTests.swift
+//  BrewTests
+//
+
+@testable import Brew
+import Foundation
+import Testing
+
+struct InstalledInventorySnapshotTests {
+    @Test func `isStale is false before default TTL elapses`() {
+        let fetchedAt = Date(timeIntervalSinceReferenceDate: 0)
+        let snapshot = InstalledInventorySnapshot(fetchedAt: fetchedAt, packages: [])
+        let ttl = InstalledInventorySnapshot.defaultTTL
+
+        #expect(!snapshot.isStale(relativeTo: fetchedAt.addingTimeInterval(ttl - 1), ttl: ttl))
+    }
+
+    @Test func `isStale is true at default TTL boundary`() {
+        let fetchedAt = Date(timeIntervalSinceReferenceDate: 0)
+        let snapshot = InstalledInventorySnapshot(fetchedAt: fetchedAt, packages: [])
+        let ttl = InstalledInventorySnapshot.defaultTTL
+
+        #expect(snapshot.isStale(relativeTo: fetchedAt.addingTimeInterval(ttl), ttl: ttl))
+    }
+
+    @Test func `isStale respects custom TTL`() {
+        let fetchedAt = Date(timeIntervalSinceReferenceDate: 0)
+        let snapshot = InstalledInventorySnapshot(fetchedAt: fetchedAt, packages: [])
+        let ttl: TimeInterval = 60
+
+        #expect(!snapshot.isStale(relativeTo: fetchedAt.addingTimeInterval(ttl - 1), ttl: ttl))
+        #expect(snapshot.isStale(relativeTo: fetchedAt.addingTimeInterval(ttl), ttl: ttl))
+    }
+
+    @Test func `graph matches standalone dependency graph for packages`() {
+        let packages = [
+            BrewPackage.fixture(name: "openssl@3", kind: .formula, dependencies: []),
+            BrewPackage.fixture(name: "node", kind: .formula, dependencies: [.formula(name: "openssl@3")]),
+        ]
+        let snapshot = InstalledInventorySnapshot(fetchedAt: .now, packages: packages)
+        let standalone = PackageDependencyGraph(packages: packages)
+        let opensslID = packages[0].id
+
+        #expect(snapshot.graph.installedDependents(for: opensslID) == standalone.installedDependents(for: opensslID))
+    }
+}

--- a/BrewTests/InstalledViewModelPresentationTests.swift
+++ b/BrewTests/InstalledViewModelPresentationTests.swift
@@ -25,17 +25,15 @@ private func sectionVisibility(_ vm: InstalledViewModel) -> SectionVisibilitySna
 
 struct InstalledViewModelPresentationTests {
     @Test @MainActor func `selectedPackage is nil for initial loading state`() {
-        let vm = InstalledViewModel(
+        let vm = makeInstalledViewModel(
             repository: StubInstalledPackagesRepository(snapshot: .empty),
-            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
         #expect(vm.selectedPackage == nil)
     }
 
     @Test @MainActor func `shouldShowInitialLoadingIndicator is true when loading with no rows and no error`() {
-        let vm = InstalledViewModel(
+        let vm = makeInstalledViewModel(
             repository: StubInstalledPackagesRepository(snapshot: .empty),
-            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
         #expect(vm.shouldShowInitialLoadingIndicator)
     }
@@ -48,9 +46,8 @@ struct InstalledViewModelPresentationTests {
     }
 
     @Test @MainActor func `shouldShowInitialLoadingIndicator is false when load has user error`() async {
-        let vm = InstalledViewModel(
+        let vm = makeInstalledViewModel(
             repository: FailingInstalledRepository(error: BrewLookupError.executableNotFound),
-            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
         await vm.load()
         #expect(!vm.shouldShowInitialLoadingIndicator)
@@ -85,9 +82,8 @@ struct InstalledViewModelPresentationTests {
     }
 
     @Test @MainActor func `packageCountSubtitle shows localized loading text when initial loading`() {
-        let vm = InstalledViewModel(
+        let vm = makeInstalledViewModel(
             repository: StubInstalledPackagesRepository(snapshot: .empty),
-            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
         let expected = String(localized: "Loading packages…", comment: "Installed tab subtitle while fetching")
         #expect(vm.packageCountSubtitle == expected)
@@ -152,7 +148,7 @@ struct InstalledViewModelPresentationTests {
 private struct FailingInstalledRepository: InstalledPackagesRepository {
     let error: Error
 
-    func loadInstalledPackages() async throws -> [BrewPackage] {
+    func loadInstalledPackages(forceRefresh _: Bool) async throws -> [BrewPackage] {
         throw error
     }
 }

--- a/BrewTests/InstalledViewModelTests.swift
+++ b/BrewTests/InstalledViewModelTests.swift
@@ -57,7 +57,7 @@ struct InstalledViewModelTests {
     @Test @MainActor func `command center running to idle triggers installed refresh`() async {
         let commandCenter = ControllableAllPhasesCommandCenter()
         let repo = CountingInstalledRepository()
-        let vm = InstalledViewModel(
+        let vm = makeInstalledViewModel(
             repository: repo,
             brewCommandCenter: commandCenter,
         )
@@ -75,7 +75,7 @@ struct InstalledViewModelTests {
     @Test @MainActor func `command center running to failed does not trigger installed refresh`() async {
         let commandCenter = ControllableAllPhasesCommandCenter()
         let repo = CountingInstalledRepository()
-        let vm = InstalledViewModel(
+        let vm = makeInstalledViewModel(
             repository: repo,
             brewCommandCenter: commandCenter,
         )
@@ -93,7 +93,7 @@ struct InstalledViewModelTests {
     @Test @MainActor func `multiple running to idle completions trigger multiple refreshes`() async {
         let commandCenter = ControllableAllPhasesCommandCenter()
         let repo = CountingInstalledRepository()
-        let vm = InstalledViewModel(
+        let vm = makeInstalledViewModel(
             repository: repo,
             brewCommandCenter: commandCenter,
         )
@@ -119,7 +119,7 @@ struct InstalledViewModelTests {
             .fixture(name: "wget", kind: .formula, latestVersion: "1.0.0", installedVersions: ["1.0.0"]),
         ]
         let repo = SequentialSnapshotsInstalledRepository(snapshots: [firstSnapshot, secondSnapshot])
-        let vm = InstalledViewModel(
+        let vm = makeInstalledViewModel(
             repository: repo,
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
@@ -141,7 +141,7 @@ struct InstalledViewModelTests {
             .fixture(name: "wget", kind: .formula),
         ]
         let repo = SequentialSnapshotsInstalledRepository(snapshots: [firstSnapshot, secondSnapshot])
-        let vm = InstalledViewModel(
+        let vm = makeInstalledViewModel(
             repository: repo,
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
@@ -156,11 +156,10 @@ struct InstalledViewModelTests {
     }
 
     @Test @MainActor func `load preserves brew stderr in user facing error state`() async {
-        let vm = InstalledViewModel(
+        let vm = makeInstalledViewModel(
             repository: StubThrowingRepository(
                 error: BrewCommandError.failed(exitCode: 1, stderr: "formula conflict"),
             ),
-            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
 
         await vm.load()
@@ -173,9 +172,8 @@ struct InstalledViewModelTests {
     }
 
     @Test @MainActor func `load maps brew lookup failure to missing Homebrew copy`() async {
-        let vm = InstalledViewModel(
+        let vm = makeInstalledViewModel(
             repository: StubThrowingRepository(error: BrewLookupError.executableNotFound),
-            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
 
         await vm.load()
@@ -188,11 +186,10 @@ struct InstalledViewModelTests {
     }
 
     @Test @MainActor func `load maps launch failure to underlying message`() async {
-        let vm = InstalledViewModel(
+        let vm = makeInstalledViewModel(
             repository: StubThrowingRepository(
                 error: BrewCommandError.launchFailed(underlying: "spawn failed"),
             ),
-            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
 
         await vm.load()
@@ -205,9 +202,8 @@ struct InstalledViewModelTests {
     }
 
     @Test @MainActor func `load maps unknown failure to generic load message`() async {
-        let vm = InstalledViewModel(
+        let vm = makeInstalledViewModel(
             repository: StubThrowingRepository(error: OddRepositoryError()),
-            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
 
         await vm.load()
@@ -240,14 +236,15 @@ private func settleAsync() async {
 @MainActor
 private func expectLoadCount(atLeast target: Int, repo: CountingInstalledRepository) async {
     for _ in 0 ..< 200 {
-        if await repo.loadCallCount >= target {
+        if repo.loadCallCount >= target {
             return
         }
         await Task.yield()
     }
 }
 
-private actor CountingInstalledRepository: InstalledPackagesRepository {
+@MainActor
+private final class CountingInstalledRepository: InstalledPackagesRepository {
     private(set) var loadCallCount = 0
     private let packages: [BrewPackage]
 
@@ -255,13 +252,14 @@ private actor CountingInstalledRepository: InstalledPackagesRepository {
         self.packages = packages
     }
 
-    func loadInstalledPackages() async throws -> [BrewPackage] {
+    func loadInstalledPackages(forceRefresh _: Bool) async throws -> [BrewPackage] {
         loadCallCount += 1
         return packages
     }
 }
 
-private actor SequentialSnapshotsInstalledRepository: InstalledPackagesRepository {
+@MainActor
+private final class SequentialSnapshotsInstalledRepository: InstalledPackagesRepository {
     private var snapshots: [[BrewPackage]]
     private var index = 0
 
@@ -269,7 +267,7 @@ private actor SequentialSnapshotsInstalledRepository: InstalledPackagesRepositor
         self.snapshots = snapshots
     }
 
-    func loadInstalledPackages() async throws -> [BrewPackage] {
+    func loadInstalledPackages(forceRefresh _: Bool) async throws -> [BrewPackage] {
         guard !snapshots.isEmpty else {
             return []
         }

--- a/BrewTests/PackageDependencyGraphTests.swift
+++ b/BrewTests/PackageDependencyGraphTests.swift
@@ -1,0 +1,49 @@
+//
+//  PackageDependencyGraphTests.swift
+//  BrewTests
+//
+
+@testable import Brew
+import Testing
+
+struct PackageDependencyGraphTests {
+    @Test func `installedDependents for package id returns sorted dependents`() {
+        let packages = [
+            BrewPackage.fixture(name: "openssl@3", kind: .formula, dependencies: []),
+            BrewPackage.fixture(name: "node", kind: .formula, dependencies: [.formula(name: "openssl@3")]),
+            BrewPackage.fixture(name: "curl", kind: .formula, dependencies: [.formula(name: "openssl@3")]),
+        ]
+        let graph = PackageDependencyGraph(packages: packages)
+        let openssl = packages[0]
+        #expect(graph.installedDependents(for: openssl.id).map(\.name) == ["curl", "node"])
+    }
+
+    @Test func `installedDependents for package id is empty when id is unknown`() {
+        let graph = PackageDependencyGraph(packages: [
+            BrewPackage.fixture(name: "wget", kind: .formula, dependencies: [.formula(name: "zlib")]),
+        ])
+        #expect(graph.installedDependents(for: BrewPackage.ID("unknown")).isEmpty)
+    }
+
+    @Test func `installedDependents for package id is empty when no installed package depends on id`() {
+        let graph = PackageDependencyGraph(packages: [
+            BrewPackage.fixture(name: "wget", kind: .formula, dependencies: [.formula(name: "zlib")]),
+        ])
+        #expect(graph.installedDependents(for: "formula:openssl@3").isEmpty)
+    }
+
+    @Test func `installedDependents distinguishes formula and cask dependency references`() {
+        let packages = [
+            BrewPackage.fixture(name: "shared", kind: .formula, dependencies: []),
+            BrewPackage.fixture(name: "shared", kind: .cask, dependencies: []),
+            BrewPackage.fixture(
+                name: "consumer",
+                kind: .cask,
+                dependencies: [.formula(name: "shared")],
+            ),
+        ]
+        let graph = PackageDependencyGraph(packages: packages)
+        #expect(graph.installedDependents(for: "formula:shared").map(\.name) == ["consumer"])
+        #expect(graph.installedDependents(for: "cask:shared").isEmpty)
+    }
+}

--- a/BrewTests/PackageRelationshipItemTests.swift
+++ b/BrewTests/PackageRelationshipItemTests.swift
@@ -1,0 +1,58 @@
+//
+//  PackageRelationshipItemTests.swift
+//  BrewTests
+//
+
+@testable import Brew
+import Testing
+
+struct PackageRelationshipItemTests {
+    @Test @MainActor func `dependency marks installed reference with package id`() {
+        let reference = HomebrewPackageReference.formula(name: "openssl@3")
+        let item = PackageRelationshipItem.dependency(
+            reference,
+            installedPackageIDs: ["formula:openssl@3"],
+        )
+
+        #expect(item.displayName == "openssl@3")
+        #expect(item.packageKind == .formula)
+        #expect(item.targetPackageID == "formula:openssl@3")
+        #expect(item.installedPackageID == "formula:openssl@3")
+        #expect(item.isInstalledInInventory)
+        #expect(item.id == "formula:openssl@3")
+    }
+
+    @Test @MainActor func `dependency marks missing reference without installed id`() {
+        let reference = HomebrewPackageReference.formula(name: "zlib")
+        let item = PackageRelationshipItem.dependency(
+            reference,
+            installedPackageIDs: ["formula:openssl@3"],
+        )
+
+        #expect(item.installedPackageID == nil)
+        #expect(!item.isInstalledInInventory)
+        #expect(item.id == "relationship:formula:zlib")
+    }
+
+    @Test @MainActor func `dependencies maps each reference`() {
+        let items = PackageRelationshipItem.dependencies(
+            [.formula(name: "openssl@3"), .formula(name: "zlib")],
+            installedPackageIDs: ["formula:openssl@3"],
+        )
+
+        #expect(items.count == 2)
+        #expect(items[0].isInstalledInInventory)
+        #expect(!items[1].isInstalledInInventory)
+    }
+
+    @Test @MainActor func `dependent and dependents always mark installed`() {
+        let package = BrewPackage.fixture(name: "curl", kind: .formula)
+        let dependent = PackageRelationshipItem.dependent(package)
+        let dependents = PackageRelationshipItem.dependents([package])
+
+        #expect(dependent.installedPackageID == package.id)
+        #expect(dependent.isInstalledInInventory)
+        #expect(dependents.count == 1)
+        #expect(dependents[0].id == package.id)
+    }
+}

--- a/BrewTests/TestSupport/BrewPackageFixtures.swift
+++ b/BrewTests/TestSupport/BrewPackageFixtures.swift
@@ -8,7 +8,7 @@ extension BrewPackage {
         homepage: String = "",
         latestVersion: String = "",
         installedVersions: [String] = [],
-        dependencies: [String] = [],
+        dependencies: [HomebrewPackageReference] = [],
         outdated: Bool = false,
     ) -> BrewPackage {
         BrewPackage(

--- a/BrewTests/TestSupport/EmptyInstalledDependentsRepository.swift
+++ b/BrewTests/TestSupport/EmptyInstalledDependentsRepository.swift
@@ -1,0 +1,8 @@
+@testable import Brew
+import Foundation
+
+struct EmptyInstalledDependentsRepository: InstalledDependentsRepository {
+    func installedDependents(for _: BrewPackage.ID) async -> [BrewPackage] {
+        []
+    }
+}

--- a/BrewTests/TestSupport/EmptyInstalledInventoryReading.swift
+++ b/BrewTests/TestSupport/EmptyInstalledInventoryReading.swift
@@ -1,0 +1,8 @@
+@testable import Brew
+import Foundation
+
+struct EmptyInstalledInventoryReading: InstalledInventoryReading {
+    func installedPackageIDs() async -> Set<BrewPackage.ID> {
+        []
+    }
+}

--- a/BrewTests/TestSupport/InstalledFeatureTestSupport.swift
+++ b/BrewTests/TestSupport/InstalledFeatureTestSupport.swift
@@ -7,10 +7,15 @@ enum InstalledFeatureTestSupport {
         formulae: [BrewPackage] = [],
         casks: [BrewPackage] = [],
     ) async -> InstalledViewModel {
+        let cache = InstalledInventoryCache()
+        let snapshot = InstalledInventorySnapshot(fetchedAt: .now, packages: formulae + casks)
+        await cache.replace(snapshot)
+        let repository = InstalledPackagesTestSupport.repository(
+            commandRunner: MockBrewCommandRunner(responses: [:]),
+            cache: cache,
+        )
         let viewModel = InstalledViewModel(
-            repository: StubInstalledPackagesRepository(
-                snapshot: formulae + casks,
-            ),
+            repository: repository,
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
         await viewModel.load()
@@ -21,7 +26,23 @@ enum InstalledFeatureTestSupport {
 struct StubInstalledPackagesRepository: InstalledPackagesRepository {
     let snapshot: [BrewPackage]
 
-    func loadInstalledPackages() async throws -> [BrewPackage] {
+    func loadInstalledPackages(forceRefresh _: Bool) async throws -> [BrewPackage] {
         snapshot
+    }
+}
+
+struct StubInstalledDependentsRepository: InstalledDependentsRepository {
+    let provider: @Sendable (BrewPackage.ID) -> [BrewPackage]
+
+    func installedDependents(for packageID: BrewPackage.ID) async -> [BrewPackage] {
+        provider(packageID)
+    }
+}
+
+struct StubInstalledInventoryReading: InstalledInventoryReading {
+    let installedIDs: Set<BrewPackage.ID>
+
+    func installedPackageIDs() async -> Set<BrewPackage.ID> {
+        installedIDs
     }
 }

--- a/BrewTests/TestSupport/InstalledPackagesRepositoryTestSupport.swift
+++ b/BrewTests/TestSupport/InstalledPackagesRepositoryTestSupport.swift
@@ -58,12 +58,19 @@ enum InstalledPackagesTestSupport {
     static let fakeBrewExecutableURL = URL(fileURLWithPath: "/fake/brew")
 
     /// Wired like production slice tests: default locator is [`fakeBrewExecutableURL`](fakeBrewExecutableURL).
+    @MainActor
     static func repository(
         commandRunner: BrewCommandRunning,
         locator: (any BrewExecutableLocating)? = nil,
+        cache: InstalledInventoryCache? = nil,
     ) -> BrewInstalledPackagesRepository {
+        let resolvedCache = cache ?? InstalledInventoryCache()
         let resolvedLocator = locator ?? BrewExecutableLocator(overrideURL: fakeBrewExecutableURL)
-        return BrewInstalledPackagesRepository(commandRunner: commandRunner, locator: resolvedLocator)
+        return BrewInstalledPackagesRepository(
+            commandRunner: commandRunner,
+            locator: resolvedLocator,
+            cache: resolvedCache,
+        )
     }
 
     // MARK: Localized copy (must match `InstalledViewModel.userMessage`)
@@ -72,13 +79,6 @@ enum InstalledPackagesTestSupport {
         String(
             localized: "Could not find Homebrew. Install it or ensure brew is in the default location.",
             comment: "Installed tab error when brew binary missing",
-        )
-    }
-
-    static func localizedHomebrewCommandFailedMessage() -> String {
-        String(
-            localized: "Homebrew command failed.",
-            comment: "Installed tab error generic brew failure",
         )
     }
 
@@ -112,26 +112,6 @@ enum InstalledPackagesTestSupport {
     ) -> [[String]: CommandOutput] {
         [
             ["info", "--installed", "--json=v2"]: CommandOutput(
-                standardOutput: standardOutput,
-                standardError: standardError,
-                terminationStatus: terminationStatus,
-            ),
-        ]
-    }
-
-    static func packageInfoJSONResponse(
-        kind: InstalledPackageKind,
-        name: String,
-        standardOutput: String,
-        terminationStatus: Int32 = 0,
-        standardError: String = "",
-    ) -> [[String]: CommandOutput] {
-        let kindFlag = switch kind {
-        case .formula: "--formula"
-        case .cask: "--cask"
-        }
-        return [
-            ["info", "--json=v2", kindFlag, name]: CommandOutput(
                 standardOutput: standardOutput,
                 standardError: standardError,
                 terminationStatus: terminationStatus,

--- a/BrewTests/TestSupport/InstalledViewModelTestsSupport.swift
+++ b/BrewTests/TestSupport/InstalledViewModelTestsSupport.swift
@@ -40,13 +40,24 @@ func snapshot(_ vm: InstalledViewModel) -> VMStateSnapshot {
 }
 
 @MainActor
+func makeInstalledViewModel(
+    repository: InstalledPackagesRepository,
+    brewCommandCenter: any BrewCommandCenter = NoopBrewCommandCenter.forTesting(),
+) -> InstalledViewModel {
+    InstalledViewModel(
+        repository: repository,
+        brewCommandCenter: brewCommandCenter,
+    )
+}
+
+@MainActor
 func loadViewModel(
     commandRunner: BrewCommandRunning,
     locator: (any BrewExecutableLocating)? = nil,
 ) async -> InstalledViewModel {
-    let repo = InstalledPackagesTestSupport.repository(commandRunner: commandRunner, locator: locator)
+    let repository = InstalledPackagesTestSupport.repository(commandRunner: commandRunner, locator: locator)
     let vm = InstalledViewModel(
-        repository: repo,
+        repository: repository,
         brewCommandCenter: NoopBrewCommandCenter.forTesting(),
     )
     await vm.load()
@@ -58,7 +69,7 @@ struct OddRepositoryError: Error {}
 struct StubThrowingRepository: InstalledPackagesRepository {
     let error: Error
 
-    func loadInstalledPackages() async throws -> [BrewPackage] {
+    func loadInstalledPackages(forceRefresh _: Bool) async throws -> [BrewPackage] {
         throw error
     }
 }


### PR DESCRIPTION
# PR: Add installed dependency/dependent navigation with inventory cache

## Summary

This PR adds dependency and dependent relationship support to the Installed detail experience, backed by a shared installed-inventory cache. It improves package exploration by letting users see what a package depends on, what depends on it, and jump directly to installed related packages.

## Changes

- Add installed inventory domain and cache primitives:
  - `InstalledInventorySnapshot`
  - `PackageDependencyGraph`
  - `InstalledInventoryCache` + environment wiring via `InstalledInventoryEnvironment`
- Add package relationship model and identity support:
  - `HomebrewPackageReference`
  - `PackageRelationshipItem` for dependency/dependent display rows
  - `BrewPackage.ID` now uses `HomebrewPackageReference`
- Extend repositories to consume the shared inventory cache:
  - `BrewInstalledPackagesRepository` now reads/writes inventory snapshots and graph metadata
  - new `InstalledDependentsRepository` + `BrewInstalledDependentsRepository`
  - new `InstalledInventoryReading` protocol for installed package identity lookups
- Extend Installed detail/list flow for relationship UX:
  - `InstalledDetailsViewModel` now loads dependencies/dependents and supports selecting installed related packages
  - new section components in `InstalledPackageDetailSubviewSections` for “Dependencies” and “Used by”, including collapsed/expanded lists and installed-only navigation affordances
  - `InstalledPackagesView` scroll behavior now follows relationship-driven selection changes so selected rows are brought into view
- Add/refresh tests for new behavior:
  - `HomebrewPackageReferenceTests`
  - `PackageDependencyGraphTests`
  - `PackageRelationshipItemTests`
  - `InstalledInventorySnapshotTests`
  - `BrewInstalledPackagesCacheTests`
  - `BrewInstalledDependentsRepositoryTests`
  - related updates to Installed view-model/repository test support
- Sync docs tooling config with current mainline setup:
  - update `.github/workflows/docs.yml`, `.ruby-version`, `Gemfile`, and `docs/Gemfile.lock`

## Why this split (optional)

This branch is scoped to relationship modeling/navigation and the inventory cache foundation it depends on. It intentionally keeps command-center mutation behavior unchanged and focuses on read-path data flow plus Installed UI presentation.

## Testing

- [ ] Manual: open Installed detail and verify dependency/dependent sections render correctly for formulae and casks.
- [ ] Manual: click an installed related package from detail and confirm list selection and scroll follow the new target.
- [ ] Manual: confirm non-installed relationships are non-navigable and clearly labeled/accessibility-described.

## PR checklist

- [ ] Have you followed this repository's contribution and workflow guidance?
- [ ] Have you explained what changed and why this should land now?
- [ ] Have you run relevant local checks for the changed scope?
- [ ] Are changes scoped and free of unrelated modifications?

-----

- [ ] AI was used to generate or assist with generating this PR.
- [ ] If yes, describe exactly how AI was used and what manual verification was performed.

  **AI use:**   **AI use:** I used Cursor's coding agent throughout this feature to help implement and iterate on the installed-inventory cache, dependency/dependent modeling, repository wiring, and Installed detail/list relationship UI behavior, including test updates and refactors across the branch. I also used it to draft this PR body from `.github/PULL_REQUEST_TEMPLATE.md` and summarize `origin/main...linked-dependents`. Manual verification included reviewing each AI-generated change in the touched files, validating behavior in the app flow (relationship rendering, navigation, and list-follow selection), and running the listed lint/test commands before opening the PR.

-----

## Follow-ups

- Consider extracting relationship list/selection patterns if a future Updates/Discover detail surface needs the same interaction model.