### PR TITLE
Uninstall package

### DIFF
--- a/.ai/memory.md
+++ b/.ai/memory.md
@@ -243,6 +243,11 @@
 - Keep the Installed list mounted under a stable parent container (`HSplitView`) across selection changes; switching between list-only and split layouts can remount the list and reset scroll position.
 - Prefer native `List(selection:)` for Installed row selection state, with view-model-backed selection binding (`setSelection(_:)`) and row tags by stable package id.
 
+## 2026-05-11 — Installed detail uninstall actions
+
+- Installed detail mutations now support both **upgrade** and **uninstall** through the shared `BrewCommandCenter` pipeline; uninstall uses `PackageUninstallCommand` with new `BrewOperationKind` cases (`uninstallFormula`, `uninstallCask`).
+- `InstalledPackageDetailView` now treats the footer as a general package-actions area: show upgrade chrome only when `package.outdated`, but always show uninstall chrome with a native confirmation dialog and copyable user-facing `brew uninstall ...` command.
+
 ## 2026-05-13 — Vale docs job and `docs/Gemfile`
 
 - **Symptom:** `vale docs/` fails with `lstat docs/../Gemfile: no such file or directory` when `docs/Gemfile` is missing.
@@ -266,3 +271,8 @@
 - Removed dead installed-inventory API surface from app target: `InstalledInventoryCache.packages()`, `InstalledInventoryReading.installedPackages(for:)`, `BrewInstalledPackagesRepository.installedPackages(for:)`, and `BrewPackage.reference`.
 - Moved test-only empty inventory/dependents stubs out of `Brew/Repositories` into `BrewTests/TestSupport` (`EmptyInstalledInventoryReading`, `EmptyInstalledDependentsRepository`) so production DI paths remain explicit.
 - Pruned unused test support helpers `localizedHomebrewCommandFailedMessage()` and `packageInfoJSONResponse(...)` from `InstalledPackagesRepositoryTestSupport`.
+
+## 2026-05-16 — Domain/presentation mapping boundary
+
+- Installed uninstall presentation mapping now uses a feature-layer `UninstallPackageItem` initialized from `BrewPackage`, instead of adding uninstall UI properties directly on `BrewPackage`.
+- Team convention clarified: domain model types stay presentation-agnostic; map to UI properties through feature ViewModels (top-level surfaces) or feature `*Item` types (subview/action presentation).

--- a/.ai/memory.md
+++ b/.ai/memory.md
@@ -276,3 +276,8 @@
 
 - Installed uninstall presentation mapping now uses a feature-layer `UninstallPackageItem` initialized from `BrewPackage`, instead of adding uninstall UI properties directly on `BrewPackage`.
 - Team convention clarified: domain model types stay presentation-agnostic; map to UI properties through feature ViewModels (top-level surfaces) or feature `*Item` types (subview/action presentation).
+
+## 2026-05-17 — Passive view enforcement for presentation state
+
+- Strengthened `CONVENTIONS.md` and `.cursor/rules/swift-implementation.mdc` with an explicit MVVM guardrail: views must not compose multiple ViewModel state primitives inline to derive a single presentation decision.
+- Preferred pattern: expose one derived ViewModel property per UI concern (for example one spinner-driving busy flag), and have the view bind directly to it.

--- a/.cursor/rules/swift-implementation.mdc
+++ b/.cursor/rules/swift-implementation.mdc
@@ -9,3 +9,4 @@ alwaysApply: false
 - Include required imports and provide compilable code updates.
 - Use `@MainActor` where UI state is mutated.
 - Avoid force unwraps/`try!`; use safe handling patterns and test helpers (`#require`, `XCTUnwrap`) in tests.
+- Keep SwiftUI views passive: do not combine multiple ViewModel flags inline to drive one UI presentation decision. Add a single derived ViewModel property (or item) and bind the view to that.

--- a/.cursor/rules/temporal-cohesion.mdc
+++ b/.cursor/rules/temporal-cohesion.mdc
@@ -1,0 +1,46 @@
+---
+description: Wrap temporally cohesive calls — things that always need to happen together — into a single named function.
+alwaysApply: false
+---
+
+# Temporal Cohesion: Wrap Co-Occurring Calls
+
+When two or more calls always appear together at every call site, extract them into a single named function. This applies everywhere: ViewModels, actors, services, repositories, test helpers — sync or async, same type or across types.
+
+**Why:** Repeated call sequences are brittle. Any new call site can silently omit one half. The composed name also communicates intent ("refresh relationships") rather than mechanism ("refresh dependencies, then dependents").
+
+**Rule:**
+
+- If `foo()` + `bar()` appear together at two or more call sites with no intervening logic that varies between sites, extract a function that calls both and replace every call site with it.
+- Name the function after the **shared intent**, not after the individual operations (e.g. `refreshRelationships()`, not `refreshDependenciesAndDependents()`).
+- Make the individual functions `private` where they have no independent callers — they become implementation details of the composed function. See `test-visibility.mdc` for the testing corollary.
+- Do **not** collapse calls whose co-occurrence is coincidental or that carry genuinely distinct purposes at each call site. Only group when the pair represents a single coherent operation from the caller's point of view.
+
+**Examples:**
+
+```swift
+// Before — async ViewModel
+await viewModel.refreshDependencies()
+await viewModel.refreshDependents()
+
+// After
+await viewModel.refreshRelationships()
+```
+
+```swift
+// Before — sync setup
+cache.invalidate()
+cache.preload()
+
+// After
+cache.reset()
+```
+
+```swift
+// Before — actor coordination
+await center.submit(id: id, command: command)
+await logger.record(id: id)
+
+// After — composed on the coordinating type
+await coordinator.submitAndRecord(id: id, command: command)
+```

--- a/.cursor/rules/test-visibility.mdc
+++ b/.cursor/rules/test-visibility.mdc
@@ -1,0 +1,38 @@
+---
+description: Never widen symbol visibility just to enable test access.
+alwaysApply: false
+---
+
+# Do Not Expose Symbols for Test Access
+
+Never widen the visibility of a method, property, computed var, or type beyond what production code requires just to make it reachable from a test target.
+
+**Why:** Leaking implementation details as `internal` (or wider) under test pressure pollutes the API surface and makes future refactoring harder. Tests should exercise behaviour through the same entry points callers actually use.
+
+**Rule:**
+
+- If a symbol would naturally be `private` but a test wants to call it, **do not make it `internal`**. Instead, update the test to go through the public/internal method that composes it (the same surface production callers use).
+- If no such composed entry point exists yet, **create one** (following the temporal cohesion rule where applicable), then test through that.
+- The one permitted exception is **`init`**: initialisers may be given wider visibility than strictly needed so tests can construct types in isolation. This is standard practice and does not leak behaviour.
+
+**Example (wrong):**
+
+```swift
+// Made internal only so tests can call it — wrong
+func refreshDependencies() async { … }
+func refreshDependents() async { … }
+```
+
+**Example (correct):**
+
+```swift
+// Private implementation details
+private func refreshDependencies() async { … }
+private func refreshDependents() async { … }
+
+// Tests call the composed public entry point instead
+func refreshRelationships() async {
+    await refreshDependencies()
+    await refreshDependents()
+}
+```

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -43,6 +43,7 @@ Guiding patterns:
 - **Views:** SwiftUI; thin — bind state, forward actions. Shared pieces in `Views/`.
 - **Feature root views (`*Root`):** Composition boundaries that bridge app-level dependencies into feature content. Root wrappers read environment-level dependencies and construct/inject content-view dependencies while managing view-model lifecycle boundaries.
 - **ViewModels:** Presentation state and mapping; delegate work downward. Keep domain rules in Interactors or Models, not here.
+- **Presentation boundary:** Domain models remain UI-agnostic. Map domain values to UI-ready properties through feature ViewModels for top-level surfaces, or dedicated feature Item types for subview/action-level presentation needs.
 - **Repositories:** CRUD-shaped access to a **data source** (CLI output, API, storage, in-memory). Swap the implementation, keep the contract.
 - **Interactors:** One **use case** each — not generic CRUD (e.g. doctor run, config snapshot). Prefer protocols + real/mock impls for tests.
 - **Services:** Infrastructure — e.g. `BrewCommandService` (subprocess, streaming, cancellation), `JSONAPIService` (fetch/decode).

--- a/Brew/Features/Installed/InstalledDetailsViewModel.swift
+++ b/Brew/Features/Installed/InstalledDetailsViewModel.swift
@@ -179,6 +179,7 @@ final class InstalledDetailsViewModel {
             return
         }
         package = newPackage
+        operationPhase = .idle
         dependencyRelationships = []
         dependentRelationships = []
         showUninstallConfirmation = false
@@ -218,7 +219,10 @@ final class InstalledDetailsViewModel {
                 newPhase: phase,
                 isPackageOutdated: package.outdated,
             )
-            isUninstalling = phase.isRunningUninstall
+            isUninstalling = InstalledUninstallBusyPresentation.showsUninstallBusy(
+                oldPhase: oldPhase,
+                newPhase: phase,
+            )
             isMutatingPackage = isUpgrading || isUninstalling
             if isUninstalling {
                 showUninstallBlockedCallout = false
@@ -302,17 +306,6 @@ private enum PackageMutationAction {
                 localized: "Something went wrong while uninstalling this package.",
                 comment: "Installed detail generic uninstall error",
             )
-        }
-    }
-}
-
-private extension BrewOperationPhase {
-    var isRunningUninstall: Bool {
-        switch self {
-        case .running(.uninstallFormula), .running(.uninstallCask):
-            true
-        default:
-            false
         }
     }
 }

--- a/Brew/Features/Installed/InstalledDetailsViewModel.swift
+++ b/Brew/Features/Installed/InstalledDetailsViewModel.swift
@@ -77,13 +77,34 @@ final class InstalledDetailsViewModel {
         uninstallItem.confirmationMessage
     }
 
+    /// True when installed dependents prevent uninstalling this package alone.
+    var isUninstallBlockedByDependents: Bool {
+        uninstallItem.isBlockedByDependents
+    }
+
+    var uninstallBlockingDependentCount: Int {
+        dependentRelationships.count
+    }
+
+    var usedByBlockingBadgeTitle: String? {
+        uninstallItem.usedByBlockingBadgeTitle
+    }
+
+    var uninstallBlockedBannerLead: String? {
+        uninstallItem.uninstallBlockedBannerLead
+    }
+
+    var uninstallBlockedBannerBody: String? {
+        uninstallItem.uninstallBlockedBannerBody
+    }
+
     /// Valid homepage URL for display, if available.
     var homepageURL: URL? {
         package.homepageURL
     }
 
     private var uninstallItem: UninstallPackageItem {
-        UninstallPackageItem(package: package)
+        UninstallPackageItem(package: package, blockingDependentCount: dependentRelationships.count)
     }
 
     init(

--- a/Brew/Features/Installed/InstalledDetailsViewModel.swift
+++ b/Brew/Features/Installed/InstalledDetailsViewModel.swift
@@ -71,12 +71,18 @@ final class InstalledDetailsViewModel {
         self.installedInventoryReading = installedInventoryReading
     }
 
-    func refreshDependents() async {
+    /// Refreshes both dependency and dependent relationships for the current package.
+    func refreshRelationships() async {
+        await refreshDependencies()
+        await refreshDependents()
+    }
+
+    private func refreshDependents() async {
         let dependents = await installedDependentsRepository.installedDependents(for: package.id)
         dependentRelationships = PackageRelationshipItem.dependents(dependents)
     }
 
-    func refreshDependencies() async {
+    private func refreshDependencies() async {
         let installedPackageIDs = await installedInventoryReading.installedPackageIDs()
         dependencyRelationships = PackageRelationshipItem.dependencies(
             package.dependencies,

--- a/Brew/Features/Installed/InstalledDetailsViewModel.swift
+++ b/Brew/Features/Installed/InstalledDetailsViewModel.swift
@@ -29,6 +29,11 @@ final class InstalledDetailsViewModel {
     /// Disables both mutation affordances while a package mutation is in progress.
     private(set) var isMutatingPackage: Bool = false
 
+    /// Drives the uninstall confirmation dialog.
+    var showUninstallConfirmation: Bool = false
+    /// Drives the uninstall-blocked explanation callout.
+    var showUninstallBlockedCallout: Bool = false
+
     var packageName: String {
         package.name
     }
@@ -98,6 +103,33 @@ final class InstalledDetailsViewModel {
         uninstallItem.uninstallBlockedBannerBody
     }
 
+    /// Muted, reduced-opacity uninstall button styling while blocked and not actively uninstalling.
+    var showsUninstallBlockedPrimaryButtonChrome: Bool {
+        isUninstallBlockedByDependents && !isUninstalling
+    }
+
+    /// What the primary uninstall control should do when activated.
+    var uninstallPrimaryButtonAction: UninstallPrimaryButtonAction {
+        isUninstallBlockedByDependents ? .revealBlockedExplanation : .presentConfirmation
+    }
+
+    func handleUninstallPrimaryButtonTapped() {
+        switch uninstallPrimaryButtonAction {
+        case .presentConfirmation:
+            showUninstallConfirmation = true
+        case .revealBlockedExplanation:
+            showUninstallBlockedCallout = true
+        }
+    }
+
+    var uninstallPrimaryButtonAccessibilityHint: String? {
+        uninstallItem.blockedPrimaryButtonAccessibilityHint
+    }
+
+    var uninstallBlockedCalloutContent: UninstallBlockedCalloutContent? {
+        uninstallItem.blockedCalloutContent
+    }
+
     /// Valid homepage URL for display, if available.
     var homepageURL: URL? {
         package.homepageURL
@@ -128,6 +160,9 @@ final class InstalledDetailsViewModel {
     private func refreshDependents() async {
         let dependents = await installedDependentsRepository.installedDependents(for: package.id)
         dependentRelationships = PackageRelationshipItem.dependents(dependents)
+        if !isUninstallBlockedByDependents {
+            showUninstallBlockedCallout = false
+        }
     }
 
     private func refreshDependencies() async {
@@ -146,6 +181,8 @@ final class InstalledDetailsViewModel {
         package = newPackage
         dependencyRelationships = []
         dependentRelationships = []
+        showUninstallConfirmation = false
+        showUninstallBlockedCallout = false
         clearMutationErrors()
     }
 
@@ -183,6 +220,9 @@ final class InstalledDetailsViewModel {
             )
             isUninstalling = phase.isRunningUninstall
             isMutatingPackage = isUpgrading || isUninstalling
+            if isUninstalling {
+                showUninstallBlockedCallout = false
+            }
         }
     }
 

--- a/Brew/Features/Installed/InstalledDetailsViewModel.swift
+++ b/Brew/Features/Installed/InstalledDetailsViewModel.swift
@@ -12,16 +12,22 @@ final class InstalledDetailsViewModel {
     private let brewCommandCenter: any BrewCommandCenter
     private let installedDependentsRepository: any InstalledDependentsRepository
     private let installedInventoryReading: any InstalledInventoryReading
-    private var upgradeTask: Task<Void, Never>?
+    private var mutationTask: Task<Void, Never>?
 
     private(set) var package: BrewPackage
-    /// Latest phase from the command center stream (see ``observeRowUpdates()``); drives ``isUpgrading`` only.
-    private var upgradeOperationPhase: BrewOperationPhase = .idle
+    /// Latest phase from the command center stream (see ``observeRowUpdates()``); drives mutation chrome.
+    private var operationPhase: BrewOperationPhase = .idle
     /// Inline message when upgrade fails; cleared when a new upgrade starts.
     private(set) var upgradeErrorMessage: String?
+    /// Inline message when uninstall fails; cleared when a new uninstall starts.
+    private(set) var uninstallErrorMessage: String?
 
     /// True while upgrade work is in flight (`CONVENTIONS.md` — transparency / guardrails).
     private(set) var isUpgrading: Bool = false
+    /// True while uninstall work is in flight.
+    private(set) var isUninstalling: Bool = false
+    /// Disables both mutation affordances while a package mutation is in progress.
+    private(set) var isMutatingPackage: Bool = false
 
     var packageName: String {
         package.name
@@ -45,6 +51,11 @@ final class InstalledDetailsViewModel {
         package.upgradeCommand
     }
 
+    /// Copyable Terminal command for uninstalling this package (`CONVENTIONS.md` — transparency).
+    var uninstallDisplayCommand: String {
+        uninstallItem.displayCommand
+    }
+
     /// Shown beside the upgrade affordance whenever the package is outdated.
     var showsUpgradeChrome: Bool {
         package.outdated
@@ -54,9 +65,25 @@ final class InstalledDetailsViewModel {
         package.upgradeButtonTitle
     }
 
+    var uninstallPrimaryButtonTitle: String {
+        uninstallItem.primaryButtonTitle
+    }
+
+    var uninstallConfirmationTitle: String {
+        uninstallItem.confirmationTitle
+    }
+
+    var uninstallConfirmationMessage: String {
+        uninstallItem.confirmationMessage
+    }
+
     /// Valid homepage URL for display, if available.
     var homepageURL: URL? {
         package.homepageURL
+    }
+
+    private var uninstallItem: UninstallPackageItem {
+        UninstallPackageItem(package: package)
     }
 
     init(
@@ -98,31 +125,27 @@ final class InstalledDetailsViewModel {
         package = newPackage
         dependencyRelationships = []
         dependentRelationships = []
-        upgradeErrorMessage = nil
+        clearMutationErrors()
     }
 
     func upgradeSelectedPackage() {
-        guard !isUpgrading else {
-            return
-        }
-
-        upgradeErrorMessage = nil
         let operationID = BrewOperationID(kind: package.kind, name: package.name)
         let command = PackageUpgradeCommand(kind: package.kind, name: package.name)
+        submitMutation(
+            action: .upgrade,
+            operationID: operationID,
+            command: command,
+        )
+    }
 
-        upgradeTask?.cancel()
-        upgradeTask = Task { @MainActor [self] in
-            do {
-                try await brewCommandCenter.submit(id: operationID, command: command)
-            } catch {
-                let latestPhase = await brewCommandCenter.phase(for: operationID)
-                if case let .failed(reason: failure) = latestPhase {
-                    upgradeErrorMessage = failure.userFacingMessage
-                } else {
-                    upgradeErrorMessage = Self.userMessage(for: error)
-                }
-            }
-        }
+    func uninstallSelectedPackage() {
+        let operationID = BrewOperationID(kind: package.kind, name: package.name)
+        let command = PackageUninstallCommand(kind: package.kind, name: package.name)
+        submitMutation(
+            action: .uninstall,
+            operationID: operationID,
+            command: command,
+        )
     }
 
     /// Run while the installed detail column shows this ``package/id`` (`InstalledListRowView` pattern).
@@ -130,17 +153,58 @@ final class InstalledDetailsViewModel {
         let operationID = BrewOperationID(package: package)
         let stream = await brewCommandCenter.phaseChanges(for: operationID)
         for await phase in stream {
-            let oldPhase = upgradeOperationPhase
-            upgradeOperationPhase = phase
+            let oldPhase = operationPhase
+            operationPhase = phase
             isUpgrading = InstalledUpgradeBusyPresentation.showsUpgradeBusy(
                 oldPhase: oldPhase,
                 newPhase: phase,
                 isPackageOutdated: package.outdated,
             )
+            isUninstalling = phase.isRunningUninstall
+            isMutatingPackage = isUpgrading || isUninstalling
         }
     }
 
-    private static func userMessage(for error: Error) -> String {
+    private func submitMutation(
+        action: PackageMutationAction,
+        operationID: BrewOperationID,
+        command: any BrewMutatingCommand,
+    ) {
+        guard !isMutatingPackage else {
+            return
+        }
+
+        clearMutationErrors()
+        mutationTask?.cancel()
+        mutationTask = Task { @MainActor [self] in
+            do {
+                try await brewCommandCenter.submit(id: operationID, command: command)
+            } catch {
+                let latestPhase = await brewCommandCenter.phase(for: operationID)
+                if case let .failed(reason: failure) = latestPhase {
+                    setErrorMessage(failure.userFacingMessage, for: action)
+                } else {
+                    setErrorMessage(Self.userMessage(for: error, fallback: action.genericFailureMessage), for: action)
+                }
+            }
+        }
+    }
+
+    private func clearMutationErrors() {
+        upgradeErrorMessage = nil
+        uninstallErrorMessage = nil
+    }
+
+    private func setErrorMessage(_ message: String, for action: PackageMutationAction) {
+        switch action {
+        case .upgrade:
+            upgradeErrorMessage = message
+        case .uninstall:
+            uninstallErrorMessage = message
+        }
+    }
+
+    private static func userMessage(for error: Error, fallback: String) -> String {
         switch error {
         case BrewLookupError.executableNotFound:
             return String(
@@ -156,10 +220,38 @@ final class InstalledDetailsViewModel {
         case let BrewCommandError.launchFailed(underlying):
             return underlying
         default:
-            return String(
+            return fallback
+        }
+    }
+}
+
+private enum PackageMutationAction {
+    case upgrade
+    case uninstall
+
+    var genericFailureMessage: String {
+        switch self {
+        case .upgrade:
+            String(
                 localized: "Something went wrong while upgrading this package.",
                 comment: "Installed detail generic upgrade error",
             )
+        case .uninstall:
+            String(
+                localized: "Something went wrong while uninstalling this package.",
+                comment: "Installed detail generic uninstall error",
+            )
+        }
+    }
+}
+
+private extension BrewOperationPhase {
+    var isRunningUninstall: Bool {
+        switch self {
+        case .running(.uninstallFormula), .running(.uninstallCask):
+            true
+        default:
+            false
         }
     }
 }

--- a/Brew/Features/Installed/InstalledListRowView.swift
+++ b/Brew/Features/Installed/InstalledListRowView.swift
@@ -61,7 +61,7 @@ struct InstalledListRowView: View {
         }
         .padding(.vertical, BrewSpacing.sm)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel(listAccessibilityLabel(viewModel: viewModel))
+        .accessibilityLabel(viewModel.rowAccessibilityLabel)
     }
 
     private func iconBadge(viewModel: InstalledListRowViewModel) -> some View {
@@ -82,7 +82,7 @@ struct InstalledListRowView: View {
                 .font(.brewBody)
                 .foregroundStyle(Color.brewTextPrimary)
 
-            if viewModel.showsUpgradeBusy {
+            if viewModel.showsOperationBusy {
                 ProgressView()
                     .controlSize(.small)
                     .accessibilityHidden(true)
@@ -117,14 +117,6 @@ struct InstalledListRowView: View {
 
     private func statusIconColor(viewModel: InstalledListRowViewModel) -> Color {
         viewModel.showsUpdateAvailable ? .brewStatusWarning : .brewStatusSuccess
-    }
-
-    private func listAccessibilityLabel(viewModel: InstalledListRowViewModel) -> String {
-        if viewModel.showsUpgradeBusy {
-            let upgrading = String(localized: "Upgrading", comment: "VoiceOver: package upgrading")
-            return "\(viewModel.accessibilitySummary), \(upgrading)"
-        }
-        return viewModel.accessibilitySummary
     }
 
     @ViewBuilder

--- a/Brew/Features/Installed/InstalledListRowViewModel.swift
+++ b/Brew/Features/Installed/InstalledListRowViewModel.swift
@@ -15,8 +15,9 @@ enum RowVersionPresentation: Equatable {
 @MainActor
 final class InstalledListRowViewModel {
     private(set) var package: BrewPackage
-    private var upgradeOperationPhase: BrewOperationPhase = .idle
+    private var operationPhase: BrewOperationPhase = .idle
     private(set) var showsUpgradeBusy: Bool = false
+    private(set) var showsUninstallBusy: Bool = false
     private let brewCommandCenter: BrewCommandCenter
 
     var id: String {
@@ -75,6 +76,24 @@ final class InstalledListRowViewModel {
         return parts.joined(separator: ", ")
     }
 
+    /// Single busy presentation state for row chrome.
+    var showsOperationBusy: Bool {
+        showsUpgradeBusy || showsUninstallBusy
+    }
+
+    /// Full VoiceOver summary, including transient mutation state when present.
+    var rowAccessibilityLabel: String {
+        if showsUpgradeBusy {
+            let upgrading = String(localized: "Upgrading", comment: "VoiceOver: package upgrading")
+            return "\(accessibilitySummary), \(upgrading)"
+        }
+        if showsUninstallBusy {
+            let uninstalling = String(localized: "Uninstalling", comment: "VoiceOver: package uninstalling")
+            return "\(accessibilitySummary), \(uninstalling)"
+        }
+        return accessibilitySummary
+    }
+
     init(package: BrewPackage, brewCommandCenter: BrewCommandCenter) {
         self.package = package
         self.brewCommandCenter = brewCommandCenter
@@ -85,19 +104,25 @@ final class InstalledListRowViewModel {
             return
         }
         package = newPackage
+        operationPhase = .idle
         showsUpgradeBusy = false
+        showsUninstallBusy = false
     }
 
     func observeRowUpdates() async {
         let operationID = BrewOperationID(package: package)
         let stream = await brewCommandCenter.phaseChanges(for: operationID)
         for await phase in stream {
-            let oldPhase = upgradeOperationPhase
-            upgradeOperationPhase = phase
+            let oldPhase = operationPhase
+            operationPhase = phase
             showsUpgradeBusy = InstalledUpgradeBusyPresentation.showsUpgradeBusy(
                 oldPhase: oldPhase,
                 newPhase: phase,
                 isPackageOutdated: package.outdated,
+            )
+            showsUninstallBusy = InstalledUninstallBusyPresentation.showsUninstallBusy(
+                oldPhase: oldPhase,
+                newPhase: phase,
             )
         }
     }

--- a/Brew/Features/Installed/InstalledPackageDetailSubviewSections.swift
+++ b/Brew/Features/Installed/InstalledPackageDetailSubviewSections.swift
@@ -149,7 +149,7 @@ struct InstalledPackageDetailUsedBySection: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: BrewSpacing.sm) {
-            InstalledPackageDetailSectionHeading(title: "Used by")
+            usedByHeading
             if viewModel.dependentRelationships.isEmpty {
                 Text("No installed packages use this package.")
                     .font(.brewCallout)
@@ -164,24 +164,44 @@ struct InstalledPackageDetailUsedBySection: View {
                     collapsedRelationshipCount: collapsedRelationshipCount,
                     onSelectInstalledPackage: onSelectInstalledPackage,
                 )
-                if !viewModel.dependentRelationships.isEmpty {
-                    usedByCallout
-                }
             }
         }
     }
 
-    private var usedByCallout: some View {
+    private var usedByHeading: some View {
+        HStack(spacing: BrewSpacing.sm) {
+            InstalledPackageDetailSectionHeading(title: "Used by")
+            if let badgeTitle = viewModel.usedByBlockingBadgeTitle {
+                Text(badgeTitle)
+                    .font(.brewCaption2.weight(.semibold))
+                    .foregroundStyle(Color.brewStatusWarning)
+                    .padding(.horizontal, BrewSpacing.xs)
+                    .padding(.vertical, BrewSpacing.xxs)
+                    .background(Color.brewStatusWarningSubtle)
+                    .clipShape(RoundedRectangle(cornerRadius: BrewRadius.sm))
+            }
+        }
+    }
+}
+
+struct UninstallBlockedCallout: View {
+    let lead: String
+    let bodyText: String
+
+    var body: some View {
         HStack(alignment: .top, spacing: BrewSpacing.sm) {
             Image(systemName: "exclamationmark.triangle.fill")
                 .font(.brewSubheadline)
-                .foregroundStyle(Color.brewBrandPrimary)
-            Text("Other installed packages depend on this. Removing it may break them.")
-                .font(.brewCallout)
-                .foregroundStyle(Color.brewTextPrimary)
+                .foregroundStyle(Color.brewStatusWarning)
+            (
+                Text(lead).fontWeight(.semibold)
+                    + Text(" \(bodyText)"),
+            )
+            .font(.brewCallout)
+            .foregroundStyle(Color.brewTextPrimary)
         }
         .padding(BrewSpacing.sm)
-        .background(Color.brewBrandTint)
+        .background(Color.brewStatusWarningSubtle)
         .clipShape(RoundedRectangle(cornerRadius: BrewRadius.md))
     }
 }

--- a/Brew/Features/Installed/InstalledPackageDetailSubviewSections.swift
+++ b/Brew/Features/Installed/InstalledPackageDetailSubviewSections.swift
@@ -289,64 +289,6 @@ struct InstalledPackageDetailRelationshipList: View {
     }
 }
 
-struct InstalledPackageDetailInfoCommandSection: View {
-    let title: String
-    let command: String
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: BrewSpacing.sm) {
-            InstalledPackageDetailSectionHeading(title: title)
-            commandConsole
-        }
-    }
-
-    private var commandConsole: some View {
-        VStack(spacing: 0) {
-            HStack {
-                Label("Terminal command", systemImage: "terminal")
-                    .font(.brewCaption)
-                    .foregroundStyle(Color.brewTextSecondary)
-                Spacer()
-                Button("Copy", systemImage: "doc.on.doc") {
-                    copyCommandToPasteboard(command)
-                }
-                .font(.brewCaption)
-                .foregroundStyle(Color.brewTextSecondary)
-                .buttonStyle(.plain)
-            }
-            .padding(.horizontal, BrewSpacing.md)
-            .padding(.vertical, BrewSpacing.sm)
-            .background(Color.brewSurfaceRecessed)
-
-            Text(command)
-                .font(.brewCode)
-                .foregroundStyle(Color.brewCodeDefault)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(BrewSpacing.md)
-                .background(Color.brewTerminal)
-                .textSelection(.enabled)
-
-            Text("Shows detailed information about this package")
-                .font(.brewCaption)
-                .foregroundStyle(Color.brewTextTertiary)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, BrewSpacing.md)
-                .padding(.vertical, BrewSpacing.sm)
-                .background(Color.brewSurfaceRecessed)
-        }
-        .clipShape(RoundedRectangle(cornerRadius: BrewRadius.md))
-        .overlay(
-            RoundedRectangle(cornerRadius: BrewRadius.md)
-                .stroke(Color.brewBorderDefault, lineWidth: 1),
-        )
-    }
-
-    private func copyCommandToPasteboard(_ command: String) {
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(command, forType: .string)
-    }
-}
-
 enum PackageRelationshipDotStyle {
     case neutral
     case warning

--- a/Brew/Features/Installed/InstalledPackageDetailView.swift
+++ b/Brew/Features/Installed/InstalledPackageDetailView.swift
@@ -150,11 +150,16 @@ private struct InstalledPackageDetailUninstallChrome: View {
                             .controlSize(.small)
                             .frame(minWidth: 120)
                     } else {
-                        Text(viewModel.uninstallPrimaryButtonTitle).foregroundStyle(Color.brewTextSecondary)
+                        Text(viewModel.uninstallPrimaryButtonTitle)
+                            .foregroundStyle(
+                                viewModel.isUninstallBlockedByDependents
+                                    ? Color.brewTextTertiary
+                                    : Color.brewTextSecondary,
+                            )
                     }
                 }
                 .buttonStyle(.bordered)
-                .disabled(viewModel.isMutatingPackage)
+                .disabled(viewModel.isMutatingPackage || viewModel.isUninstallBlockedByDependents)
                 .accessibilityLabel(viewModel.uninstallPrimaryButtonTitle)
                 .confirmationDialog(
                     viewModel.uninstallConfirmationTitle,
@@ -166,6 +171,12 @@ private struct InstalledPackageDetailUninstallChrome: View {
                     Button("Cancel", role: .cancel) {}
                 } message: {
                     Text(viewModel.uninstallConfirmationMessage)
+                }
+
+                if let lead = viewModel.uninstallBlockedBannerLead,
+                   let body = viewModel.uninstallBlockedBannerBody
+                {
+                    UninstallBlockedCallout(lead: lead, bodyText: body)
                 }
 
                 if let uninstallError = viewModel.uninstallErrorMessage {

--- a/Brew/Features/Installed/InstalledPackageDetailView.swift
+++ b/Brew/Features/Installed/InstalledPackageDetailView.swift
@@ -31,7 +31,6 @@ struct InstalledPackageDetailView: View {
     @State private var viewModel: InstalledDetailsViewModel
     @State private var expandedDependencies = false
     @State private var expandedDependents = false
-    @State private var showUninstallConfirmation = false
 
     private let collapsedRelationshipCount = 3
 
@@ -67,7 +66,6 @@ struct InstalledPackageDetailView: View {
             viewModel.update(package: newPackage)
             expandedDependencies = false
             expandedDependents = false
-            showUninstallConfirmation = false
             Task {
                 await viewModel.refreshRelationships()
             }
@@ -94,10 +92,7 @@ struct InstalledPackageDetailView: View {
                 InstalledPackageDetailUpgradeChrome(viewModel: viewModel)
                 InstalledPackageDetailSectionDivider()
             }
-            InstalledPackageDetailUninstallChrome(
-                viewModel: viewModel,
-                showConfirmation: $showUninstallConfirmation,
-            )
+            InstalledPackageDetailUninstallChrome(viewModel: viewModel)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -128,7 +123,6 @@ struct InstalledPackageDetailView: View {
 /// Uninstall affordance and copyable `brew uninstall` command (`CONVENTIONS.md` — transparency).
 private struct InstalledPackageDetailUninstallChrome: View {
     @Bindable var viewModel: InstalledDetailsViewModel
-    @Binding var showConfirmation: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: BrewSpacing.sm) {
@@ -143,7 +137,7 @@ private struct InstalledPackageDetailUninstallChrome: View {
                 )
 
                 Button {
-                    showConfirmation = true
+                    viewModel.handleUninstallPrimaryButtonTapped()
                 } label: {
                     if viewModel.isUninstalling {
                         ProgressView()
@@ -152,18 +146,20 @@ private struct InstalledPackageDetailUninstallChrome: View {
                     } else {
                         Text(viewModel.uninstallPrimaryButtonTitle)
                             .foregroundStyle(
-                                viewModel.isUninstallBlockedByDependents
+                                viewModel.showsUninstallBlockedPrimaryButtonChrome
                                     ? Color.brewTextTertiary
                                     : Color.brewTextSecondary,
                             )
                     }
                 }
                 .buttonStyle(.bordered)
-                .disabled(viewModel.isMutatingPackage || viewModel.isUninstallBlockedByDependents)
+                .opacity(viewModel.showsUninstallBlockedPrimaryButtonChrome ? 0.65 : 1)
+                .disabled(viewModel.isMutatingPackage)
                 .accessibilityLabel(viewModel.uninstallPrimaryButtonTitle)
+                .accessibilityHint(viewModel.uninstallPrimaryButtonAccessibilityHint ?? "")
                 .confirmationDialog(
                     viewModel.uninstallConfirmationTitle,
-                    isPresented: $showConfirmation,
+                    isPresented: $viewModel.showUninstallConfirmation,
                 ) {
                     Button(viewModel.uninstallPrimaryButtonTitle, role: .destructive) {
                         viewModel.uninstallSelectedPackage()
@@ -173,10 +169,10 @@ private struct InstalledPackageDetailUninstallChrome: View {
                     Text(viewModel.uninstallConfirmationMessage)
                 }
 
-                if let lead = viewModel.uninstallBlockedBannerLead,
-                   let body = viewModel.uninstallBlockedBannerBody
+                if viewModel.showUninstallBlockedCallout,
+                   let callout = viewModel.uninstallBlockedCalloutContent
                 {
-                    UninstallBlockedCallout(lead: lead, bodyText: body)
+                    UninstallBlockedCallout(lead: callout.lead, bodyText: callout.body)
                 }
 
                 if let uninstallError = viewModel.uninstallErrorMessage {

--- a/Brew/Features/Installed/InstalledPackageDetailView.swift
+++ b/Brew/Features/Installed/InstalledPackageDetailView.swift
@@ -59,8 +59,7 @@ struct InstalledPackageDetailView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .task(id: package.id) {
-            await viewModel.refreshDependencies()
-            await viewModel.refreshDependents()
+            await viewModel.refreshRelationships()
             await viewModel.observeRowUpdates()
         }
         .onChange(of: package) { _, newPackage in
@@ -68,8 +67,7 @@ struct InstalledPackageDetailView: View {
             expandedDependencies = false
             expandedDependents = false
             Task {
-                await viewModel.refreshDependencies()
-                await viewModel.refreshDependents()
+                await viewModel.refreshRelationships()
             }
         }
     }

--- a/Brew/Features/Installed/InstalledPackageDetailView.swift
+++ b/Brew/Features/Installed/InstalledPackageDetailView.swift
@@ -31,6 +31,7 @@ struct InstalledPackageDetailView: View {
     @State private var viewModel: InstalledDetailsViewModel
     @State private var expandedDependencies = false
     @State private var expandedDependents = false
+    @State private var showUninstallConfirmation = false
 
     private let collapsedRelationshipCount = 3
 
@@ -66,6 +67,7 @@ struct InstalledPackageDetailView: View {
             viewModel.update(package: newPackage)
             expandedDependencies = false
             expandedDependents = false
+            showUninstallConfirmation = false
             Task {
                 await viewModel.refreshRelationships()
             }
@@ -77,10 +79,7 @@ struct InstalledPackageDetailView: View {
             VStack(alignment: .leading, spacing: BrewSpacing.xl) {
                 InstalledPackageDetailHeroSection(viewModel: viewModel)
                 packageDetailsSections(viewModel: viewModel)
-
-                if viewModel.showsUpgradeChrome {
-                    upgradeFooter(viewModel: viewModel)
-                }
+                packageActionsFooter(viewModel: viewModel)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(BrewSpacing.xl)
@@ -88,10 +87,17 @@ struct InstalledPackageDetailView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
-    private func upgradeFooter(viewModel: InstalledDetailsViewModel) -> some View {
-        VStack(alignment: .leading, spacing: BrewSpacing.md) {
+    private func packageActionsFooter(viewModel: InstalledDetailsViewModel) -> some View {
+        VStack(alignment: .leading, spacing: BrewSpacing.xl) {
             InstalledPackageDetailSectionDivider()
-            InstalledPackageDetailUpgradeChrome(viewModel: viewModel)
+            if viewModel.showsUpgradeChrome {
+                InstalledPackageDetailUpgradeChrome(viewModel: viewModel)
+                InstalledPackageDetailSectionDivider()
+            }
+            InstalledPackageDetailUninstallChrome(
+                viewModel: viewModel,
+                showConfirmation: $showUninstallConfirmation,
+            )
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -116,8 +122,60 @@ struct InstalledPackageDetailView: View {
             onSelectInstalledPackage: onSelectInstalledPackage,
             isExpanded: $expandedDependents,
         )
-        InstalledPackageDetailSectionDivider()
-        InstalledPackageDetailInfoCommandSection(title: "Command", command: viewModel.displayCommand)
+    }
+}
+
+/// Uninstall affordance and copyable `brew uninstall` command (`CONVENTIONS.md` — transparency).
+private struct InstalledPackageDetailUninstallChrome: View {
+    @Bindable var viewModel: InstalledDetailsViewModel
+    @Binding var showConfirmation: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: BrewSpacing.sm) {
+            Text("Uninstall")
+                .font(.brewSubheadline.weight(.semibold))
+                .foregroundStyle(Color.brewTextPrimary)
+
+            VStack(alignment: .leading, spacing: BrewSpacing.md) {
+                MutationCommandConsole(
+                    command: viewModel.uninstallDisplayCommand,
+                    summaryText: "Uninstalls this package from this Mac",
+                )
+
+                Button {
+                    showConfirmation = true
+                } label: {
+                    if viewModel.isUninstalling {
+                        ProgressView()
+                            .controlSize(.small)
+                            .frame(minWidth: 120)
+                    } else {
+                        Text(viewModel.uninstallPrimaryButtonTitle).foregroundStyle(Color.brewTextSecondary)
+                    }
+                }
+                .buttonStyle(.bordered)
+                .disabled(viewModel.isMutatingPackage)
+                .accessibilityLabel(viewModel.uninstallPrimaryButtonTitle)
+                .confirmationDialog(
+                    viewModel.uninstallConfirmationTitle,
+                    isPresented: $showConfirmation,
+                ) {
+                    Button(viewModel.uninstallPrimaryButtonTitle, role: .destructive) {
+                        viewModel.uninstallSelectedPackage()
+                    }
+                    Button("Cancel", role: .cancel) {}
+                } message: {
+                    Text(viewModel.uninstallConfirmationMessage)
+                }
+
+                if let uninstallError = viewModel.uninstallErrorMessage {
+                    Text(uninstallError)
+                        .font(.brewCallout)
+                        .foregroundStyle(Color.brewStatusError)
+                        .textSelection(.enabled)
+                }
+            }
+        }
     }
 }
 
@@ -132,7 +190,10 @@ private struct InstalledPackageDetailUpgradeChrome: View {
                 .foregroundStyle(Color.brewTextPrimary)
 
             VStack(alignment: .leading, spacing: BrewSpacing.md) {
-                upgradeCommandConsole
+                MutationCommandConsole(
+                    command: viewModel.upgradeDisplayCommand,
+                    summaryText: "Upgrades this package to the latest available version",
+                )
 
                 if let title = viewModel.upgradePrimaryButtonTitle {
                     HStack(spacing: BrewSpacing.sm) {
@@ -161,8 +222,14 @@ private struct InstalledPackageDetailUpgradeChrome: View {
             }
         }
     }
+}
 
-    private var upgradeCommandConsole: some View {
+/// Shared terminal-command card used by Installed mutation sections (upgrade/uninstall).
+private struct MutationCommandConsole: View {
+    let command: String
+    let summaryText: String
+
+    var body: some View {
         VStack(spacing: 0) {
             HStack {
                 Label("Terminal command", systemImage: "terminal")
@@ -171,7 +238,7 @@ private struct InstalledPackageDetailUpgradeChrome: View {
                 Spacer()
                 Button("Copy", systemImage: "doc.on.doc") {
                     NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString(viewModel.upgradeDisplayCommand, forType: .string)
+                    NSPasteboard.general.setString(command, forType: .string)
                 }
                 .font(.brewCaption)
                 .foregroundStyle(Color.brewTextSecondary)
@@ -181,7 +248,7 @@ private struct InstalledPackageDetailUpgradeChrome: View {
             .padding(.vertical, BrewSpacing.sm)
             .background(Color.brewSurfaceRecessed)
 
-            Text(viewModel.upgradeDisplayCommand)
+            Text(command)
                 .font(.brewCode)
                 .foregroundStyle(Color.brewCodeDefault)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -189,7 +256,7 @@ private struct InstalledPackageDetailUpgradeChrome: View {
                 .background(Color.brewTerminal)
                 .textSelection(.enabled)
 
-            Text("Upgrades this package to the latest available version")
+            Text(summaryText)
                 .font(.brewCaption)
                 .foregroundStyle(Color.brewTextTertiary)
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/Brew/Features/Installed/InstalledUninstallBusyPresentation.swift
+++ b/Brew/Features/Installed/InstalledUninstallBusyPresentation.swift
@@ -1,0 +1,42 @@
+//
+//  InstalledUninstallBusyPresentation.swift
+//  Brew
+//
+
+import Foundation
+
+/// Derived presentation for "uninstall in progress" chrome when observing ``BrewOperationPhase`` for an installed row.
+///
+/// ``BrewCommandCenter`` can report ``BrewOperationPhase/idle`` before ``InstalledViewModel`` finishes
+/// `refresh()` and removes the package from the catalog; while the snapshot still shows the package as
+/// installed, keep showing busy state so the UI does not flash back to the normal installed appearance.
+///
+/// The latch releases when:
+/// - The phase transitions to ``BrewOperationPhase/failed(reason:)`` (error is surfaced instead), or
+/// - ``InstalledListRowViewModel/update(package:)`` / ``InstalledDetailsViewModel/update(package:)``
+///   resets `operationPhase` to ``BrewOperationPhase/idle`` after the catalog refresh propagates.
+enum InstalledUninstallBusyPresentation {
+    static func showsUninstallBusy(
+        oldPhase: BrewOperationPhase,
+        newPhase: BrewOperationPhase,
+    ) -> Bool {
+        if newPhase.isRunningUninstall {
+            return true
+        }
+        if oldPhase.isRunningUninstall, case .idle = newPhase {
+            return true
+        }
+        return false
+    }
+}
+
+private extension BrewOperationPhase {
+    var isRunningUninstall: Bool {
+        switch self {
+        case .running(.uninstallFormula), .running(.uninstallCask):
+            true
+        default:
+            false
+        }
+    }
+}

--- a/Brew/Features/Installed/InstalledUpgradeBusyPresentation.swift
+++ b/Brew/Features/Installed/InstalledUpgradeBusyPresentation.swift
@@ -5,23 +5,36 @@
 
 import Foundation
 
-/// Derived presentation for “upgrade in progress” chrome when observing ``BrewOperationPhase`` for an installed row.
+/// Derived presentation for "upgrade in progress" chrome when observing ``BrewOperationPhase`` for an installed row.
 ///
 /// ``BrewCommandCenter`` can report ``BrewOperationPhase/idle`` before ``InstalledViewModel`` finishes
 /// `refresh()` and pushes an updated ``BrewPackage``; while the snapshot still shows ``BrewPackage/outdated``,
 /// keep showing busy state.
+///
+/// Only upgrade operation kinds are matched; uninstall busy state is handled by ``InstalledUninstallBusyPresentation``.
 enum InstalledUpgradeBusyPresentation {
     static func showsUpgradeBusy(
         oldPhase: BrewOperationPhase,
         newPhase: BrewOperationPhase,
         isPackageOutdated: Bool,
     ) -> Bool {
-        if case .running = newPhase {
+        if newPhase.isRunningUpgrade {
             return true
         }
-        if case .running = oldPhase, case .idle = newPhase, isPackageOutdated {
+        if oldPhase.isRunningUpgrade, case .idle = newPhase, isPackageOutdated {
             return true
         }
         return false
+    }
+}
+
+private extension BrewOperationPhase {
+    var isRunningUpgrade: Bool {
+        switch self {
+        case .running(.upgradeFormula), .running(.upgradeCask):
+            true
+        default:
+            false
+        }
     }
 }

--- a/Brew/Features/Installed/UninstallPackageItem.swift
+++ b/Brew/Features/Installed/UninstallPackageItem.swift
@@ -8,9 +8,57 @@ import Foundation
 /// Presentation mapping for uninstall actions shown in Installed package detail subviews.
 struct UninstallPackageItem {
     private let package: BrewPackage
+    private let blockingDependentCount: Int
 
-    init(package: BrewPackage) {
+    init(package: BrewPackage, blockingDependentCount: Int = 0) {
         self.package = package
+        self.blockingDependentCount = max(0, blockingDependentCount)
+    }
+
+    /// True when installed dependents prevent removing this package alone.
+    var isBlockedByDependents: Bool {
+        blockingDependentCount > 0
+    }
+
+    /// Badge beside the Used by heading when uninstall is blocked.
+    var usedByBlockingBadgeTitle: String? {
+        guard isBlockedByDependents else {
+            return nil
+        }
+        return String(
+            localized: "blocking uninstall",
+            comment: "Installed detail Used by badge when dependents block uninstall",
+        )
+    }
+
+    /// Leading sentence for the uninstall-blocked callout (bold in UI).
+    var uninstallBlockedBannerLead: String? {
+        guard isBlockedByDependents else {
+            return nil
+        }
+        return String(
+            localized: "Can't uninstall yet.",
+            comment: "Installed detail uninstall blocked callout lead sentence",
+        )
+    }
+
+    /// Body copy for the uninstall-blocked callout after the lead sentence.
+    var uninstallBlockedBannerBody: String? {
+        guard isBlockedByDependents else {
+            return nil
+        }
+        let name = package.name
+        if blockingDependentCount == 1 {
+            return String(
+                localized: "1 package above depends on \(name). Uninstall it first.",
+                comment: "Installed detail uninstall blocked callout body for one dependent",
+            )
+        }
+        let count = blockingDependentCount
+        return String(
+            localized: "\(count) packages above depend on \(name). Uninstall them first.",
+            comment: "Installed detail uninstall blocked callout body for multiple dependents",
+        )
     }
 
     /// Copyable Terminal command for uninstalling this package (`CONVENTIONS.md` — transparency).

--- a/Brew/Features/Installed/UninstallPackageItem.swift
+++ b/Brew/Features/Installed/UninstallPackageItem.swift
@@ -1,0 +1,49 @@
+//
+//  UninstallPackageItem.swift
+//  Brew
+//
+
+import Foundation
+
+/// Presentation mapping for uninstall actions shown in Installed package detail subviews.
+struct UninstallPackageItem {
+    private let package: BrewPackage
+
+    init(package: BrewPackage) {
+        self.package = package
+    }
+
+    /// Copyable Terminal command for uninstalling this package (`CONVENTIONS.md` — transparency).
+    var displayCommand: String {
+        switch package.kind {
+        case .formula:
+            "brew uninstall --formula \(package.name)"
+        case .cask:
+            "brew uninstall --cask \(package.name)"
+        }
+    }
+
+    /// Primary uninstall button label.
+    var primaryButtonTitle: String {
+        String(
+            localized: "Uninstall",
+            comment: "Installed detail uninstall button title",
+        )
+    }
+
+    /// Confirmation title shown before uninstalling this package.
+    var confirmationTitle: String {
+        String(
+            localized: "Uninstall \(package.name)?",
+            comment: "Installed detail uninstall confirmation title; interpolated package name",
+        )
+    }
+
+    /// Confirmation detail shown before uninstalling this package.
+    var confirmationMessage: String {
+        String(
+            localized: "This will remove \(package.name) from this Mac using Homebrew.",
+            comment: "Installed detail uninstall confirmation message; interpolated package name",
+        )
+    }
+}

--- a/Brew/Features/Installed/UninstallPackageItem.swift
+++ b/Brew/Features/Installed/UninstallPackageItem.swift
@@ -20,6 +20,27 @@ struct UninstallPackageItem {
         blockingDependentCount > 0
     }
 
+    /// VoiceOver hint for the primary uninstall control when dependents block removal.
+    var blockedPrimaryButtonAccessibilityHint: String? {
+        guard isBlockedByDependents else {
+            return nil
+        }
+        return String(
+            localized: "Blocked by installed dependents. Activate to see why.",
+            comment: "Installed detail uninstall button accessibility hint when blocked",
+        )
+    }
+
+    /// Lead and body for the uninstall-blocked callout, when shown.
+    var blockedCalloutContent: UninstallBlockedCalloutContent? {
+        guard let lead = uninstallBlockedBannerLead,
+              let body = uninstallBlockedBannerBody
+        else {
+            return nil
+        }
+        return UninstallBlockedCalloutContent(lead: lead, body: body)
+    }
+
     /// Badge beside the Used by heading when uninstall is blocked.
     var usedByBlockingBadgeTitle: String? {
         guard isBlockedByDependents else {
@@ -94,4 +115,16 @@ struct UninstallPackageItem {
             comment: "Installed detail uninstall confirmation message; interpolated package name",
         )
     }
+}
+
+/// Copy shown in the uninstall-blocked warning callout.
+struct UninstallBlockedCalloutContent: Equatable {
+    let lead: String
+    let body: String
+}
+
+/// Result of activating the primary uninstall control in Installed detail.
+enum UninstallPrimaryButtonAction: Equatable {
+    case presentConfirmation
+    case revealBlockedExplanation
 }

--- a/Brew/Services/BrewOperationModels.swift
+++ b/Brew/Services/BrewOperationModels.swift
@@ -9,6 +9,8 @@ import Foundation
 nonisolated enum BrewOperationKind: String, Hashable {
     case upgradeFormula
     case upgradeCask
+    case uninstallFormula
+    case uninstallCask
 }
 
 /// Stable opaque identity for in-flight mutating work (e.g. upgrades). Conventionally `formula:<name>` or `cask:<name>` to align with Homebrew package identity strings — see ``BrewOperationID`` helpers in the Models layer.

--- a/Brew/Services/PackageUninstallCommand.swift
+++ b/Brew/Services/PackageUninstallCommand.swift
@@ -1,0 +1,52 @@
+//
+//  PackageUninstallCommand.swift
+//  Brew
+//
+import Foundation
+
+/// Schedules `brew uninstall <name>` or `brew uninstall --cask <name>` via ``BrewCommandCenter/submit``,
+/// using ``BrewCommandExecutionContext`` for subprocess execution and `brew` resolution.
+struct PackageUninstallCommand: BrewMutatingCommand {
+    let packageName: String
+    let kind: InstalledPackageKind
+
+    init(package: BrewPackage) {
+        packageName = package.name
+        kind = package.kind
+    }
+
+    init(kind: InstalledPackageKind, name: String) {
+        packageName = name
+        self.kind = kind
+    }
+
+    nonisolated var operationKind: BrewOperationKind {
+        switch kind {
+        case .formula:
+            .uninstallFormula
+        case .cask:
+            .uninstallCask
+        }
+    }
+
+    func run(in context: BrewCommandExecutionContext) async throws {
+        let brew = try context.brewExecutableURL()
+        let arguments: [String] = switch kind {
+        case .formula:
+            ["uninstall", "--formula", packageName]
+        case .cask:
+            ["uninstall", "--cask", packageName]
+        }
+
+        let output = try await context.commandRunner.run(
+            executableURL: brew,
+            arguments: arguments,
+        )
+        guard output.terminationStatus == 0 else {
+            throw BrewCommandError.failed(
+                exitCode: output.terminationStatus,
+                stderr: output.standardError,
+            )
+        }
+    }
+}

--- a/Brew/Theme/BrewSpacing.swift
+++ b/Brew/Theme/BrewSpacing.swift
@@ -39,12 +39,12 @@ enum BrewLayout {
     static let inspectorWidth: CGFloat = 280
 
     /// Installed list column (middle pane of `NavigationSplitView`).
-    static let installedListColumnMinWidth: CGFloat = 220
-    static let installedListColumnIdealWidth: CGFloat = 300
+    static let installedListColumnMinWidth: CGFloat = 300
+    static let installedListColumnIdealWidth: CGFloat = 400
     static let installedListColumnMaxWidth: CGFloat = 800
 
     /// Third column (package detail).
-    static let installedDetailColumnIdealWidth: CGFloat = 320
+    static let installedDetailColumnIdealWidth: CGFloat = 400
     static let installedDetailColumnMaxWidth: CGFloat = 1200
     static let installedThreePaneMinWindowWidth: CGFloat = 960
 

--- a/BrewTests/InstalledDetailsViewModelMutationParityTests.swift
+++ b/BrewTests/InstalledDetailsViewModelMutationParityTests.swift
@@ -1,0 +1,104 @@
+//
+//  InstalledDetailsViewModelMutationParityTests.swift
+//  BrewTests
+//
+
+@testable import Brew
+import Testing
+
+@MainActor
+struct InstalledDetailsMutationTests {
+    @Test func `uninstall failure maps launch failure to underlying message`() async {
+        let viewModel = makeInstalledDetailsViewModel(
+            package: details(name: "wget"),
+            brewCommandCenter: ThrowingSubmitCommandCenter(
+                error: BrewCommandError.launchFailed(underlying: "spawn failed"),
+            ),
+        )
+
+        await withInstalledDetailPhaseObservation(on: viewModel) {
+            viewModel.uninstallSelectedPackage()
+            await waitForUninstallError(on: viewModel)
+            #expect(viewModel.uninstallErrorMessage == "spawn failed")
+        }
+    }
+
+    @Test func `uninstall failure with empty stderr uses generic brew failure message`() async {
+        let viewModel = makeInstalledDetailsViewModel(
+            package: details(name: "wget"),
+            brewCommandCenter: ThrowingSubmitCommandCenter(
+                error: BrewCommandError.failed(exitCode: 1, stderr: " \n"),
+            ),
+        )
+
+        await withInstalledDetailPhaseObservation(on: viewModel) {
+            viewModel.uninstallSelectedPackage()
+            await waitForUninstallError(on: viewModel)
+            #expect(viewModel.uninstallErrorMessage == "Homebrew command failed.")
+        }
+    }
+
+    @Test func `isMutatingPackage is true while upgrade is running`() async {
+        let center = RunningSubmitCountingCommandCenter()
+        let viewModel = makeInstalledDetailsViewModel(
+            package: details(name: "wget"),
+            brewCommandCenter: center,
+        )
+
+        viewModel.upgradeSelectedPackage()
+        let observer = Task { await viewModel.observeRowUpdates() }
+        defer { observer.cancel() }
+
+        await waitForUpgrading(on: viewModel)
+        #expect(viewModel.isMutatingPackage)
+    }
+
+    @Test func `isMutatingPackage is true while uninstall is running`() async {
+        let center = RunningSubmitCountingCommandCenter(phase: .running(.uninstallFormula))
+        let viewModel = makeInstalledDetailsViewModel(
+            package: details(name: "wget"),
+            brewCommandCenter: center,
+        )
+
+        viewModel.uninstallSelectedPackage()
+        let observer = Task { await viewModel.observeRowUpdates() }
+        defer { observer.cancel() }
+
+        await waitForUninstalling(on: viewModel)
+        #expect(viewModel.isMutatingPackage)
+    }
+
+    @Test func `isMutatingPackage clears after uninstall completes`() async {
+        let viewModel = makeInstalledDetailsViewModel(
+            package: details(name: "wget"),
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
+        )
+
+        await withInstalledDetailPhaseObservation(on: viewModel) {
+            viewModel.uninstallSelectedPackage()
+            await waitForUninstallAttemptToFinish(on: viewModel)
+            #expect(!viewModel.isMutatingPackage)
+        }
+    }
+
+    @Test func `observeRowUpdates clears blocked callout when uninstall starts`() async {
+        let package = details(name: "ada-url")
+        let viewModel = makeInstalledDetailsViewModel(
+            package: package,
+            brewCommandCenter: ConstantPhaseCommandCenter(phase: .running(.uninstallFormula)),
+            installedDependentsRepository: StubInstalledDependentsRepository { packageID in
+                packageID == package.id ? [.fixture(name: "curl")] : []
+            },
+        )
+
+        await viewModel.refreshRelationships()
+        viewModel.handleUninstallPrimaryButtonTapped()
+        #expect(viewModel.showUninstallBlockedCallout)
+
+        let observer = Task { await viewModel.observeRowUpdates() }
+        defer { observer.cancel() }
+        await waitForUninstalling(on: viewModel)
+
+        #expect(!viewModel.showUninstallBlockedCallout)
+    }
+}

--- a/BrewTests/InstalledDetailsViewModelTests.swift
+++ b/BrewTests/InstalledDetailsViewModelTests.swift
@@ -172,6 +172,21 @@ struct InstalledDetailsViewModelTests {
         #expect(!viewModel.isUpgrading)
     }
 
+    @Test @MainActor func `blocked uninstall primary button presentation`() async {
+        let package = details(name: "ada-url")
+        let viewModel = makeInstalledDetailsViewModel(
+            package: package,
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
+            installedDependentsRepository: StubInstalledDependentsRepository { packageID in
+                packageID == package.id ? [.fixture(name: "curl")] : []
+            },
+        )
+        await viewModel.refreshDependents()
+        #expect(viewModel.showsUninstallBlockedPrimaryButtonChrome)
+        #expect(viewModel.uninstallPrimaryButtonAction == .revealBlockedExplanation)
+        #expect(viewModel.uninstallBlockedCalloutContent != nil)
+    }
+
     @Test @MainActor func `dependents uses injected repository for current package`() async {
         let package = details(name: "openssl@3")
         let viewModel = makeInstalledDetailsViewModel(
@@ -461,3 +476,49 @@ struct InstalledDetailsViewModelUpgradeTests {
 }
 
 private struct GenericUpgradeError: Error {}
+
+// MARK: - Uninstall presentation state
+
+extension InstalledDetailsViewModelTests {
+    @Test @MainActor func `handleUninstallPrimaryButtonTapped sets showUninstallConfirmation when not blocked`() {
+        let viewModel = makeInstalledDetailsViewModel(
+            package: .fixture(name: "wget", kind: .formula),
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
+        )
+        viewModel.handleUninstallPrimaryButtonTapped()
+        #expect(viewModel.showUninstallConfirmation)
+        #expect(!viewModel.showUninstallBlockedCallout)
+    }
+
+    @Test @MainActor func `handleUninstallPrimaryButtonTapped sets showUninstallBlockedCallout when blocked`() async {
+        let package = details(name: "ada-url")
+        let viewModel = makeInstalledDetailsViewModel(
+            package: package,
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
+            installedDependentsRepository: StubInstalledDependentsRepository { packageID in
+                packageID == package.id ? [.fixture(name: "curl")] : []
+            },
+        )
+        await viewModel.refreshDependents()
+        viewModel.handleUninstallPrimaryButtonTapped()
+        #expect(viewModel.showUninstallBlockedCallout)
+        #expect(!viewModel.showUninstallConfirmation)
+    }
+
+    @Test @MainActor func `update package clears uninstall presentation flags`() async {
+        let package = details(name: "ada-url")
+        let viewModel = makeInstalledDetailsViewModel(
+            package: package,
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
+            installedDependentsRepository: StubInstalledDependentsRepository { packageID in
+                packageID == package.id ? [.fixture(name: "curl")] : []
+            },
+        )
+        await viewModel.refreshDependents()
+        viewModel.handleUninstallPrimaryButtonTapped()
+        #expect(viewModel.showUninstallBlockedCallout)
+        viewModel.update(package: .fixture(name: "wget", kind: .formula))
+        #expect(!viewModel.showUninstallBlockedCallout)
+        #expect(!viewModel.showUninstallConfirmation)
+    }
+}

--- a/BrewTests/InstalledDetailsViewModelTests.swift
+++ b/BrewTests/InstalledDetailsViewModelTests.swift
@@ -148,7 +148,7 @@ struct InstalledDetailsViewModelTests {
                     : []
             },
         )
-        await viewModel.refreshDependents()
+        await viewModel.refreshRelationships()
         #expect(viewModel.dependentRelationships.map(\.displayName) == ["curl", "node"])
         #expect(viewModel.dependentRelationships.map(\.packageKind) == [.formula, .formula])
         #expect(viewModel.dependentRelationships.map(\.isInstalledInInventory) == [true, true])
@@ -164,13 +164,13 @@ struct InstalledDetailsViewModelTests {
                 packageID == wget.id ? [.fixture(name: "curl")] : []
             },
         )
-        await viewModel.refreshDependents()
+        await viewModel.refreshRelationships()
         viewModel.update(package: wget)
-        await viewModel.refreshDependents()
+        await viewModel.refreshRelationships()
         #expect(viewModel.dependentRelationships.map(\.displayName) == ["curl"])
     }
 
-    @Test @MainActor func `refreshDependencies marks installed and missing dependency refs`() async {
+    @Test @MainActor func `refreshRelationships marks installed and missing dependency refs`() async {
         let package = BrewPackage.fixture(
             name: "wget",
             kind: .formula,
@@ -182,7 +182,7 @@ struct InstalledDetailsViewModelTests {
             installedInventoryReading: StubInstalledInventoryReading(installedIDs: ["formula:openssl@3"]),
         )
 
-        await viewModel.refreshDependencies()
+        await viewModel.refreshRelationships()
 
         #expect(viewModel.dependencyRelationships.count == 2)
         #expect(viewModel.dependencyRelationships[0].displayName == "openssl@3")
@@ -203,7 +203,7 @@ struct InstalledDetailsViewModelTests {
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
             installedInventoryReading: StubInstalledInventoryReading(installedIDs: ["formula:openssl@3"]),
         )
-        await viewModel.refreshDependencies()
+        await viewModel.refreshRelationships()
         viewModel.update(package: BrewPackage.fixture(name: "curl", kind: .formula))
         #expect(viewModel.dependencyRelationships.isEmpty)
     }
@@ -217,7 +217,7 @@ struct InstalledDetailsViewModelTests {
                 packageID == package.id ? [.fixture(name: "curl")] : []
             },
         )
-        await viewModel.refreshDependents()
+        await viewModel.refreshRelationships()
         viewModel.update(package: BrewPackage.fixture(name: "wget", kind: .formula))
         #expect(viewModel.dependentRelationships.isEmpty)
     }

--- a/BrewTests/InstalledDetailsViewModelTests.swift
+++ b/BrewTests/InstalledDetailsViewModelTests.swift
@@ -181,7 +181,7 @@ struct InstalledDetailsViewModelTests {
                 packageID == package.id ? [.fixture(name: "curl")] : []
             },
         )
-        await viewModel.refreshDependents()
+        await viewModel.refreshRelationships()
         #expect(viewModel.showsUninstallBlockedPrimaryButtonChrome)
         #expect(viewModel.uninstallPrimaryButtonAction == .revealBlockedExplanation)
         #expect(viewModel.uninstallBlockedCalloutContent != nil)
@@ -499,7 +499,7 @@ extension InstalledDetailsViewModelTests {
                 packageID == package.id ? [.fixture(name: "curl")] : []
             },
         )
-        await viewModel.refreshDependents()
+        await viewModel.refreshRelationships()
         viewModel.handleUninstallPrimaryButtonTapped()
         #expect(viewModel.showUninstallBlockedCallout)
         #expect(!viewModel.showUninstallConfirmation)
@@ -514,7 +514,7 @@ extension InstalledDetailsViewModelTests {
                 packageID == package.id ? [.fixture(name: "curl")] : []
             },
         )
-        await viewModel.refreshDependents()
+        await viewModel.refreshRelationships()
         viewModel.handleUninstallPrimaryButtonTapped()
         #expect(viewModel.showUninstallBlockedCallout)
         viewModel.update(package: .fixture(name: "wget", kind: .formula))

--- a/BrewTests/InstalledDetailsViewModelTests.swift
+++ b/BrewTests/InstalledDetailsViewModelTests.swift
@@ -78,6 +78,31 @@ struct InstalledDetailsViewModelTests {
         #expect(viewModel.upgradeDisplayCommand == "brew upgrade --formula wget@2")
     }
 
+    @Test @MainActor func `uninstallDisplayCommand reflects formula name`() {
+        let viewModel = makeInstalledDetailsViewModel(
+            package: .fixture(name: "wget", kind: .formula),
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
+        )
+        #expect(viewModel.uninstallDisplayCommand == "brew uninstall --formula wget")
+    }
+
+    @Test @MainActor func `uninstallDisplayCommand uses cask terminal flags`() {
+        let viewModel = makeInstalledDetailsViewModel(
+            package: .fixture(name: "docker", kind: .cask),
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
+        )
+        #expect(viewModel.uninstallDisplayCommand == "brew uninstall --cask docker")
+    }
+
+    @Test @MainActor func `uninstallDisplayCommand updates when package name changes`() {
+        let viewModel = makeInstalledDetailsViewModel(
+            package: .fixture(name: "wget", kind: .formula),
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
+        )
+        viewModel.update(package: details(name: "wget@2"))
+        #expect(viewModel.uninstallDisplayCommand == "brew uninstall --formula wget@2")
+    }
+
     @Test @MainActor func `showsUpgradeChrome follows package outdated flag`() {
         var outdatedDetails = details(name: "wget")
         outdatedDetails.outdated = true
@@ -127,6 +152,16 @@ struct InstalledDetailsViewModelTests {
         newer.latestVersion = "2.0.0"
         viewModel.update(package: newer)
         #expect(viewModel.upgradePrimaryButtonTitle?.contains("v2.0.0") == true)
+    }
+
+    @Test @MainActor func `uninstall presentation uses package name`() {
+        let viewModel = makeInstalledDetailsViewModel(
+            package: .fixture(name: "wget", kind: .formula),
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
+        )
+        #expect(viewModel.uninstallPrimaryButtonTitle == "Uninstall")
+        #expect(viewModel.uninstallConfirmationTitle == "Uninstall wget?")
+        #expect(viewModel.uninstallConfirmationMessage == "This will remove wget from this Mac using Homebrew.")
     }
 
     @Test @MainActor func `detail row is not upgrading before observeRowUpdates runs`() {
@@ -220,6 +255,14 @@ struct InstalledDetailsViewModelTests {
         await viewModel.refreshRelationships()
         viewModel.update(package: BrewPackage.fixture(name: "wget", kind: .formula))
         #expect(viewModel.dependentRelationships.isEmpty)
+    }
+
+    @Test @MainActor func `detail row is not uninstalling before observeRowUpdates runs`() {
+        let viewModel = makeInstalledDetailsViewModel(
+            package: details(name: "wget"),
+            brewCommandCenter: ConstantPhaseCommandCenter(phase: .running(.uninstallFormula)),
+        )
+        #expect(!viewModel.isUninstalling)
     }
 }
 
@@ -335,6 +378,84 @@ struct InstalledDetailsViewModelUpgradeTests {
             #expect(await center.submitCallCount == 1)
             await center.resolveSubmit()
             await waitForUpgradeAttemptToFinish(on: viewModel)
+        }
+    }
+
+    @Test @MainActor func `uninstall completes with idle phase and no error using noop center`() async {
+        let viewModel = makeInstalledDetailsViewModel(
+            package: details(name: "wget"),
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
+        )
+
+        await withInstalledDetailPhaseObservation(on: viewModel) {
+            viewModel.uninstallSelectedPackage()
+            await waitForUninstallAttemptToFinish(on: viewModel)
+            #expect(viewModel.uninstallErrorMessage == nil)
+        }
+    }
+
+    @Test @MainActor func `uninstall failure sets uninstall error message`() async {
+        let viewModel = makeInstalledDetailsViewModel(
+            package: details(name: "wget"),
+            brewCommandCenter: ThrowingSubmitCommandCenter(
+                error: BrewCommandError.failed(exitCode: 1, stderr: "uninstall blocked"),
+            ),
+        )
+
+        await withInstalledDetailPhaseObservation(on: viewModel) {
+            viewModel.uninstallSelectedPackage()
+            await waitForUninstallError(on: viewModel)
+            #expect(viewModel.uninstallErrorMessage == "uninstall blocked")
+        }
+    }
+
+    @Test @MainActor func `uninstall ignores reentry while already uninstalling`() async {
+        let center = RunningSubmitCountingCommandCenter(phase: .running(.uninstallFormula))
+        let viewModel = makeInstalledDetailsViewModel(
+            package: details(name: "wget"),
+            brewCommandCenter: center,
+        )
+
+        viewModel.uninstallSelectedPackage()
+        let observer = Task { await viewModel.observeRowUpdates() }
+        defer { observer.cancel() }
+
+        await waitForUninstalling(on: viewModel)
+        viewModel.uninstallSelectedPackage()
+
+        #expect(await center.submitCallCount == 1)
+    }
+
+    @Test @MainActor func `uninstall failure maps missing brew to user facing message`() async {
+        let viewModel = makeInstalledDetailsViewModel(
+            package: details(name: "wget"),
+            brewCommandCenter: ThrowingSubmitCommandCenter(
+                error: BrewLookupError.executableNotFound,
+            ),
+        )
+
+        await withInstalledDetailPhaseObservation(on: viewModel) {
+            viewModel.uninstallSelectedPackage()
+            await waitForUninstallError(on: viewModel)
+            #expect(
+                viewModel.uninstallErrorMessage ==
+                    "Could not find Homebrew. Install it or ensure brew is in the default location.",
+            )
+        }
+    }
+
+    @Test @MainActor func `uninstall failure maps unknown errors to generic message`() async {
+        let viewModel = makeInstalledDetailsViewModel(
+            package: details(name: "wget"),
+            brewCommandCenter: ThrowingSubmitCommandCenter(
+                error: GenericUpgradeError(),
+            ),
+        )
+
+        await withInstalledDetailPhaseObservation(on: viewModel) {
+            viewModel.uninstallSelectedPackage()
+            await waitForUninstallError(on: viewModel)
+            #expect(viewModel.uninstallErrorMessage == "Something went wrong while uninstalling this package.")
         }
     }
 }

--- a/BrewTests/InstalledDetailsViewModelTestsSupport.swift
+++ b/BrewTests/InstalledDetailsViewModelTestsSupport.swift
@@ -181,6 +181,35 @@ func waitForUpgrading(on viewModel: InstalledDetailsViewModel) async {
     Issue.record("timed out waiting for isUpgrading")
 }
 
+@MainActor
+func waitForUninstallAttemptToFinish(on viewModel: InstalledDetailsViewModel) async {
+    for step in 0 ..< 300 {
+        await Task.yield()
+        if step >= 10, !viewModel.isUninstalling {
+            return
+        }
+    }
+    Issue.record("timed out waiting for isUninstalling to clear")
+}
+
+@MainActor
+func waitForUninstallError(on viewModel: InstalledDetailsViewModel) async {
+    for _ in 0 ..< 100 {
+        if viewModel.uninstallErrorMessage != nil { return }
+        await Task.yield()
+    }
+    Issue.record("timed out waiting for uninstallErrorMessage")
+}
+
+@MainActor
+func waitForUninstalling(on viewModel: InstalledDetailsViewModel) async {
+    for _ in 0 ..< 100 {
+        if viewModel.isUninstalling { return }
+        await Task.yield()
+    }
+    Issue.record("timed out waiting for isUninstalling")
+}
+
 /// Runs ``InstalledDetailsViewModel/observeRowUpdates()`` concurrently — required for upgrades to mirror the detail column lifecycle.
 @MainActor
 func withInstalledDetailPhaseObservation(

--- a/BrewTests/InstalledListRowViewModelTests.swift
+++ b/BrewTests/InstalledListRowViewModelTests.swift
@@ -28,6 +28,15 @@ struct InstalledListRowViewModelTests {
         #expect(!viewModel.showsUpgradeBusy)
     }
 
+    @Test func `observeRowUpdates latches uninstall busy after running to idle`() async {
+        let package = BrewPackage.fixture(name: "git", kind: .formula)
+        let center = PhaseSequenceCommandCenter(phases: [.running(.uninstallFormula), .idle])
+        let viewModel = InstalledListRowViewModel(package: package, brewCommandCenter: center)
+        await viewModel.observeRowUpdates()
+        #expect(!viewModel.showsUpgradeBusy)
+        #expect(viewModel.showsUninstallBusy)
+    }
+
     @Test func `update package flips row version presentation when outdated changes`() {
         let current = BrewPackage.fixture(
             name: "git",

--- a/BrewTests/InstalledListRowViewModelTests.swift
+++ b/BrewTests/InstalledListRowViewModelTests.swift
@@ -21,11 +21,14 @@ struct InstalledListRowViewModelTests {
     }
 
     @Test func `observeRowUpdates ends on last phased stream emission`() async {
-        let package = BrewPackage.fixture(name: "git", kind: .formula)
+        var package = BrewPackage.fixture(name: "git", kind: .formula)
+        package.outdated = true
         let center = PhaseSequenceCommandCenter(phases: [.running(.upgradeFormula), .idle])
         let viewModel = InstalledListRowViewModel(package: package, brewCommandCenter: center)
         await viewModel.observeRowUpdates()
-        #expect(!viewModel.showsUpgradeBusy)
+        #expect(viewModel.showsUpgradeBusy)
+        #expect(viewModel.showsOperationBusy)
+        #expect(viewModel.rowAccessibilityLabel.contains("Upgrading"))
     }
 
     @Test func `observeRowUpdates latches uninstall busy after running to idle`() async {
@@ -35,6 +38,43 @@ struct InstalledListRowViewModelTests {
         await viewModel.observeRowUpdates()
         #expect(!viewModel.showsUpgradeBusy)
         #expect(viewModel.showsUninstallBusy)
+        #expect(viewModel.showsOperationBusy)
+        #expect(viewModel.rowAccessibilityLabel.contains("Uninstalling"))
+    }
+
+    @Test func `update package clears upgrade busy latch and operation busy`() async {
+        var package = BrewPackage.fixture(name: "git", kind: .formula)
+        package.outdated = true
+        let center = PhaseSequenceCommandCenter(phases: [.running(.upgradeFormula), .idle])
+        let viewModel = InstalledListRowViewModel(package: package, brewCommandCenter: center)
+        await viewModel.observeRowUpdates()
+        #expect(viewModel.showsUpgradeBusy)
+        #expect(viewModel.showsOperationBusy)
+
+        let refreshedPackage = BrewPackage.fixture(name: "git", kind: .formula)
+        viewModel.update(package: refreshedPackage)
+
+        #expect(!viewModel.showsUpgradeBusy)
+        #expect(!viewModel.showsUninstallBusy)
+        #expect(!viewModel.showsOperationBusy)
+        #expect(!viewModel.rowAccessibilityLabel.contains("Upgrading"))
+    }
+
+    @Test func `update package clears uninstall busy latch and operation busy`() async {
+        let package = BrewPackage.fixture(name: "git", kind: .formula)
+        let center = PhaseSequenceCommandCenter(phases: [.running(.uninstallFormula), .idle])
+        let viewModel = InstalledListRowViewModel(package: package, brewCommandCenter: center)
+        await viewModel.observeRowUpdates()
+        #expect(viewModel.showsUninstallBusy)
+        #expect(viewModel.showsOperationBusy)
+
+        let refreshedPackage = BrewPackage.fixture(name: "git", kind: .formula, description: "Updated")
+        viewModel.update(package: refreshedPackage)
+
+        #expect(!viewModel.showsUpgradeBusy)
+        #expect(!viewModel.showsUninstallBusy)
+        #expect(!viewModel.showsOperationBusy)
+        #expect(!viewModel.rowAccessibilityLabel.contains("Uninstalling"))
     }
 
     @Test func `update package flips row version presentation when outdated changes`() {

--- a/BrewTests/InstalledUninstallBusyPresentationTests.swift
+++ b/BrewTests/InstalledUninstallBusyPresentationTests.swift
@@ -1,0 +1,74 @@
+//
+//  InstalledUninstallBusyPresentationTests.swift
+//  BrewTests
+//
+
+@testable import Brew
+import Foundation
+import Testing
+
+struct InstalledUninstallBusyPresentationTests {
+    @Test func `running uninstall phase shows busy`() {
+        #expect(
+            InstalledUninstallBusyPresentation.showsUninstallBusy(
+                oldPhase: .idle,
+                newPhase: .running(.uninstallFormula),
+            ),
+        )
+        #expect(
+            InstalledUninstallBusyPresentation.showsUninstallBusy(
+                oldPhase: .idle,
+                newPhase: .running(.uninstallCask),
+            ),
+        )
+    }
+
+    @Test func `running uninstall to idle latches busy`() {
+        #expect(
+            InstalledUninstallBusyPresentation.showsUninstallBusy(
+                oldPhase: .running(.uninstallFormula),
+                newPhase: .idle,
+            ),
+        )
+        #expect(
+            InstalledUninstallBusyPresentation.showsUninstallBusy(
+                oldPhase: .running(.uninstallCask),
+                newPhase: .idle,
+            ),
+        )
+    }
+
+    @Test func `running uninstall to failed clears busy`() {
+        let failure = OperationFailure(userFacingMessage: "uninstall failed")
+        #expect(
+            !InstalledUninstallBusyPresentation.showsUninstallBusy(
+                oldPhase: .running(.uninstallFormula),
+                newPhase: .failed(reason: failure),
+            ),
+        )
+    }
+
+    @Test func `idle to idle does not trigger busy`() {
+        #expect(
+            !InstalledUninstallBusyPresentation.showsUninstallBusy(
+                oldPhase: .idle,
+                newPhase: .idle,
+            ),
+        )
+    }
+
+    @Test func `upgrade running phase does not trigger uninstall busy`() {
+        #expect(
+            !InstalledUninstallBusyPresentation.showsUninstallBusy(
+                oldPhase: .idle,
+                newPhase: .running(.upgradeFormula),
+            ),
+        )
+        #expect(
+            !InstalledUninstallBusyPresentation.showsUninstallBusy(
+                oldPhase: .idle,
+                newPhase: .running(.upgradeCask),
+            ),
+        )
+    }
+}

--- a/BrewTests/InstalledUpgradeBusyPresentationTests.swift
+++ b/BrewTests/InstalledUpgradeBusyPresentationTests.swift
@@ -65,4 +65,21 @@ struct InstalledUpgradeBusyPresentationTests {
             ),
         )
     }
+
+    @Test func `running uninstall phase does not show upgrade busy`() {
+        #expect(
+            !InstalledUpgradeBusyPresentation.showsUpgradeBusy(
+                oldPhase: .idle,
+                newPhase: .running(.uninstallFormula),
+                isPackageOutdated: true,
+            ),
+        )
+        #expect(
+            !InstalledUpgradeBusyPresentation.showsUpgradeBusy(
+                oldPhase: .running(.uninstallCask),
+                newPhase: .idle,
+                isPackageOutdated: true,
+            ),
+        )
+    }
 }

--- a/BrewTests/PackageUninstallCommandTests.swift
+++ b/BrewTests/PackageUninstallCommandTests.swift
@@ -49,6 +49,19 @@ struct PackageUninstallCommandTests {
             try await PackageUninstallCommand(package: package).run(in: ctx)
         }
     }
+
+    @Test func `kind and name initializer matches uninstall argv`() async throws {
+        let runner = CapturingUninstallCommandRunner()
+        let brewURL = URL(fileURLWithPath: "/opt/homebrew/bin/brew")
+        let ctx = BrewCommandExecutionContext(
+            commandRunner: runner,
+            locator: BrewExecutableLocator(overrideURL: brewURL),
+        )
+
+        try await PackageUninstallCommand(kind: .formula, name: "wget").run(in: ctx)
+        #expect(await runner.lastExecutable == brewURL)
+        #expect(await runner.lastArguments == ["uninstall", "--formula", "wget"])
+    }
 }
 
 private actor CapturingUninstallCommandRunner: BrewCommandRunning {

--- a/BrewTests/PackageUninstallCommandTests.swift
+++ b/BrewTests/PackageUninstallCommandTests.swift
@@ -1,0 +1,68 @@
+//
+//  PackageUninstallCommandTests.swift
+//  BrewTests
+//
+
+@testable import Brew
+import Foundation
+import Testing
+
+struct PackageUninstallCommandTests {
+    @Test func `formula run invokes brew uninstall formula name`() async throws {
+        let runner = CapturingUninstallCommandRunner()
+        let brewURL = URL(fileURLWithPath: "/opt/homebrew/bin/brew")
+        let ctx = BrewCommandExecutionContext(
+            commandRunner: runner,
+            locator: BrewExecutableLocator(overrideURL: brewURL),
+        )
+        let package = BrewPackage.fixture(name: "git", kind: .formula)
+        try await PackageUninstallCommand(package: package).run(in: ctx)
+
+        #expect(await runner.lastExecutable == brewURL)
+        #expect(await runner.lastArguments == ["uninstall", "--formula", "git"])
+    }
+
+    @Test func `cask run invokes brew uninstall cask name`() async throws {
+        let runner = CapturingUninstallCommandRunner()
+        let brewURL = URL(fileURLWithPath: "/usr/local/bin/brew")
+        let ctx = BrewCommandExecutionContext(
+            commandRunner: runner,
+            locator: BrewExecutableLocator(overrideURL: brewURL),
+        )
+        let package = BrewPackage.fixture(name: "Slack", kind: .cask)
+        try await PackageUninstallCommand(package: package).run(in: ctx)
+
+        #expect(await runner.lastArguments == ["uninstall", "--cask", "Slack"])
+    }
+
+    @Test func `nonzero exit throws BrewCommandError`() async {
+        let runner = CapturingUninstallCommandRunner()
+        await runner.setOutput(
+            CommandOutput(standardOutput: "", standardError: "blocked", terminationStatus: 1),
+        )
+        let ctx = BrewCommandExecutionContext(
+            commandRunner: runner,
+            locator: BrewExecutableLocator(overrideURL: URL(fileURLWithPath: "/opt/homebrew/bin/brew")),
+        )
+        let package = BrewPackage.fixture(name: "x", kind: .formula)
+        await #expect(throws: BrewCommandError.self) {
+            try await PackageUninstallCommand(package: package).run(in: ctx)
+        }
+    }
+}
+
+private actor CapturingUninstallCommandRunner: BrewCommandRunning {
+    private(set) var lastExecutable: URL?
+    private(set) var lastArguments: [String]?
+    private var output = CommandOutput(standardOutput: "", standardError: "", terminationStatus: 0)
+
+    func setOutput(_ output: CommandOutput) {
+        self.output = output
+    }
+
+    func run(executableURL: URL, arguments: [String]) async throws -> CommandOutput {
+        lastExecutable = executableURL
+        lastArguments = arguments
+        return output
+    }
+}

--- a/BrewTests/UninstallPackageItemTests.swift
+++ b/BrewTests/UninstallPackageItemTests.swift
@@ -1,0 +1,26 @@
+//
+//  UninstallPackageItemTests.swift
+//  BrewTests
+//
+
+@testable import Brew
+import Testing
+
+struct UninstallPackageItemTests {
+    @Test func `display command uses formula uninstall flag`() {
+        let item = UninstallPackageItem(package: .fixture(name: "wget", kind: .formula))
+        #expect(item.displayCommand == "brew uninstall --formula wget")
+    }
+
+    @Test func `display command uses cask uninstall flag`() {
+        let item = UninstallPackageItem(package: .fixture(name: "docker", kind: .cask))
+        #expect(item.displayCommand == "brew uninstall --cask docker")
+    }
+
+    @Test func `confirmation copy uses package name`() {
+        let item = UninstallPackageItem(package: .fixture(name: "wget", kind: .formula))
+        #expect(item.primaryButtonTitle == "Uninstall")
+        #expect(item.confirmationTitle == "Uninstall wget?")
+        #expect(item.confirmationMessage == "This will remove wget from this Mac using Homebrew.")
+    }
+}

--- a/BrewTests/UninstallPackageItemTests.swift
+++ b/BrewTests/UninstallPackageItemTests.swift
@@ -43,6 +43,21 @@ struct UninstallPackageItemTests {
         )
     }
 
+    @Test func `blocked accessibility hint and callout content`() {
+        let item = UninstallPackageItem(
+            package: .fixture(name: "ada-url", kind: .formula),
+            blockingDependentCount: 2,
+        )
+        #expect(
+            item.blockedPrimaryButtonAccessibilityHint ==
+                "Blocked by installed dependents. Activate to see why.",
+        )
+        #expect(item.blockedCalloutContent == UninstallBlockedCalloutContent(
+            lead: "Can't uninstall yet.",
+            body: "2 packages above depend on ada-url. Uninstall them first.",
+        ))
+    }
+
     @Test func `blocked copy uses plural grammar for multiple dependents`() {
         let item = UninstallPackageItem(
             package: .fixture(name: "ada-url", kind: .formula),

--- a/BrewTests/UninstallPackageItemTests.swift
+++ b/BrewTests/UninstallPackageItemTests.swift
@@ -23,4 +23,37 @@ struct UninstallPackageItemTests {
         #expect(item.confirmationTitle == "Uninstall wget?")
         #expect(item.confirmationMessage == "This will remove wget from this Mac using Homebrew.")
     }
+
+    @Test func `blocked copy is nil without dependents`() {
+        let item = UninstallPackageItem(package: .fixture(name: "ada-url", kind: .formula))
+        #expect(!item.isBlockedByDependents)
+        #expect(item.usedByBlockingBadgeTitle == nil)
+        #expect(item.uninstallBlockedBannerLead == nil)
+        #expect(item.uninstallBlockedBannerBody == nil)
+    }
+
+    @Test func `blocked copy uses singular grammar for one dependent`() {
+        let item = UninstallPackageItem(
+            package: .fixture(name: "ada-url", kind: .formula),
+            blockingDependentCount: 1,
+        )
+        #expect(
+            item.uninstallBlockedBannerBody ==
+                "1 package above depends on ada-url. Uninstall it first.",
+        )
+    }
+
+    @Test func `blocked copy uses plural grammar for multiple dependents`() {
+        let item = UninstallPackageItem(
+            package: .fixture(name: "ada-url", kind: .formula),
+            blockingDependentCount: 3,
+        )
+        #expect(item.isBlockedByDependents)
+        #expect(item.usedByBlockingBadgeTitle == "blocking uninstall")
+        #expect(item.uninstallBlockedBannerLead == "Can't uninstall yet.")
+        #expect(
+            item.uninstallBlockedBannerBody ==
+                "3 packages above depend on ada-url. Uninstall them first.",
+        )
+    }
 }

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -40,6 +40,8 @@ UI in `Brew/` uses **semantic tokens** under [`Brew/Theme/`](Brew/Theme/) (`Brew
 
 **MVVM boundary:** Keep views as passive as practical. Put view-facing UI policy, derived flags, and decision/branching logic in ViewModels (for example, split/detail visibility booleans and action-routing decisions). Views should primarily bind/render and forward actions. Keep view-layer branching limited to simple presentation branches (for example, loading/error/empty content blocks) and avoid embedding cross-state decision trees in views. Add unit tests for non-trivial ViewModel-derived UI state.
 
+**Domain-to-presentation mapping boundary:** Do not add UI-facing presentation properties/extensions directly on domain model types. Map domain models into presentation in one of two places only: (1) feature ViewModels for top-level surfaces, or (2) feature `*Item` types for subview/action-specific presentation data.
+
 **Root view dependency ownership:** When a feature defines a `*Root` view wrapper, the root is the dependency-composition boundary for that surface. Root views must read app-level dependencies (for example `@Environment` values), construct and inject content-view dependencies, and own view-model lifecycle boundaries. Content views must focus on rendering and behavior and must not acquire those app-level dependencies directly when a root exists.
 
 **Anti-pattern to avoid:** Do not make a content view model optional only to work around dependency acquisition inside the content view. Keep dependency resolution in the root and inject non-optional dependencies into the content view.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -40,6 +40,8 @@ UI in `Brew/` uses **semantic tokens** under [`Brew/Theme/`](Brew/Theme/) (`Brew
 
 **MVVM boundary:** Keep views as passive as practical. Put view-facing UI policy, derived flags, and decision/branching logic in ViewModels (for example, split/detail visibility booleans and action-routing decisions). Views should primarily bind/render and forward actions. Keep view-layer branching limited to simple presentation branches (for example, loading/error/empty content blocks) and avoid embedding cross-state decision trees in views. Add unit tests for non-trivial ViewModel-derived UI state.
 
+**Passive view enforcement:** A view must not compose multiple ViewModel booleans (or other raw state primitives) inline to derive a single UI concern. If a UI element has one presentation state (for example, showing one spinner), expose one ViewModel property for that state and bind directly to it.
+
 **Domain-to-presentation mapping boundary:** Do not add UI-facing presentation properties/extensions directly on domain model types. Map domain models into presentation in one of two places only: (1) feature ViewModels for top-level surfaces, or (2) feature `*Item` types for subview/action-specific presentation data.
 
 **Root view dependency ownership:** When a feature defines a `*Root` view wrapper, the root is the dependency-composition boundary for that surface. Root views must read app-level dependencies (for example `@Environment` values), construct and inject content-view dependencies, and own view-model lifecycle boundaries. Content views must focus on rendering and behavior and must not acquire those app-level dependencies directly when a root exists.


### PR DESCRIPTION
# PR: Add package uninstall to the Installed detail

## Summary

Adds an Uninstall affordance to the Installed package detail view. Covers the full flow: confirmation dialog, `brew uninstall` execution, inline error on failure, and a "blocked by dependents" state that explains why removal isn't possible yet rather than silently disabling the button.

## Changes

- **`PackageUninstallCommand`** — new `BrewMutatingCommand` that runs `brew uninstall --formula/--cask`.
- **`UninstallPackageItem`** — presentation model owning all copy and state logic for the uninstall section (button title, confirmation copy, blocked callout, "Used by" badge, display command).
- **`InstalledDetailsViewModel`** — wired up uninstall state, confirmation/blocked callout toggles, and `handleUninstallPrimaryButtonTapped()`. Relationship fetch consolidated into a single `refreshRelationships()` call.
- **`InstalledPackageDetailView`** — uninstall chrome added to the detail footer; info command item removed to keep the view focused on mutable actions.
- **`InstalledUninstallBusyPresentation`** — keeps the list row spinner visible until the catalog refresh propagates after uninstall, matching the existing upgrade busy behaviour.
- **Layout** — nudged installed list and detail column min/ideal widths to feel more comfortable at default sizes.
- **Conventions/rules** — added `temporal-cohesion` and `test-visibility` Cursor rules; updated `CONVENTIONS.md` and `ARCHITECTURE.md` accordingly.

## Testing

- [x] `xcodebuild test -scheme Brew` — all tests pass (new: `PackageUninstallCommandTests`, `UninstallPackageItemTests`, `InstalledUninstallBusyPresentationTests`, plus extended ViewModel and row tests).
- [x] `mint run swiftformat --lint .` and `mint run swiftlint lint --strict` — clean.
- [x] Manual: uninstall happy path, blocked-by-dependents path, and inline error all verified in a running build.

## PR checklist

- [x] Have you followed this repository's contribution and workflow guidance?
- [x] Have you explained what changed and why this should land now?
- [x] Have you run relevant local checks for the changed scope?
- [x] Are changes scoped and free of unrelated modifications?

-----

- [x] AI was used to generate or assist with generating this PR.
- [x] If yes, describe exactly how AI was used and what manual verification was performed.

  **AI use:** Almost everything on this branch was produced with Cursor using Claude and Codex — implementation, tests, Cursor rules, and this PR description. Manual work was the odd tweak plus reviewing every generated change, validating the three main flows in a running build, and running the quality gates above before opening.

-----

## Follow-ups (optional)

- `brew uninstall --ignore-dependencies` is deliberately out of scope; the blocked state guides the user to remove dependents first.
