### PR TITLE
Use correct display names

### DIFF
--- a/.ai/memory.md
+++ b/.ai/memory.md
@@ -318,3 +318,12 @@
   - formula: `full_name` (fallback `name`)
   - cask: first `name` entry (fallback `token`)
 - `HomebrewPackageReference` remains identity-first (`.formula(name:)` / `.cask(token:)`) and still uses canonical values for `packageID`; dependency-only contexts may continue showing token/name when richer metadata is not present.
+
+## 2026-05-18 — PR descriptions location preference
+
+- User preference: place generated PR descriptions in `.ai/scratchpad.md` by default.
+
+## 2026-05-18 — PR description project skill
+
+- Added project skill at `.cursor/skills/pr-description-to-scratchpad/SKILL.md`.
+- Skill contract: build PR bodies from `main...HEAD`, follow `.github/PULL_REQUEST_TEMPLATE.md`, and append to `.ai/scratchpad.md`.

--- a/.ai/memory.md
+++ b/.ai/memory.md
@@ -310,3 +310,11 @@
 - Previews should consume centralized support types (`AppPreviewSupport`, preview fakes) instead of defining one-off inline mock services/repositories per view.
 - Preview blocks are colocated at the bottom of their view files; standalone `+Previews.swift` files for those views were removed.
 - Enforcement guidance is documented in `CONVENTIONS.md` and `.cursor/rules/previews-centralized.mdc` (linked from `swift-implementation.mdc`).
+
+## 2026-05-18 — Package display labels vs canonical IDs
+
+- `BrewPackage` now carries `displayName` for UI labels while keeping `name` as the canonical Homebrew identifier used for IDs and CLI commands.
+- Installed mapping from `brew info --json=v2` now uses richer display fields with fallback:
+  - formula: `full_name` (fallback `name`)
+  - cask: first `name` entry (fallback `token`)
+- `HomebrewPackageReference` remains identity-first (`.formula(name:)` / `.cask(token:)`) and still uses canonical values for `packageID`; dependency-only contexts may continue showing token/name when richer metadata is not present.

--- a/.cursor/skills/pr-description-to-scratchpad/SKILL.md
+++ b/.cursor/skills/pr-description-to-scratchpad/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: pr-description-to-scratchpad
+description: Generates a pull request description from the current branch diff against its base, formats it using .github/PULL_REQUEST_TEMPLATE.md, and appends the final PR body to .ai/scratchpad.md. Use when the user asks for a PR description, PR body, pull request write-up, or asks to use the PR template/scratchpad workflow.
+disable-model-invocation: true
+---
+
+# PR Description To Scratchpad
+
+## Purpose
+
+Create a complete PR description using:
+
+- `.github/PULL_REQUEST_TEMPLATE.md` as the structure.
+- Branch diff from base (`main...HEAD`) as the source of truth.
+- `.ai/scratchpad.md` as the default output location.
+
+## Workflow
+
+1. Determine the current branch and compare scope against `main`.
+   - Use:
+     - `git rev-parse --abbrev-ref HEAD`
+     - `git log --oneline --no-merges main...HEAD`
+     - `git diff --stat main...HEAD`
+     - `git diff --name-only main...HEAD`
+
+2. Read `.github/PULL_REQUEST_TEMPLATE.md`.
+
+3. Draft the PR body from the template:
+   - Fill all major sections (`Summary`, `Changes`, `Testing`, `PR checklist`, AI disclosure).
+   - Keep the content grounded in actual branch changes.
+   - If tests/checks were run, list exact commands.
+   - If unknown, use unchecked checklist items or explicit TODO wording.
+
+4. AI disclosure rule:
+   - Assume AI was used for most changes unless the user says otherwise.
+   - Include a concise note on manual verification/editing performed.
+
+5. Write output to `.ai/scratchpad.md`:
+   - Append under heading: `## PR body (<branch-name> branch)`.
+   - Do not overwrite existing scratchpad content.
+   - Keep the generated section self-contained and copy-paste ready.
+
+6. Return to the user:
+   - Confirm the PR body was appended to `.ai/scratchpad.md`.
+   - Provide the same PR body in chat unless the user asks for file-only output.
+
+## Style Constraints
+
+- Be concise, concrete, and reviewer-friendly.
+- Do not invent issue links, checks, or behaviors.
+- Keep terminology consistent with repository naming.

--- a/Brew/Features/Installed/ViewModels/InstalledListRowViewModel.swift
+++ b/Brew/Features/Installed/ViewModels/InstalledListRowViewModel.swift
@@ -25,7 +25,7 @@ final class InstalledListRowViewModel {
     }
 
     var name: String {
-        package.name
+        package.displayName
     }
 
     var kind: InstalledPackageKind {

--- a/Brew/Features/Installed/ViewModels/InstalledPackageDetailViewModel.swift
+++ b/Brew/Features/Installed/ViewModels/InstalledPackageDetailViewModel.swift
@@ -35,7 +35,7 @@ final class InstalledPackageDetailViewModel {
     var showUninstallBlockedCallout: Bool = false
 
     var packageName: String {
-        package.name
+        package.displayName
     }
 
     var packageKind: InstalledPackageKind {

--- a/Brew/Features/Installed/ViewModels/PackageRelationshipItem.swift
+++ b/Brew/Features/Installed/ViewModels/PackageRelationshipItem.swift
@@ -37,7 +37,7 @@ extension PackageRelationshipItem {
 
     static func dependent(_ package: BrewPackage) -> PackageRelationshipItem {
         PackageRelationshipItem(
-            displayName: package.name,
+            displayName: package.displayName,
             packageKind: package.kind,
             targetPackageID: package.id,
             installedPackageID: package.id,

--- a/Brew/Features/Installed/Views/InstalledPackagesView.swift
+++ b/Brew/Features/Installed/Views/InstalledPackagesView.swift
@@ -131,6 +131,7 @@ struct InstalledPackagesView: View {
         [
             BrewPackage(
                 name: "Placeholder Formula",
+                displayName: "Placeholder Formula",
                 kind: .formula,
                 description: "Placeholder description text for loading row.",
                 homepage: "",
@@ -141,6 +142,7 @@ struct InstalledPackagesView: View {
             ),
             BrewPackage(
                 name: "Placeholder Formula",
+                displayName: "Placeholder Formula",
                 kind: .formula,
                 description: "Placeholder description text for loading row.",
                 homepage: "",
@@ -151,6 +153,7 @@ struct InstalledPackagesView: View {
             ),
             BrewPackage(
                 name: "Placeholder Formula",
+                displayName: "Placeholder Formula",
                 kind: .formula,
                 description: "Placeholder description text for loading row.",
                 homepage: "",

--- a/Brew/Models/BrewPackage.swift
+++ b/Brew/Models/BrewPackage.swift
@@ -7,6 +7,7 @@ import Foundation
 
 struct BrewPackage: Identifiable, Hashable {
     let name: String
+    let displayName: String
     let kind: HomebrewPackageKind
     var description: String
     var homepage: String

--- a/Brew/PreviewSupport/AppPreviewSupport.swift
+++ b/Brew/PreviewSupport/AppPreviewSupport.swift
@@ -11,6 +11,7 @@ enum AppPreviewSupport {
 
     static let outdatedFormula = BrewPackage(
         name: "git",
+        displayName: "git",
         kind: .formula,
         description: "Distributed revision control system.",
         homepage: "https://git-scm.com",
@@ -22,6 +23,7 @@ enum AppPreviewSupport {
 
     static let currentFormula = BrewPackage(
         name: "node",
+        displayName: "node",
         kind: .formula,
         description: "JavaScript runtime built on V8.",
         homepage: "https://nodejs.org",
@@ -33,6 +35,7 @@ enum AppPreviewSupport {
 
     static let currentCask = BrewPackage(
         name: "docker",
+        displayName: "Docker",
         kind: .cask,
         description: "Build and share containerized applications.",
         homepage: "https://www.docker.com",
@@ -47,6 +50,7 @@ enum AppPreviewSupport {
         currentFormula,
         BrewPackage(
             name: "python",
+            displayName: "python",
             kind: .formula,
             description: "Interpreted, interactive, object-oriented programming language.",
             homepage: "https://www.python.org",
@@ -57,6 +61,7 @@ enum AppPreviewSupport {
         ),
         BrewPackage(
             name: "visual-studio-code",
+            displayName: "Visual Studio Code",
             kind: .cask,
             description: "Open-source code editor.",
             homepage: "https://code.visualstudio.com",
@@ -74,6 +79,7 @@ enum AppPreviewSupport {
         outdatedFormula.id: [
             BrewPackage(
                 name: "gh",
+                displayName: "gh",
                 kind: .formula,
                 description: "GitHub's official command line tool.",
                 homepage: "https://cli.github.com",

--- a/Brew/Services/BrewCommand/JSON/BrewInfoJSON+Mapping.swift
+++ b/Brew/Services/BrewCommand/JSON/BrewInfoJSON+Mapping.swift
@@ -25,6 +25,7 @@ private extension BrewInfoFormula {
         let runtimeDependencies = dependencies
         return BrewPackage(
             name: name,
+            displayName: BrewInfoJSON.trimmedOrNil(fullName) ?? name,
             kind: .formula,
             description: BrewInfoJSON.trimmedOrEmpty(desc),
             homepage: BrewInfoJSON.trimmedOrEmpty(homepage),
@@ -42,6 +43,7 @@ private extension BrewInfoCask {
         let latest = BrewInfoJSON.trimmedOrNil(versions.stable) ?? BrewInfoJSON.trimmedOrNil(version) ?? ""
         return BrewPackage(
             name: token,
+            displayName: BrewInfoJSON.trimmedOrNil(firstDisplayName) ?? token,
             kind: .cask,
             description: BrewInfoJSON.trimmedOrEmpty(desc),
             homepage: BrewInfoJSON.trimmedOrEmpty(homepage),

--- a/Brew/Services/BrewCommand/JSON/BrewInfoJSON.swift
+++ b/Brew/Services/BrewCommand/JSON/BrewInfoJSON.swift
@@ -24,6 +24,7 @@ struct BrewInfoJSON: Decodable {
 
 struct BrewInfoFormula: Decodable {
     var name: String
+    var fullName: String?
     var desc: String?
     var homepage: String?
     var dependencies: [String]
@@ -37,6 +38,7 @@ struct BrewInfoFormula: Decodable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         name = (try? container.decode(String.self, forKey: .name)) ?? ""
+        fullName = try? container.decode(String.self, forKey: .fullName)
         desc = try? container.decode(String.self, forKey: .desc)
         homepage = try? container.decode(String.self, forKey: .homepage)
         dependencies = container.decodeStringArray(forKey: .dependencies)
@@ -52,6 +54,7 @@ struct BrewInfoFormula: Decodable {
 
     private enum CodingKeys: String, CodingKey {
         case name
+        case fullName = "full_name"
         case desc
         case homepage
         case dependencies
@@ -74,6 +77,7 @@ struct BrewInfoFormulaInstalled: Decodable {
 
 struct BrewInfoCask: Decodable {
     var token: String
+    var names: [String]
     var desc: String?
     var homepage: String?
     /// Tap / current cask version string (upgrade target analogue to formula `versions.stable`).
@@ -87,6 +91,7 @@ struct BrewInfoCask: Decodable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         token = (try? container.decode(String.self, forKey: .token)) ?? ""
+        names = container.decodeStringArrayOrSingle(forKey: .name)
         desc = try? container.decode(String.self, forKey: .desc)
         homepage = try? container.decode(String.self, forKey: .homepage)
         version = try? container.decode(String.self, forKey: .version)
@@ -101,6 +106,7 @@ struct BrewInfoCask: Decodable {
 
     private enum CodingKeys: String, CodingKey {
         case token
+        case name
         case desc
         case homepage
         case version
@@ -109,6 +115,10 @@ struct BrewInfoCask: Decodable {
         case dependencies
         case dependsOn = "depends_on"
         case outdated
+    }
+
+    var firstDisplayName: String? {
+        names.first
     }
 }
 
@@ -129,6 +139,16 @@ private extension KeyedDecodingContainer {
         }
         if let values = try? decode([String].self, forKey: key) {
             return values.filter { !$0.isEmpty }
+        }
+        return []
+    }
+
+    func decodeStringArrayOrSingle(forKey key: Key) -> [String] {
+        if let values = try? decode([String].self, forKey: key) {
+            return values.filter { !$0.isEmpty }
+        }
+        if let value = try? decode(String.self, forKey: key), !value.isEmpty {
+            return [value]
         }
         return []
     }

--- a/BrewTests/BrewInstalledPackagesRepositoryTests.swift
+++ b/BrewTests/BrewInstalledPackagesRepositoryTests.swift
@@ -12,11 +12,16 @@ struct BrewInstalledPackagesRepositoryTests {
         let json = """
         {
           "formulae": [
-            { "name": "wget", "versions": { "stable": "1.0.0" }, "installed": [{ "version": "1.24.5" }] },
+            {
+              "name": "wget",
+              "full_name": "homebrew/core/wget",
+              "versions": { "stable": "1.0.0" },
+              "installed": [{ "version": "1.24.5" }]
+            },
             { "name": "aria2", "versions": { "stable": "2.0.0" }, "installed": [] }
           ],
           "casks": [
-            { "token": "zed", "version": "1.2.3", "installed": "1.2.4" }
+            { "token": "zed", "name": ["Zed"], "version": "1.2.3", "installed": "1.2.4" }
           ]
         }
         """
@@ -30,11 +35,16 @@ struct BrewInstalledPackagesRepositoryTests {
 
         let aria2 = try #require(package(named: "aria2", in: packages))
         #expect(aria2.kind == .formula)
+        #expect(aria2.displayName == "aria2")
         #expect(aria2.latestVersion == "2.0.0")
         #expect(aria2.installedVersions.isEmpty)
 
+        let wget = try #require(package(named: "wget", in: packages))
+        #expect(wget.displayName == "homebrew/core/wget")
+
         let zed = try #require(package(named: "zed", in: packages))
         #expect(zed.kind == .cask)
+        #expect(zed.displayName == "Zed")
         #expect(zed.latestVersion == "1.2.3")
         #expect(zed.installedVersions == ["1.2.4"])
     }
@@ -260,4 +270,35 @@ struct BrewInstalledPackagesRepositoryTests {
 @MainActor
 private func package(named name: String, in packages: [BrewPackage]) -> BrewPackage? {
     packages.first { $0.name == name }
+}
+
+extension BrewInstalledPackagesRepositoryTests {
+    @Test @MainActor
+    func `load falls back to canonical names when display fields are missing or invalid`() async throws {
+        let json = """
+        {
+          "formulae": [
+            { "name": "wget", "full_name": "   ", "installed": [{ "version": "1.24.5" }] }
+          ],
+          "casks": [
+            { "token": "visual-studio-code", "name": [], "installed": "1.99.0" },
+            { "token": "docker", "name": "Docker", "installed": "4.39.0" }
+          ]
+        }
+        """
+        let runner = MockBrewCommandRunner(
+            responses: InstalledPackagesTestSupport.installedInfoJSONResponse(standardOutput: json),
+        )
+        let repo = InstalledPackagesTestSupport.repository(commandRunner: runner)
+        let packages = try await repo.loadInstalledPackages()
+
+        let wget = try #require(package(named: "wget", in: packages))
+        #expect(wget.displayName == "wget")
+
+        let vscode = try #require(package(named: "visual-studio-code", in: packages))
+        #expect(vscode.displayName == "visual-studio-code")
+
+        let docker = try #require(package(named: "docker", in: packages))
+        #expect(docker.displayName == "Docker")
+    }
 }

--- a/BrewTests/InstalledDetailsViewModelTests.swift
+++ b/BrewTests/InstalledDetailsViewModelTests.swift
@@ -8,6 +8,14 @@ import Foundation
 import Testing
 
 struct InstalledDetailsViewModelTests {
+    @Test @MainActor func `packageName uses package display name`() {
+        let viewModel = makeInstalledDetailsViewModel(
+            package: .fixture(name: "visual-studio-code", displayName: "Visual Studio Code", kind: .cask),
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
+        )
+        #expect(viewModel.packageName == "Visual Studio Code")
+    }
+
     @Test @MainActor func `homepageURL returns valid http URL from package`() {
         var loadedDetails = details(name: "wget")
         loadedDetails.homepage = "https://example.com"

--- a/BrewTests/InstalledDetailsViewModelTestsSupport.swift
+++ b/BrewTests/InstalledDetailsViewModelTestsSupport.swift
@@ -244,6 +244,7 @@ func details(
 ) -> BrewPackage {
     BrewPackage(
         name: name,
+        displayName: name,
         kind: kind,
         description: "desc",
         homepage: "",

--- a/BrewTests/InstalledListRowViewModelTests.swift
+++ b/BrewTests/InstalledListRowViewModelTests.swift
@@ -9,6 +9,15 @@ import Testing
 
 @MainActor
 struct InstalledListRowViewModelTests {
+    @Test func `name uses package display name`() {
+        let package = BrewPackage.fixture(name: "visual-studio-code", displayName: "Visual Studio Code", kind: .cask)
+        let viewModel = InstalledListRowViewModel(
+            package: package,
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
+        )
+        #expect(viewModel.name == "Visual Studio Code")
+    }
+
     @Test func `observeRowUpdates applies first phase from noop center`() async {
         let package = BrewPackage.fixture(name: "git", kind: .formula)
         let center = NoopBrewCommandCenter.forTesting()

--- a/BrewTests/PackageRelationshipItemTests.swift
+++ b/BrewTests/PackageRelationshipItemTests.swift
@@ -46,13 +46,15 @@ struct PackageRelationshipItemTests {
     }
 
     @Test @MainActor func `dependent and dependents always mark installed`() {
-        let package = BrewPackage.fixture(name: "curl", kind: .formula)
+        let package = BrewPackage.fixture(name: "curl", displayName: "cURL", kind: .formula)
         let dependent = PackageRelationshipItem.dependent(package)
         let dependents = PackageRelationshipItem.dependents([package])
 
+        #expect(dependent.displayName == "cURL")
         #expect(dependent.installedPackageID == package.id)
         #expect(dependent.isInstalledInInventory)
         #expect(dependents.count == 1)
+        #expect(dependents[0].displayName == "cURL")
         #expect(dependents[0].id == package.id)
     }
 }

--- a/BrewTests/TestSupport/BrewPackageFixtures.swift
+++ b/BrewTests/TestSupport/BrewPackageFixtures.swift
@@ -3,6 +3,7 @@
 extension BrewPackage {
     static func fixture(
         name: String = "git",
+        displayName: String? = nil,
         kind: HomebrewPackageKind = .formula,
         description: String = "",
         homepage: String = "",
@@ -13,6 +14,7 @@ extension BrewPackage {
     ) -> BrewPackage {
         BrewPackage(
             name: name,
+            displayName: displayName ?? name,
             kind: kind,
             description: description,
             homepage: homepage,


### PR DESCRIPTION
# PR: Use display names for package UI labels

## Summary

This PR introduces a domain-level `displayName` for `BrewPackage` so Installed UI surfaces can show richer package labels without changing canonical Homebrew identifiers used for IDs and command execution. It maps display labels from `brew info --json=v2` (`full_name` for formulae, `name[0]` for casks) with safe fallbacks.

## Changes

- Added `displayName` to `BrewPackage` while preserving `name`/`id` identity semantics.
- Extended resilient JSON decoding:
  - `BrewInfoFormula` decodes optional `full_name`.
  - `BrewInfoCask` decodes `name` as string-or-array and exposes first display label.
- Updated mapping in `BrewInfoJSON+Mapping`:
  - Formula `displayName = trimmed(full_name) ?? name`
  - Cask `displayName = firstTrimmedName ?? token`
- Updated Installed presentation to render `displayName` where available:
  - list row title/accessibility (`InstalledListRowViewModel`)
  - detail title (`InstalledPackageDetailViewModel`)
  - dependent relationship labels (`PackageRelationshipItem`)
- Kept canonical command/ID paths unchanged (`package.name`, `HomebrewPackageReference` identity contract).
- Updated previews, fixtures, and tests for new `displayName` behavior and fallback coverage.

## Why this split (optional)

This is scoped as a display-layer enhancement only: richer labels in UI, no behavioral change to operation identity or CLI command targeting.

## Testing

- [x] `mint run swiftformat --lint .`
- [x] `mint run swiftlint lint --strict`
- [x] `xcodebuild -scheme Brew -destination 'platform=macOS' -only-testing:BrewTests/BrewInstalledPackagesRepositoryTests -only-testing:BrewTests/InstalledListRowViewModelTests -only-testing:BrewTests/InstalledDetailsViewModelTests -only-testing:BrewTests/PackageRelationshipItemTests test`

## PR checklist

- [x] Have you followed this repository's contribution and workflow guidance?
- [x] Have you explained what changed and why this should land now?
- [x] Have you run relevant local checks for the changed scope?
- [x] Are changes scoped and free of unrelated modifications?

-----

- [x] AI was used to generate or assist with generating this PR.
- [x] If yes, describe exactly how AI was used and what manual verification was performed.
  AI drafted and applied most code/test edits for the display-name mapping and Installed UI presentation updates. Manual tweaks were made to test structure/line-length cleanup and final wording. Manual verification included reviewing touched files, re-running format/lint, and running the targeted unit test suite listed above.