### PR TITLE
Discover data layer

### DIFF
--- a/.ai/memory.md
+++ b/.ai/memory.md
@@ -399,3 +399,11 @@
   - cold start (no cache) blocks on refresh and surfaces errors;
   - `304` updates only last-refresh timestamp;
   - background refresh failures are swallowed.
+
+## 2026-05-19 — Transport models must not cross repo/service APIs
+
+- `CatalogueRepository` now maps cached/network catalogue transport payloads to domain `BrewPackage` arrays before returning.
+- Durable rule: `Codable` transport types (`*JSON`, DTO/wire models) must stay behind service/repository boundaries and not appear in service/repository protocol return types.
+- Enforcement/docs:
+  - Added `CONVENTIONS.md` note under **Transport boundary**.
+  - Added `.cursor/rules/codable-boundary.mdc` (always apply) and linked guidance in `.cursor/rules/swift-implementation.mdc`.

--- a/.ai/memory.md
+++ b/.ai/memory.md
@@ -384,3 +384,18 @@
 
 - Catalogue transport decoding (`FormulaCatalogueJSON` / `CaskCatalogueJSON`) now treats `desc`, `homepage`, `versions.stable`, and `analytics.install["30d"]` as required fields.
 - Catalogue array decoding is now lossy per item: invalid entries are skipped, and decode failures are captured with item index + error string so callers can handle partial failures without dropping valid items.
+
+## 2026-05-19 — Catalogue cache + repository split
+
+- Split catalogue responsibilities into two boundaries:
+  - `CatalogueCache` actor owns only in-memory state, disk persistence, and ETag storage.
+  - `BrewCatalogueRepository` owns TTL, stale-while-revalidate policy, refresh orchestration, and in-flight task deduplication.
+- `CatalogueCache` currently preloads cache on async init:
+  - `init(...) async` loads formula/cask cache files immediately (missing/corrupt files are swallowed);
+  - read/write methods operate on preloaded in-memory state (no separate warm-up method).
+- `BrewCatalogueRepository` behavior:
+  - one refresh `Task` per catalogue kind is shared across concurrent callers;
+  - stale cached data returns immediately while background refresh runs;
+  - cold start (no cache) blocks on refresh and surfaces errors;
+  - `304` updates only last-refresh timestamp;
+  - background refresh failures are swallowed.

--- a/.ai/memory.md
+++ b/.ai/memory.md
@@ -407,3 +407,17 @@
 - Enforcement/docs:
   - Added `CONVENTIONS.md` note under **Transport boundary**.
   - Added `.cursor/rules/codable-boundary.mdc` (always apply) and linked guidance in `.cursor/rules/swift-implementation.mdc`.
+
+## 2026-05-19 — Installed model split (`InstalledBrewPackage` vs `BrewPackage`)
+
+- Installed-only state moved out of shared package domain:
+  - `InstalledBrewPackage` composes a `BrewPackage` (`package`) plus `installedVersions` and `outdated`.
+  - Public fields shared with `BrewPackage` are exposed as wrapper properties; identity (`id`, `reference`) derives from `package`.
+  - `BrewPackage` is slim/shared for catalogue/discover-prep fields only.
+- Boundary rule:
+  - installed repositories/inventory/graph/view-model surfaces use `InstalledBrewPackage`,
+  - catalogue repository surfaces remain `[BrewPackage]` and must not reintroduce installed-only fields.
+- Command/convenience identity behavior remains stable via `kind:name` IDs:
+  - `BrewOperationID(package:)` now takes `InstalledBrewPackage`,
+  - `HomebrewPackageReference` gained `init(installedPackage:)` (delegates to `init(package:)`),
+  - package ID/reference semantics remain canonical and unchanged.

--- a/.ai/memory.md
+++ b/.ai/memory.md
@@ -34,7 +34,7 @@
 
 - **Sandboxing:** App is unsandboxed. No entitlements needed for subprocess execution.
 - **Homebrew detection:** Check `/opt/homebrew/bin/brew` (Apple Silicon) then `/usr/local/bin/brew` (Intel). Degrade gracefully if neither found.
-- **JSON API schema drift:** Handle via optional decoding — never crash on unknown fields.
+- **JSON API schema drift:** Prefer tolerant handling for unknown fields; required-field policy is endpoint-specific (see 2026-05-18 strict catalogue decoding entry).
 
 ## 2026-03-11 — Developer Hook Workflow
 
@@ -379,3 +379,8 @@
 - Installed search still filters on canonical `BrewPackage.name` rather than `displayName`.
 - User requested this remain unchanged for now and be revisited during discovery search work.
 - Keep this as an explicit follow-up so label-search behavior can be aligned intentionally later.
+
+## 2026-05-18 — Catalogue decode strictness
+
+- Catalogue transport decoding (`FormulaCatalogueJSON` / `CaskCatalogueJSON`) now treats `desc`, `homepage`, `versions.stable`, and `analytics.install["30d"]` as required fields.
+- Catalogue array decoding is now lossy per item: invalid entries are skipped, and decode failures are captured with item index + error string so callers can handle partial failures without dropping valid items.

--- a/.ai/memory.md
+++ b/.ai/memory.md
@@ -327,3 +327,55 @@
 
 - Added project skill at `.cursor/skills/pr-description-to-scratchpad/SKILL.md`.
 - Skill contract: build PR bodies from `main...HEAD`, follow `.github/PULL_REQUEST_TEMPLATE.md`, and append to `.ai/scratchpad.md`.
+
+## 2026-05-18 — Discover analytics data-access slice
+
+- Added a dedicated Homebrew analytics network boundary:
+  - `BrewAPIClient` protocol + `URLSessionBrewAPIClient` in `Brew/Services/BrewAPIClient.swift`.
+  - Endpoint-specific APIs for Discover:
+    - `fetchFormulaInstallOnRequestAnalytics(window:)`
+    - `fetchCaskInstallAnalytics(window:)`
+- Added resilient analytics decoding model `BrewAnalyticsJSON`:
+  - tolerant top-level decode with `formulae`/`casks` bucket fallback
+  - count parsing supports both numeric and comma-separated string forms
+  - normalized `BrewAnalyticsPackageCount` output for repository mapping
+- Added `DiscoverPackagesRepository` + `BrewDiscoverPackagesRepository` returning one combined `DiscoverTopPackagesSnapshot` (`topFormulae` + `topCasks`) with limit/window parameters (defaults: top 10, 30d).
+
+## 2026-05-18 — Package-domain lookup identity rule
+
+- Package-domain representations should expose `HomebrewPackageReference` as their lookup identity (formulae map to `.formula(name:)`, casks map to `.cask(token:)`).
+- `BrewPackage` now exposes `reference` again as a computed property from `kind` + `name`.
+- Discover models now carry typed references:
+  - `BrewAnalyticsPackageCount.reference`
+  - `DiscoverTopPackage.reference`
+- Added `.cursor/rules/package-domain-reference.mdc` and mirrored the rule in `CONVENTIONS.md` to keep the requirement persistent for future domain models.
+
+## 2026-05-18 — URLSessionProtocol testing seam for API client
+
+- Added `URLSessionProtocol` (`data(for:)`) in `Brew/Services/URLSessionProtocol.swift` with `URLSession` conformance.
+- `URLSessionBrewAPIClient` now supports dependency injection via `init(session: any URLSessionProtocol, ...)`, enabling deterministic unit tests with a mock session implementation instead of closure-only stubbing.
+
+## 2026-05-18 — Discover analytics strict decoding policy
+
+- Discover analytics decoding now fails fast for required non-optional fields rather than defaulting to empty/zero values.
+- `BrewAnalyticsJSON` requires valid `category`, `total_items`, `total_count`, `start_date`, `end_date`, and at least one analytics bucket container (`formulae` or `casks`).
+- Malformed per-entry `count` values now throw during decode (no fallback `0`), and unresolved package references are treated as decode failures instead of being silently filtered out.
+
+## 2026-05-18 — Discover analytics decoder simplification
+
+- Simplified `BrewAnalyticsJSON` strict decoder by removing fallback identity inference:
+  - no fallback from bucket key
+  - no fallback from `category` inferred kind
+- Analytics rows now require explicit identity in payload (`formula` xor `cask`), which keeps failure behavior deterministic when server payloads are incomplete/ambiguous.
+
+## 2026-05-18 — API client tests use URLProtocol stubs
+
+- Replaced `URLSessionProtocol` abstraction tests with integration-style tests that use a real `URLSession` configured with `URLProtocol` stubbing.
+- `URLSessionBrewAPIClient` session init now takes concrete `URLSession`.
+- `BrewAPIClientTests` use host-scoped stub queues/recording in `StubURLProtocol` to keep tests deterministic under concurrent execution.
+
+## 2026-05-18 — Deferred Installed search adaptation
+
+- Installed search still filters on canonical `BrewPackage.name` rather than `displayName`.
+- User requested this remain unchanged for now and be revisited during discovery search work.
+- Keep this as an explicit follow-up so label-search behavior can be aligned intentionally later.

--- a/.cursor/rules/codable-boundary.mdc
+++ b/.cursor/rules/codable-boundary.mdc
@@ -1,0 +1,11 @@
+---
+description: Keep Codable transport models behind service/repository boundaries.
+alwaysApply: true
+---
+
+# Codable Boundary
+
+- Do not return `Codable` transport payload types (`*JSON`, DTOs, wire models) from service or repository APIs.
+- Decode transport payloads at the boundary, then map to app-facing contracts before returning.
+- Service and repository protocols should expose domain models (`Models/`) or explicit feature-layer data contracts only.
+- Keep transport model placement under infrastructure boundaries (for example `Services/API/`), not `Models/`.

--- a/.cursor/rules/package-domain-reference.mdc
+++ b/.cursor/rules/package-domain-reference.mdc
@@ -1,0 +1,12 @@
+---
+description: Package domain model lookup identity.
+globs:
+  - Brew/Models/**/*.swift
+alwaysApply: false
+---
+
+# Package Domain Reference
+
+- Any domain model that represents a Homebrew package must expose a `HomebrewPackageReference` property for lookup identity.
+- Use `.formula(name:)` for formula-backed models and `.cask(token:)` for cask-backed models.
+- Prefer deriving `name`/display fields from `HomebrewPackageReference.displayName` where practical to avoid duplicate identity sources.

--- a/.cursor/rules/swift-implementation.mdc
+++ b/.cursor/rules/swift-implementation.mdc
@@ -6,6 +6,7 @@ alwaysApply: false
 # Swift Implementation
 
 - Follow `CONVENTIONS.md` for naming, architecture boundaries, error handling, and **design system** (`Brew/Theme/` — see `design-system.mdc` when editing `Brew/**/*.swift`).
+- Keep `Codable` transport models behind boundaries; do not expose `*JSON`/DTO wire types from service or repository APIs (see `codable-boundary.mdc`).
 - Include required imports and provide compilable code updates.
 - Use `@MainActor` where UI state is mutated.
 - Avoid force unwraps/`try!`; use safe handling patterns and test helpers (`#require`, `XCTUnwrap`) in tests.

--- a/Brew/BrewApp.swift
+++ b/Brew/BrewApp.swift
@@ -11,9 +11,11 @@ import SwiftUI
 struct BrewApp: App {
     private let commandCenter: SerialBrewCommandCenter
     private let installedInventoryCache: InstalledInventoryCache
+    private let catalogueCache: CatalogueCache
 
     init() {
         installedInventoryCache = InstalledInventoryCache()
+        catalogueCache = CatalogueCache()
         commandCenter = SerialBrewCommandCenter(executionContext: .live())
     }
 
@@ -22,6 +24,8 @@ struct BrewApp: App {
             MainWindowView()
                 .environment(\.brewCommandCenter, commandCenter)
                 .environment(\.installedInventoryCache, installedInventoryCache)
+                .environment(\.catalogueCache, catalogueCache)
+                .task { await catalogueCache.prepare() }
         }
         .defaultSize(
             width: BrewLayout.minWindowWidth,

--- a/Brew/Features/Installed/ViewModels/InstalledListRowViewModel.swift
+++ b/Brew/Features/Installed/ViewModels/InstalledListRowViewModel.swift
@@ -14,7 +14,7 @@ enum InstalledListRowVersionPresentation: Equatable {
 @Observable
 @MainActor
 final class InstalledListRowViewModel {
-    private(set) var package: BrewPackage
+    private(set) var package: InstalledBrewPackage
     private var operationPhase: BrewOperationPhase = .idle
     private(set) var showsUpgradeBusy: Bool = false
     private(set) var showsUninstallBusy: Bool = false
@@ -94,12 +94,12 @@ final class InstalledListRowViewModel {
         return accessibilitySummary
     }
 
-    init(package: BrewPackage, brewCommandCenter: BrewCommandCenter) {
+    init(package: InstalledBrewPackage, brewCommandCenter: BrewCommandCenter) {
         self.package = package
         self.brewCommandCenter = brewCommandCenter
     }
 
-    func update(package newPackage: BrewPackage) {
+    func update(package newPackage: InstalledBrewPackage) {
         guard newPackage != package else {
             return
         }

--- a/Brew/Features/Installed/ViewModels/InstalledPackageDetailViewModel.swift
+++ b/Brew/Features/Installed/ViewModels/InstalledPackageDetailViewModel.swift
@@ -14,7 +14,7 @@ final class InstalledPackageDetailViewModel {
     private let installedInventoryReading: any InstalledInventoryReading
     private var mutationTask: Task<Void, Never>?
 
-    private(set) var package: BrewPackage
+    private(set) var package: InstalledBrewPackage
     /// Latest phase from the command center stream (see ``observeRowUpdates()``); drives mutation chrome.
     private var operationPhase: BrewOperationPhase = .idle
     /// Inline message when upgrade fails; cleared when a new upgrade starts.
@@ -86,7 +86,7 @@ final class InstalledPackageDetailViewModel {
     }
 
     init(
-        package: BrewPackage,
+        package: InstalledBrewPackage,
         brewCommandCenter: any BrewCommandCenter,
         installedDependentsRepository: any InstalledDependentsRepository,
         installedInventoryReading: any InstalledInventoryReading,
@@ -120,7 +120,7 @@ final class InstalledPackageDetailViewModel {
     }
 
     /// Syncs snapshot data for this row (`InstalledListRowViewModel/update(package:)` pattern).
-    func update(package newPackage: BrewPackage) {
+    func update(package newPackage: InstalledBrewPackage) {
         guard newPackage != package else {
             return
         }

--- a/Brew/Features/Installed/ViewModels/InstalledViewModel.swift
+++ b/Brew/Features/Installed/ViewModels/InstalledViewModel.swift
@@ -8,7 +8,7 @@ import Observation
 import OSLog
 
 struct InstalledPackagesContent: Equatable {
-    var packages: [BrewPackage]
+    var packages: [InstalledBrewPackage]
 
     var shouldShowFormulaeSection: Bool {
         !formulaPackages.isEmpty
@@ -18,11 +18,11 @@ struct InstalledPackagesContent: Equatable {
         !caskPackages.isEmpty
     }
 
-    var formulaPackages: [BrewPackage] {
+    var formulaPackages: [InstalledBrewPackage] {
         packages.filter { $0.kind == .formula }
     }
 
-    var caskPackages: [BrewPackage] {
+    var caskPackages: [InstalledBrewPackage] {
         packages.filter { $0.kind == .cask }
     }
 }
@@ -53,8 +53,8 @@ final class InstalledViewModel {
     private var observerTask: Task<Void, Never>?
 
     private var loadedContent: InstalledPackagesContent?
-    private var preSearchSelectedPackageID: BrewPackage.ID?
-    private var searchPreviewSelectedPackageID: BrewPackage.ID?
+    private var preSearchSelectedPackageID: InstalledBrewPackage.ID?
+    private var searchPreviewSelectedPackageID: InstalledBrewPackage.ID?
     private var didCommitSelectionDuringSearch = false
     private(set) var state: InstalledLoadState = .loading
     var searchQuery: String = "" {
@@ -65,10 +65,10 @@ final class InstalledViewModel {
         }
     }
 
-    private var selectedPackageID: BrewPackage.ID?
+    private var selectedPackageID: InstalledBrewPackage.ID?
     var isSearchSelected: Bool = false
 
-    var activeSelectedPackageID: BrewPackage.ID? {
+    var activeSelectedPackageID: InstalledBrewPackage.ID? {
         searchPreviewSelectedPackageID ?? selectedPackageID
     }
 
@@ -94,7 +94,7 @@ final class InstalledViewModel {
         return "\(totalPackageCount) packages"
     }
 
-    var selectedPackage: BrewPackage? {
+    var selectedPackage: InstalledBrewPackage? {
         allRows.first(where: { $0.id == activeSelectedPackageID })
     }
 
@@ -156,7 +156,7 @@ final class InstalledViewModel {
         }
     }
 
-    func setSelection(_ selection: BrewPackage.ID?) {
+    func setSelection(_ selection: InstalledBrewPackage.ID?) {
         if isSearchActive {
             didCommitSelectionDuringSearch = true
             searchPreviewSelectedPackageID = nil
@@ -173,7 +173,7 @@ final class InstalledViewModel {
         searchPreviewSelectedPackageID = nil
     }
 
-    func selectInstalledPackage(id: BrewPackage.ID) {
+    func selectInstalledPackage(id: InstalledBrewPackage.ID) {
         guard allRows.contains(where: { $0.id == id }) else {
             return
         }
@@ -184,7 +184,7 @@ final class InstalledViewModel {
         !Self.normalizedSearchQuery(searchQuery).isEmpty
     }
 
-    private var allRows: [BrewPackage] {
+    private var allRows: [InstalledBrewPackage] {
         guard case let .loaded(content) = state else {
             return []
         }
@@ -245,7 +245,7 @@ final class InstalledViewModel {
         }
     }
 
-    private func firstVisibleRowID() -> BrewPackage.ID? {
+    private func firstVisibleRowID() -> InstalledBrewPackage.ID? {
         allRows.first?.id
     }
 
@@ -273,7 +273,7 @@ final class InstalledViewModel {
         query.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    private static func packagesContent(from snapshot: [BrewPackage]) -> InstalledPackagesContent {
+    private static func packagesContent(from snapshot: [InstalledBrewPackage]) -> InstalledPackagesContent {
         InstalledPackagesContent(packages: snapshot)
     }
 

--- a/Brew/Features/Installed/ViewModels/PackageDetailMetadataItem.swift
+++ b/Brew/Features/Installed/ViewModels/PackageDetailMetadataItem.swift
@@ -7,9 +7,9 @@ import Foundation
 
 /// Presentation mapping for Installed detail metadata content.
 struct PackageDetailMetadataItem {
-    private let package: BrewPackage
+    private let package: InstalledBrewPackage
 
-    init(package: BrewPackage) {
+    init(package: InstalledBrewPackage) {
         self.package = package
     }
 

--- a/Brew/Features/Installed/ViewModels/PackageRelationshipItem.swift
+++ b/Brew/Features/Installed/ViewModels/PackageRelationshipItem.swift
@@ -9,8 +9,8 @@ import Foundation
 struct PackageRelationshipItem: Identifiable, Hashable {
     let displayName: String
     let packageKind: HomebrewPackageKind
-    let targetPackageID: BrewPackage.ID
-    let installedPackageID: BrewPackage.ID?
+    let targetPackageID: InstalledBrewPackage.ID
+    let installedPackageID: InstalledBrewPackage.ID?
 
     var id: String {
         installedPackageID ?? "relationship:\(targetPackageID)"
@@ -25,7 +25,7 @@ struct PackageRelationshipItem: Identifiable, Hashable {
 extension PackageRelationshipItem {
     static func dependency(
         _ reference: HomebrewPackageReference,
-        installedPackageIDs: Set<BrewPackage.ID>,
+        installedPackageIDs: Set<InstalledBrewPackage.ID>,
     ) -> PackageRelationshipItem {
         PackageRelationshipItem(
             displayName: reference.name,
@@ -35,7 +35,7 @@ extension PackageRelationshipItem {
         )
     }
 
-    static func dependent(_ package: BrewPackage) -> PackageRelationshipItem {
+    static func dependent(_ package: InstalledBrewPackage) -> PackageRelationshipItem {
         PackageRelationshipItem(
             displayName: package.displayName,
             packageKind: package.kind,
@@ -46,12 +46,12 @@ extension PackageRelationshipItem {
 
     static func dependencies(
         _ references: [HomebrewPackageReference],
-        installedPackageIDs: Set<BrewPackage.ID>,
+        installedPackageIDs: Set<InstalledBrewPackage.ID>,
     ) -> [PackageRelationshipItem] {
         references.map { dependency($0, installedPackageIDs: installedPackageIDs) }
     }
 
-    static func dependents(_ packages: [BrewPackage]) -> [PackageRelationshipItem] {
+    static func dependents(_ packages: [InstalledBrewPackage]) -> [PackageRelationshipItem] {
         packages.map(dependent)
     }
 }

--- a/Brew/Features/Installed/ViewModels/PackageRelationshipItem.swift
+++ b/Brew/Features/Installed/ViewModels/PackageRelationshipItem.swift
@@ -28,7 +28,7 @@ extension PackageRelationshipItem {
         installedPackageIDs: Set<BrewPackage.ID>,
     ) -> PackageRelationshipItem {
         PackageRelationshipItem(
-            displayName: reference.displayName,
+            displayName: reference.name,
             packageKind: reference.kind,
             targetPackageID: reference.packageID,
             installedPackageID: installedPackageIDs.contains(reference.packageID) ? reference.packageID : nil,

--- a/Brew/Features/Installed/ViewModels/UninstallPackageItem.swift
+++ b/Brew/Features/Installed/ViewModels/UninstallPackageItem.swift
@@ -7,10 +7,10 @@ import Foundation
 
 /// Presentation mapping for uninstall actions shown in Installed package detail subviews.
 struct UninstallPackageItem {
-    private let package: BrewPackage
+    private let package: InstalledBrewPackage
     private let blockingDependentCount: Int
 
-    init(package: BrewPackage, blockingDependentCount: Int = 0) {
+    init(package: InstalledBrewPackage, blockingDependentCount: Int = 0) {
         self.package = package
         self.blockingDependentCount = max(0, blockingDependentCount)
     }

--- a/Brew/Features/Installed/ViewModels/UpgradePackageItem.swift
+++ b/Brew/Features/Installed/ViewModels/UpgradePackageItem.swift
@@ -7,9 +7,9 @@ import Foundation
 
 /// Presentation mapping for upgrade actions shown in Installed package detail.
 struct UpgradePackageItem {
-    private let package: BrewPackage
+    private let package: InstalledBrewPackage
 
-    init(package: BrewPackage) {
+    init(package: InstalledBrewPackage) {
         self.package = package
     }
 

--- a/Brew/Features/Installed/Views/InstalledListRowView.swift
+++ b/Brew/Features/Installed/Views/InstalledListRowView.swift
@@ -7,7 +7,7 @@ import SwiftUI
 
 /// Owns ``InstalledListRowViewModel`` for one row and runs ``InstalledListRowViewModel/observeRowUpdates()`` while the row is on screen.
 struct InstalledListRowRoot: View {
-    let package: BrewPackage
+    let package: InstalledBrewPackage
     @Environment(\.brewCommandCenter) private var brewCommandCenter
 
     var body: some View {
@@ -20,10 +20,10 @@ struct InstalledListRowRoot: View {
 }
 
 struct InstalledListRowView: View {
-    let package: BrewPackage
+    let package: InstalledBrewPackage
     @State private var viewModel: InstalledListRowViewModel
 
-    init(package: BrewPackage, brewCommandCenter: BrewCommandCenter) {
+    init(package: InstalledBrewPackage, brewCommandCenter: BrewCommandCenter) {
         _viewModel = State(
             initialValue: InstalledListRowViewModel(
                 package: package,

--- a/Brew/Features/Installed/Views/InstalledPackageDetailSubviewSections.swift
+++ b/Brew/Features/Installed/Views/InstalledPackageDetailSubviewSections.swift
@@ -126,7 +126,7 @@ struct InstalledPackageDetailMetadataSection: View {
 struct InstalledPackageDetailUsedBySection: View {
     let viewModel: InstalledPackageDetailViewModel
     let collapsedRelationshipCount: Int
-    let onSelectInstalledPackage: (BrewPackage.ID) -> Void
+    let onSelectInstalledPackage: (InstalledBrewPackage.ID) -> Void
     @Binding var isExpanded: Bool
 
     var body: some View {
@@ -193,7 +193,7 @@ struct InstalledPackageDetailRelationshipList: View {
     let relationships: [PackageRelationshipItem]
     let dotStyle: PackageRelationshipDotStyle
     let collapsedRelationshipCount: Int
-    let onSelectInstalledPackage: (BrewPackage.ID) -> Void
+    let onSelectInstalledPackage: (InstalledBrewPackage.ID) -> Void
     let showsHeading: Bool
     @Binding var isExpanded: Bool
 
@@ -204,7 +204,7 @@ struct InstalledPackageDetailRelationshipList: View {
         isExpanded: Binding<Bool>,
         showsHeading: Bool = true,
         collapsedRelationshipCount: Int,
-        onSelectInstalledPackage: @escaping (BrewPackage.ID) -> Void,
+        onSelectInstalledPackage: @escaping (InstalledBrewPackage.ID) -> Void,
     ) {
         self.title = title
         self.relationships = relationships

--- a/Brew/Features/Installed/Views/InstalledPackageDetailView.swift
+++ b/Brew/Features/Installed/Views/InstalledPackageDetailView.swift
@@ -8,8 +8,8 @@ import SwiftUI
 
 /// Root view for the selected row; detail content reads ``EnvironmentValues/brewCommandCenter`` and builds relationship repositories from ``EnvironmentValues/installedInventoryCache``.
 struct InstalledPackageDetailRoot: View {
-    let selectedPackage: BrewPackage
-    let onSelectInstalledPackage: (BrewPackage.ID) -> Void
+    let selectedPackage: InstalledBrewPackage
+    let onSelectInstalledPackage: (InstalledBrewPackage.ID) -> Void
     @Environment(\.brewCommandCenter) private var brewCommandCenter
     @Environment(\.installedInventoryCache) private var installedInventoryCache
 
@@ -26,8 +26,8 @@ struct InstalledPackageDetailRoot: View {
 
 /// Right-hand column: detail for the selected installed package.
 struct InstalledPackageDetailView: View {
-    let package: BrewPackage
-    let onSelectInstalledPackage: (BrewPackage.ID) -> Void
+    let package: InstalledBrewPackage
+    let onSelectInstalledPackage: (InstalledBrewPackage.ID) -> Void
     @State private var viewModel: InstalledPackageDetailViewModel
     @State private var expandedDependencies = false
     @State private var expandedDependents = false
@@ -35,11 +35,11 @@ struct InstalledPackageDetailView: View {
     private let collapsedRelationshipCount = 3
 
     init(
-        package: BrewPackage,
+        package: InstalledBrewPackage,
         brewCommandCenter: BrewCommandCenter,
         installedDependentsRepository: any InstalledDependentsRepository,
         installedInventoryReading: any InstalledInventoryReading,
-        onSelectInstalledPackage: @escaping (BrewPackage.ID) -> Void = { _ in },
+        onSelectInstalledPackage: @escaping (InstalledBrewPackage.ID) -> Void = { _ in },
     ) {
         self.package = package
         self.onSelectInstalledPackage = onSelectInstalledPackage

--- a/Brew/Features/Installed/Views/InstalledPackagesView.swift
+++ b/Brew/Features/Installed/Views/InstalledPackagesView.swift
@@ -94,12 +94,12 @@ struct InstalledPackagesView: View {
         }
     }
 
-    private func listRow(for package: BrewPackage) -> some View {
+    private func listRow(for package: InstalledBrewPackage) -> some View {
         InstalledListRowRoot(package: package)
     }
 
     private func scrollToSelection(
-        _ selectedID: BrewPackage.ID?,
+        _ selectedID: InstalledBrewPackage.ID?,
         in content: InstalledPackagesContent,
         with proxy: ScrollViewProxy,
     ) {
@@ -127,39 +127,45 @@ struct InstalledPackagesView: View {
         .accessibilityLabel("Loading package list")
     }
 
-    private var loadingFormulaeRows: [BrewPackage] {
+    private var loadingFormulaeRows: [InstalledBrewPackage] {
         [
-            BrewPackage(
-                name: "Placeholder Formula",
-                displayName: "Placeholder Formula",
-                kind: .formula,
-                description: "Placeholder description text for loading row.",
-                homepage: "",
-                latestVersion: "0.0.0",
+            InstalledBrewPackage(
+                package: BrewPackage(
+                    name: "Placeholder Formula",
+                    displayName: "Placeholder Formula",
+                    kind: .formula,
+                    description: "Placeholder description text for loading row.",
+                    homepage: "",
+                    latestVersion: "0.0.0",
+                    dependencies: [],
+                ),
                 installedVersions: ["0.0.0"],
-                dependencies: [],
                 outdated: false,
             ),
-            BrewPackage(
-                name: "Placeholder Formula",
-                displayName: "Placeholder Formula",
-                kind: .formula,
-                description: "Placeholder description text for loading row.",
-                homepage: "",
-                latestVersion: "0.0.0",
+            InstalledBrewPackage(
+                package: BrewPackage(
+                    name: "Placeholder Formula",
+                    displayName: "Placeholder Formula",
+                    kind: .formula,
+                    description: "Placeholder description text for loading row.",
+                    homepage: "",
+                    latestVersion: "0.0.0",
+                    dependencies: [],
+                ),
                 installedVersions: ["0.0.0"],
-                dependencies: [],
                 outdated: false,
             ),
-            BrewPackage(
-                name: "Placeholder Formula",
-                displayName: "Placeholder Formula",
-                kind: .formula,
-                description: "Placeholder description text for loading row.",
-                homepage: "",
-                latestVersion: "0.0.0",
+            InstalledBrewPackage(
+                package: BrewPackage(
+                    name: "Placeholder Formula",
+                    displayName: "Placeholder Formula",
+                    kind: .formula,
+                    description: "Placeholder description text for loading row.",
+                    homepage: "",
+                    latestVersion: "0.0.0",
+                    dependencies: [],
+                ),
                 installedVersions: ["0.0.0"],
-                dependencies: [],
                 outdated: false,
             ),
         ]

--- a/Brew/Models/BrewAnalyticsJSON.swift
+++ b/Brew/Models/BrewAnalyticsJSON.swift
@@ -1,0 +1,168 @@
+//
+//  BrewAnalyticsJSON.swift
+//  Brew
+//
+
+import Foundation
+
+/// Supported Homebrew analytics windows used by Discover.
+enum BrewAnalyticsWindow: String, CaseIterable {
+    case days30 = "30d"
+    case days90 = "90d"
+    case days365 = "365d"
+}
+
+/// Strict schema for Homebrew analytics API responses.
+struct BrewAnalyticsJSON: Decodable {
+    let category: String
+    let totalItems: Int
+    let totalCount: Int
+    let startDate: String
+    let endDate: String
+    private let parsedPackageCounts: [BrewAnalyticsPackageCount]
+
+    var packageCounts: [BrewAnalyticsPackageCount] {
+        parsedPackageCounts
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        category = try container.decodeNonEmptyString(forKey: .category)
+        totalItems = try container.decodeRequiredIntLossy(forKey: .totalItems)
+        totalCount = try container.decodeRequiredIntLossy(forKey: .totalCount)
+        startDate = try container.decodeNonEmptyString(forKey: .startDate)
+        endDate = try container.decodeNonEmptyString(forKey: .endDate)
+
+        let packageBuckets: [String: [BrewAnalyticsEntry]]
+        if container.contains(.formulae) {
+            packageBuckets = try container.decode([String: [BrewAnalyticsEntry]].self, forKey: .formulae)
+        } else if container.contains(.casks) {
+            packageBuckets = try container.decode([String: [BrewAnalyticsEntry]].self, forKey: .casks)
+        } else {
+            throw DecodingError.keyNotFound(
+                CodingKeys.formulae,
+                DecodingError.Context(
+                    codingPath: container.codingPath,
+                    debugDescription: "Expected formulae or casks analytics buckets.",
+                ),
+            )
+        }
+
+        parsedPackageCounts = try packageBuckets.map { bucketName, entries in
+            let normalizedBucket = bucketName.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let firstEntry = entries.first else {
+                throw DecodingError.dataCorrupted(
+                    DecodingError.Context(
+                        codingPath: container.codingPath,
+                        debugDescription: "Analytics bucket '\(normalizedBucket)' has no entries.",
+                    ),
+                )
+            }
+            let reference = try firstEntry.requiredReference(codingPath: container.codingPath)
+            return BrewAnalyticsPackageCount(reference: reference, count: firstEntry.count)
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case category
+        case totalItems = "total_items"
+        case totalCount = "total_count"
+        case startDate = "start_date"
+        case endDate = "end_date"
+        case formulae
+        case casks
+    }
+}
+
+struct BrewAnalyticsPackageCount: Hashable {
+    let reference: HomebrewPackageReference
+    let count: Int
+
+    var name: String {
+        reference.displayName
+    }
+}
+
+private struct BrewAnalyticsEntry: Decodable {
+    let formula: String?
+    let cask: String?
+    let count: Int
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        formula = try container.decodeIfPresent(String.self, forKey: .formula)
+        cask = try container.decodeIfPresent(String.self, forKey: .cask)
+        count = try container.decodeRequiredIntLossy(forKey: .count)
+    }
+
+    func requiredReference(codingPath: [CodingKey]) throws -> HomebrewPackageReference {
+        let formulaName = Self.trimmedOrNil(formula)
+        let caskToken = Self.trimmedOrNil(cask)
+
+        switch (formulaName, caskToken) {
+        case let (.some(name), nil):
+            return .formula(name: name)
+        case let (nil, .some(token)):
+            return .cask(token: token)
+        case (.none, .none):
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: codingPath,
+                    debugDescription: "Analytics entry must include formula or cask.",
+                ),
+            )
+        case (.some, .some):
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: codingPath,
+                    debugDescription: "Analytics entry cannot include both formula and cask.",
+                ),
+            )
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case formula
+        case cask
+        case count
+    }
+
+    private static func trimmedOrNil(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+}
+
+private extension KeyedDecodingContainer {
+    func decodeRequiredIntLossy(forKey key: Key) throws -> Int {
+        if let value = try? decode(Int.self, forKey: key) {
+            return value
+        }
+        if let stringValue = try? decode(String.self, forKey: key) {
+            let digitsOnly = stringValue.filter(\.isNumber)
+            if let parsedValue = Int(digitsOnly) {
+                return parsedValue
+            }
+        }
+        throw DecodingError.dataCorruptedError(
+            forKey: key,
+            in: self,
+            debugDescription: "Expected an integer-compatible analytics count.",
+        )
+    }
+
+    func decodeNonEmptyString(forKey key: Key) throws -> String {
+        let value = try decode(String.self, forKey: key)
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw DecodingError.dataCorruptedError(
+                forKey: key,
+                in: self,
+                debugDescription: "Expected non-empty string.",
+            )
+        }
+        return trimmed
+    }
+}

--- a/Brew/Models/BrewAnalyticsJSON.swift
+++ b/Brew/Models/BrewAnalyticsJSON.swift
@@ -79,7 +79,7 @@ struct BrewAnalyticsPackageCount: Hashable {
     let count: Int
 
     var name: String {
-        reference.displayName
+        reference.name
     }
 }
 

--- a/Brew/Models/BrewPackage.swift
+++ b/Brew/Models/BrewPackage.swift
@@ -12,9 +12,7 @@ struct BrewPackage: Identifiable, Hashable {
     var description: String
     var homepage: String
     var latestVersion: String
-    var installedVersions: [String]
     var dependencies: [HomebrewPackageReference]
-    var outdated: Bool
 
     var id: String {
         "\(kind.rawValue):\(name)"

--- a/Brew/Models/BrewPackage.swift
+++ b/Brew/Models/BrewPackage.swift
@@ -19,4 +19,8 @@ struct BrewPackage: Identifiable, Hashable {
     var id: String {
         "\(kind.rawValue):\(name)"
     }
+
+    var reference: HomebrewPackageReference {
+        HomebrewPackageReference(package: self)
+    }
 }

--- a/Brew/Models/DiscoverTopPackagesSnapshot.swift
+++ b/Brew/Models/DiscoverTopPackagesSnapshot.swift
@@ -1,0 +1,21 @@
+//
+//  DiscoverTopPackagesSnapshot.swift
+//  Brew
+//
+
+import Foundation
+
+/// Domain output for Discover top package sections.
+struct DiscoverTopPackagesSnapshot: Equatable {
+    let topFormulae: [DiscoverTopPackage]
+    let topCasks: [DiscoverTopPackage]
+}
+
+struct DiscoverTopPackage: Equatable, Hashable {
+    let reference: HomebrewPackageReference
+    let installCount: Int
+
+    var name: String {
+        reference.name
+    }
+}

--- a/Brew/Models/HomebrewPackageReference.swift
+++ b/Brew/Models/HomebrewPackageReference.swift
@@ -19,7 +19,7 @@ enum HomebrewPackageReference: Hashable {
         }
     }
 
-    var displayName: String {
+    var name: String {
         switch self {
         case let .formula(name):
             name

--- a/Brew/Models/HomebrewPackageReference.swift
+++ b/Brew/Models/HomebrewPackageReference.swift
@@ -45,6 +45,10 @@ enum HomebrewPackageReference: Hashable {
             self = .cask(token: package.name)
         }
     }
+
+    init(installedPackage: InstalledBrewPackage) {
+        self.init(package: installedPackage.package)
+    }
 }
 
 extension HomebrewPackageReference {

--- a/Brew/Models/InstalledBrewPackage.swift
+++ b/Brew/Models/InstalledBrewPackage.swift
@@ -1,0 +1,52 @@
+//
+//  InstalledBrewPackage.swift
+//  Brew
+//
+
+import Foundation
+
+struct InstalledBrewPackage: Identifiable, Hashable {
+    var package: BrewPackage
+    var installedVersions: [String]
+    var outdated: Bool
+
+    var name: String {
+        package.name
+    }
+
+    var displayName: String {
+        package.displayName
+    }
+
+    var kind: HomebrewPackageKind {
+        package.kind
+    }
+
+    var description: String {
+        get { package.description }
+        set { package.description = newValue }
+    }
+
+    var homepage: String {
+        get { package.homepage }
+        set { package.homepage = newValue }
+    }
+
+    var latestVersion: String {
+        get { package.latestVersion }
+        set { package.latestVersion = newValue }
+    }
+
+    var dependencies: [HomebrewPackageReference] {
+        get { package.dependencies }
+        set { package.dependencies = newValue }
+    }
+
+    var id: String {
+        package.id
+    }
+
+    var reference: HomebrewPackageReference {
+        HomebrewPackageReference(package: package)
+    }
+}

--- a/Brew/Models/PackageDependencyGraph.swift
+++ b/Brew/Models/PackageDependencyGraph.swift
@@ -7,12 +7,12 @@ import Foundation
 
 /// Reverse dependency lookups over one installed-inventory snapshot.
 struct PackageDependencyGraph: Equatable {
-    private let packagesByID: [BrewPackage.ID: BrewPackage]
-    private let dependentsByDependencyPackageID: [BrewPackage.ID: [BrewPackage.ID]]
+    private let packagesByID: [InstalledBrewPackage.ID: InstalledBrewPackage]
+    private let dependentsByDependencyPackageID: [InstalledBrewPackage.ID: [InstalledBrewPackage.ID]]
 
-    init(packages: [BrewPackage]) {
-        var byID: [BrewPackage.ID: BrewPackage] = [:]
-        var reverse: [BrewPackage.ID: [BrewPackage.ID]] = [:]
+    init(packages: [InstalledBrewPackage]) {
+        var byID: [InstalledBrewPackage.ID: InstalledBrewPackage] = [:]
+        var reverse: [InstalledBrewPackage.ID: [InstalledBrewPackage.ID]] = [:]
 
         for package in packages {
             byID[package.id] = package
@@ -25,7 +25,7 @@ struct PackageDependencyGraph: Equatable {
         dependentsByDependencyPackageID = reverse
     }
 
-    func installedDependents(for packageID: BrewPackage.ID) -> [BrewPackage] {
+    func installedDependents(for packageID: InstalledBrewPackage.ID) -> [InstalledBrewPackage] {
         (dependentsByDependencyPackageID[packageID] ?? [])
             .compactMap { packagesByID[$0] }
             .sorted {

--- a/Brew/PreviewSupport/AppPreviewSupport.swift
+++ b/Brew/PreviewSupport/AppPreviewSupport.swift
@@ -9,95 +9,107 @@ enum AppPreviewSupport {
     static let commandCenter = PreviewBrewCommandCenter()
     static let installedInventoryCache = InstalledInventoryCache()
 
-    static let outdatedFormula = BrewPackage(
-        name: "git",
-        displayName: "git",
-        kind: .formula,
-        description: "Distributed revision control system.",
-        homepage: "https://git-scm.com",
-        latestVersion: "2.46.1",
+    static let outdatedFormula = InstalledBrewPackage(
+        package: BrewPackage(
+            name: "git",
+            displayName: "git",
+            kind: .formula,
+            description: "Distributed revision control system.",
+            homepage: "https://git-scm.com",
+            latestVersion: "2.46.1",
+            dependencies: [.formula(name: "openssl@3"), .formula(name: "pcre2")],
+        ),
         installedVersions: ["2.45.0"],
-        dependencies: [.formula(name: "openssl@3"), .formula(name: "pcre2")],
         outdated: true,
     )
 
-    static let currentFormula = BrewPackage(
-        name: "node",
-        displayName: "node",
-        kind: .formula,
-        description: "JavaScript runtime built on V8.",
-        homepage: "https://nodejs.org",
-        latestVersion: "22.14.0",
+    static let currentFormula = InstalledBrewPackage(
+        package: BrewPackage(
+            name: "node",
+            displayName: "node",
+            kind: .formula,
+            description: "JavaScript runtime built on V8.",
+            homepage: "https://nodejs.org",
+            latestVersion: "22.14.0",
+            dependencies: [.formula(name: "icu4c@76")],
+        ),
         installedVersions: ["22.14.0"],
-        dependencies: [.formula(name: "icu4c@76")],
         outdated: false,
     )
 
-    static let currentCask = BrewPackage(
-        name: "docker",
-        displayName: "Docker",
-        kind: .cask,
-        description: "Build and share containerized applications.",
-        homepage: "https://www.docker.com",
-        latestVersion: "4.39.0",
+    static let currentCask = InstalledBrewPackage(
+        package: BrewPackage(
+            name: "docker",
+            displayName: "Docker",
+            kind: .cask,
+            description: "Build and share containerized applications.",
+            homepage: "https://www.docker.com",
+            latestVersion: "4.39.0",
+            dependencies: [],
+        ),
         installedVersions: ["4.39.0"],
-        dependencies: [],
         outdated: false,
     )
 
-    static let installedPackages: [BrewPackage] = [
+    static let installedPackages: [InstalledBrewPackage] = [
         outdatedFormula,
         currentFormula,
-        BrewPackage(
-            name: "python",
-            displayName: "python",
-            kind: .formula,
-            description: "Interpreted, interactive, object-oriented programming language.",
-            homepage: "https://www.python.org",
-            latestVersion: "3.13.2",
+        InstalledBrewPackage(
+            package: BrewPackage(
+                name: "python",
+                displayName: "python",
+                kind: .formula,
+                description: "Interpreted, interactive, object-oriented programming language.",
+                homepage: "https://www.python.org",
+                latestVersion: "3.13.2",
+                dependencies: [.formula(name: "openssl@3"), .formula(name: "sqlite")],
+            ),
             installedVersions: ["3.13.2"],
-            dependencies: [.formula(name: "openssl@3"), .formula(name: "sqlite")],
             outdated: false,
         ),
-        BrewPackage(
-            name: "visual-studio-code",
-            displayName: "Visual Studio Code",
-            kind: .cask,
-            description: "Open-source code editor.",
-            homepage: "https://code.visualstudio.com",
-            latestVersion: "1.99.0",
+        InstalledBrewPackage(
+            package: BrewPackage(
+                name: "visual-studio-code",
+                displayName: "Visual Studio Code",
+                kind: .cask,
+                description: "Open-source code editor.",
+                homepage: "https://code.visualstudio.com",
+                latestVersion: "1.99.0",
+                dependencies: [],
+            ),
             installedVersions: ["1.99.0"],
-            dependencies: [],
             outdated: false,
         ),
         currentCask,
     ]
 
-    static let emptyPackages: [BrewPackage] = []
+    static let emptyPackages: [InstalledBrewPackage] = []
 
-    static let installedDependentsByPackageID: [BrewPackage.ID: [BrewPackage]] = [
+    static let installedDependentsByPackageID: [InstalledBrewPackage.ID: [InstalledBrewPackage]] = [
         outdatedFormula.id: [
-            BrewPackage(
-                name: "gh",
-                displayName: "gh",
-                kind: .formula,
-                description: "GitHub's official command line tool.",
-                homepage: "https://cli.github.com",
-                latestVersion: "2.67.0",
+            InstalledBrewPackage(
+                package: BrewPackage(
+                    name: "gh",
+                    displayName: "gh",
+                    kind: .formula,
+                    description: "GitHub's official command line tool.",
+                    homepage: "https://cli.github.com",
+                    latestVersion: "2.67.0",
+                    dependencies: [.formula(name: "git")],
+                ),
                 installedVersions: ["2.67.0"],
-                dependencies: [.formula(name: "git")],
                 outdated: false,
             ),
         ],
     ]
 
-    static let installedInventoryIDs: Set<BrewPackage.ID> = Set(
+    static let installedInventoryIDs: Set<InstalledBrewPackage.ID> = Set(
         installedPackages.map(\.id) + ["formula:openssl@3", "formula:pcre2", "formula:icu4c@76"],
     )
 
     @MainActor
     static func makeInstalledViewModel(
-        packages: [BrewPackage] = installedPackages,
+        packages: [InstalledBrewPackage] = installedPackages,
         commandCenter: any BrewCommandCenter = commandCenter,
     ) -> InstalledViewModel {
         InstalledViewModel(
@@ -152,25 +164,25 @@ actor PreviewBrewCommandCenter: BrewCommandCenter {
 }
 
 struct PreviewInstalledPackagesRepository: InstalledPackagesRepository {
-    let packages: [BrewPackage]
+    let packages: [InstalledBrewPackage]
 
-    func loadInstalledPackages(forceRefresh _: Bool) async throws -> [BrewPackage] {
+    func loadInstalledPackages(forceRefresh _: Bool) async throws -> [InstalledBrewPackage] {
         packages
     }
 }
 
 struct PreviewInstalledDependentsRepository: InstalledDependentsRepository {
-    let dependentsByPackageID: [BrewPackage.ID: [BrewPackage]]
+    let dependentsByPackageID: [InstalledBrewPackage.ID: [InstalledBrewPackage]]
 
-    func installedDependents(for packageID: BrewPackage.ID) async -> [BrewPackage] {
+    func installedDependents(for packageID: InstalledBrewPackage.ID) async -> [InstalledBrewPackage] {
         dependentsByPackageID[packageID] ?? []
     }
 }
 
 struct PreviewInstalledInventoryReading: InstalledInventoryReading {
-    let knownInstalledPackageIDs: Set<BrewPackage.ID>
+    let knownInstalledPackageIDs: Set<InstalledBrewPackage.ID>
 
-    func installedPackageIDs() async -> Set<BrewPackage.ID> {
+    func installedPackageIDs() async -> Set<InstalledBrewPackage.ID> {
         knownInstalledPackageIDs
     }
 }

--- a/Brew/Repositories/BrewInstalledDependentsRepository.swift
+++ b/Brew/Repositories/BrewInstalledDependentsRepository.swift
@@ -12,7 +12,7 @@ struct BrewInstalledDependentsRepository: InstalledDependentsRepository {
         self.cache = cache
     }
 
-    func installedDependents(for packageID: BrewPackage.ID) async -> [BrewPackage] {
+    func installedDependents(for packageID: InstalledBrewPackage.ID) async -> [InstalledBrewPackage] {
         guard let snapshot = await cache.currentSnapshot() else {
             return []
         }

--- a/Brew/Repositories/BrewInstalledPackagesRepository.swift
+++ b/Brew/Repositories/BrewInstalledPackagesRepository.swift
@@ -29,7 +29,7 @@ struct BrewInstalledPackagesRepository: InstalledPackagesRepository, InstalledIn
         )
     }
 
-    func loadInstalledPackages(forceRefresh: Bool = false) async throws -> [BrewPackage] {
+    func loadInstalledPackages(forceRefresh: Bool = false) async throws -> [InstalledBrewPackage] {
         guard !forceRefresh else {
             return try await fetchInstalledPackages()
         }
@@ -42,14 +42,14 @@ struct BrewInstalledPackagesRepository: InstalledPackagesRepository, InstalledIn
         }
     }
 
-    func installedPackageIDs() async -> Set<BrewPackage.ID> {
+    func installedPackageIDs() async -> Set<InstalledBrewPackage.ID> {
         guard let snapshot = await cache.currentSnapshot() else {
             return []
         }
         return Set(snapshot.packages.map(\.id))
     }
 
-    private func fetchInstalledPackages() async throws -> [BrewPackage] {
+    private func fetchInstalledPackages() async throws -> [InstalledBrewPackage] {
         let brew = try locator.findBrewExecutable()
         let output = try await runInstalledInfoJSON(executable: brew)
         let payload = try decodeInfoJSON(from: output)

--- a/Brew/Repositories/CatalogueRepository.swift
+++ b/Brew/Repositories/CatalogueRepository.swift
@@ -36,7 +36,7 @@ final class BrewCatalogueRepository: CatalogueRepository {
     }
 
     private let apiClient: any BrewAPIClient
-    private let cache: CatalogueCache
+    private let cache: any CatalogueCaching
     private let userDefaults: UserDefaults
     private let now: @Sendable () -> Date
     private let ttl: TimeInterval
@@ -46,7 +46,7 @@ final class BrewCatalogueRepository: CatalogueRepository {
 
     init(
         apiClient: any BrewAPIClient,
-        cache: CatalogueCache,
+        cache: any CatalogueCaching,
         userDefaults: UserDefaults = .standard,
         now: @escaping @Sendable () -> Date = Date.init,
         ttl: TimeInterval = BrewCatalogueRepository.defaultTTL,
@@ -56,14 +56,6 @@ final class BrewCatalogueRepository: CatalogueRepository {
         self.userDefaults = userDefaults
         self.now = now
         self.ttl = ttl
-    }
-
-    static func live(
-        apiClient: any BrewAPIClient = URLSessionBrewAPIClient.live(),
-        userDefaults: UserDefaults = .standard,
-    ) async -> BrewCatalogueRepository {
-        let cache = await CatalogueCache()
-        return BrewCatalogueRepository(apiClient: apiClient, cache: cache, userDefaults: userDefaults)
     }
 
     func loadFormulaCatalogue(forceRefresh: Bool = false) async throws -> FormulaCatalogueJSON {

--- a/Brew/Repositories/CatalogueRepository.swift
+++ b/Brew/Repositories/CatalogueRepository.swift
@@ -7,16 +7,16 @@ import Foundation
 
 @MainActor
 protocol CatalogueRepository: Sendable {
-    func loadFormulaCatalogue(forceRefresh: Bool) async throws -> FormulaCatalogueJSON
-    func loadCaskCatalogue(forceRefresh: Bool) async throws -> CaskCatalogueJSON
+    func loadFormulaCatalogue(forceRefresh: Bool) async throws -> [BrewPackage]
+    func loadCaskCatalogue(forceRefresh: Bool) async throws -> [BrewPackage]
 }
 
 extension CatalogueRepository {
-    func loadFormulaCatalogue() async throws -> FormulaCatalogueJSON {
+    func loadFormulaCatalogue() async throws -> [BrewPackage] {
         try await loadFormulaCatalogue(forceRefresh: false)
     }
 
-    func loadCaskCatalogue() async throws -> CaskCatalogueJSON {
+    func loadCaskCatalogue() async throws -> [BrewPackage] {
         try await loadCaskCatalogue(forceRefresh: false)
     }
 }
@@ -41,8 +41,8 @@ final class BrewCatalogueRepository: CatalogueRepository {
     private let now: @Sendable () -> Date
     private let ttl: TimeInterval
 
-    private var formulaRefreshTask: Task<FormulaCatalogueJSON, Error>?
-    private var caskRefreshTask: Task<CaskCatalogueJSON, Error>?
+    private var formulaRefreshTask: Task<[BrewPackage], Error>?
+    private var caskRefreshTask: Task<[BrewPackage], Error>?
 
     init(
         apiClient: any BrewAPIClient,
@@ -58,7 +58,7 @@ final class BrewCatalogueRepository: CatalogueRepository {
         self.ttl = ttl
     }
 
-    func loadFormulaCatalogue(forceRefresh: Bool = false) async throws -> FormulaCatalogueJSON {
+    func loadFormulaCatalogue(forceRefresh: Bool = false) async throws -> [BrewPackage] {
         if forceRefresh {
             return try await refreshFormulaAwaitingSharedTask()
         }
@@ -67,13 +67,13 @@ final class BrewCatalogueRepository: CatalogueRepository {
             if isStale(kind: .formula) {
                 scheduleFormulaBackgroundRefreshIfNeeded()
             }
-            return cached
+            return mapFormulaPackages(from: cached)
         }
 
         return try await refreshFormulaAwaitingSharedTask()
     }
 
-    func loadCaskCatalogue(forceRefresh: Bool = false) async throws -> CaskCatalogueJSON {
+    func loadCaskCatalogue(forceRefresh: Bool = false) async throws -> [BrewPackage] {
         if forceRefresh {
             return try await refreshCaskAwaitingSharedTask()
         }
@@ -82,7 +82,7 @@ final class BrewCatalogueRepository: CatalogueRepository {
             if isStale(kind: .cask) {
                 scheduleCaskBackgroundRefreshIfNeeded()
             }
-            return cached
+            return mapCaskPackages(from: cached)
         }
 
         return try await refreshCaskAwaitingSharedTask()
@@ -102,7 +102,7 @@ final class BrewCatalogueRepository: CatalogueRepository {
         }
     }
 
-    private func refreshFormulaAwaitingSharedTask() async throws -> FormulaCatalogueJSON {
+    private func refreshFormulaAwaitingSharedTask() async throws -> [BrewPackage] {
         if let existingTask = formulaRefreshTask {
             return try await existingTask.value
         }
@@ -119,7 +119,7 @@ final class BrewCatalogueRepository: CatalogueRepository {
         }
     }
 
-    private func refreshCaskAwaitingSharedTask() async throws -> CaskCatalogueJSON {
+    private func refreshCaskAwaitingSharedTask() async throws -> [BrewPackage] {
         if let existingTask = caskRefreshTask {
             return try await existingTask.value
         }
@@ -136,14 +136,14 @@ final class BrewCatalogueRepository: CatalogueRepository {
         }
     }
 
-    private func performFormulaRefresh() async throws -> FormulaCatalogueJSON {
+    private func performFormulaRefresh() async throws -> [BrewPackage] {
         let etag = await cache.etag(for: .formula)
         let response = try await apiClient.fetchFormulaCatalogue(etag: etag)
         switch response {
         case .notModified:
             updateLastRefresh(kind: .formula)
             if let cached = await cache.formulaCatalogue() {
-                return cached
+                return mapFormulaPackages(from: cached)
             }
             throw CatalogueRepositoryError.cacheMissingAfterNotModified(kind: .formula)
         case let .updated(data: data, etag: nextETag):
@@ -153,18 +153,18 @@ final class BrewCatalogueRepository: CatalogueRepository {
                 etag: nextETag,
             )
             updateLastRefresh(kind: .formula)
-            return data
+            return mapFormulaPackages(from: data)
         }
     }
 
-    private func performCaskRefresh() async throws -> CaskCatalogueJSON {
+    private func performCaskRefresh() async throws -> [BrewPackage] {
         let etag = await cache.etag(for: .cask)
         let response = try await apiClient.fetchCaskCatalogue(etag: etag)
         switch response {
         case .notModified:
             updateLastRefresh(kind: .cask)
             if let cached = await cache.caskCatalogue() {
-                return cached
+                return mapCaskPackages(from: cached)
             }
             throw CatalogueRepositoryError.cacheMissingAfterNotModified(kind: .cask)
         case let .updated(data: data, etag: nextETag):
@@ -174,7 +174,7 @@ final class BrewCatalogueRepository: CatalogueRepository {
                 etag: nextETag,
             )
             updateLastRefresh(kind: .cask)
-            return data
+            return mapCaskPackages(from: data)
         }
     }
 
@@ -204,5 +204,37 @@ final class BrewCatalogueRepository: CatalogueRepository {
 
     private func encodeCaskPayload(_ catalogue: CaskCatalogueJSON) throws -> Data {
         try JSONEncoder().encode(catalogue.items)
+    }
+
+    private func mapFormulaPackages(from catalogue: FormulaCatalogueJSON) -> [BrewPackage] {
+        catalogue.items.map {
+            BrewPackage(
+                name: $0.name,
+                displayName: $0.name,
+                kind: .formula,
+                description: $0.description,
+                homepage: $0.homepage,
+                latestVersion: $0.stableVersion,
+                installedVersions: [],
+                dependencies: $0.dependencyReferences,
+                outdated: false,
+            )
+        }
+    }
+
+    private func mapCaskPackages(from catalogue: CaskCatalogueJSON) -> [BrewPackage] {
+        catalogue.items.map {
+            BrewPackage(
+                name: $0.name,
+                displayName: $0.name,
+                kind: .cask,
+                description: $0.description,
+                homepage: $0.homepage,
+                latestVersion: $0.stableVersion,
+                installedVersions: [],
+                dependencies: $0.dependencyReferences,
+                outdated: false,
+            )
+        }
     }
 }

--- a/Brew/Repositories/CatalogueRepository.swift
+++ b/Brew/Repositories/CatalogueRepository.swift
@@ -1,0 +1,216 @@
+//
+//  CatalogueRepository.swift
+//  Brew
+//
+
+import Foundation
+
+@MainActor
+protocol CatalogueRepository: Sendable {
+    func loadFormulaCatalogue(forceRefresh: Bool) async throws -> FormulaCatalogueJSON
+    func loadCaskCatalogue(forceRefresh: Bool) async throws -> CaskCatalogueJSON
+}
+
+extension CatalogueRepository {
+    func loadFormulaCatalogue() async throws -> FormulaCatalogueJSON {
+        try await loadFormulaCatalogue(forceRefresh: false)
+    }
+
+    func loadCaskCatalogue() async throws -> CaskCatalogueJSON {
+        try await loadCaskCatalogue(forceRefresh: false)
+    }
+}
+
+@MainActor
+enum CatalogueRepositoryError: Error, Equatable {
+    case cacheMissingAfterNotModified(kind: CatalogueCache.CatalogueKind)
+}
+
+@MainActor
+final class BrewCatalogueRepository: CatalogueRepository {
+    nonisolated static let defaultTTL: TimeInterval = 3600
+
+    private enum DefaultsKey {
+        static let formulaLastRefresh = "CatalogueRepository.formula.lastRefresh"
+        static let caskLastRefresh = "CatalogueRepository.cask.lastRefresh"
+    }
+
+    private let apiClient: any BrewAPIClient
+    private let cache: CatalogueCache
+    private let userDefaults: UserDefaults
+    private let now: @Sendable () -> Date
+    private let ttl: TimeInterval
+
+    private var formulaRefreshTask: Task<FormulaCatalogueJSON, Error>?
+    private var caskRefreshTask: Task<CaskCatalogueJSON, Error>?
+
+    init(
+        apiClient: any BrewAPIClient,
+        cache: CatalogueCache,
+        userDefaults: UserDefaults = .standard,
+        now: @escaping @Sendable () -> Date = Date.init,
+        ttl: TimeInterval = BrewCatalogueRepository.defaultTTL,
+    ) {
+        self.apiClient = apiClient
+        self.cache = cache
+        self.userDefaults = userDefaults
+        self.now = now
+        self.ttl = ttl
+    }
+
+    static func live(
+        apiClient: any BrewAPIClient = URLSessionBrewAPIClient.live(),
+        userDefaults: UserDefaults = .standard,
+    ) async -> BrewCatalogueRepository {
+        let cache = await CatalogueCache()
+        return BrewCatalogueRepository(apiClient: apiClient, cache: cache, userDefaults: userDefaults)
+    }
+
+    func loadFormulaCatalogue(forceRefresh: Bool = false) async throws -> FormulaCatalogueJSON {
+        if forceRefresh {
+            return try await refreshFormulaAwaitingSharedTask()
+        }
+
+        if let cached = await cache.formulaCatalogue() {
+            if isStale(kind: .formula) {
+                scheduleFormulaBackgroundRefreshIfNeeded()
+            }
+            return cached
+        }
+
+        return try await refreshFormulaAwaitingSharedTask()
+    }
+
+    func loadCaskCatalogue(forceRefresh: Bool = false) async throws -> CaskCatalogueJSON {
+        if forceRefresh {
+            return try await refreshCaskAwaitingSharedTask()
+        }
+
+        if let cached = await cache.caskCatalogue() {
+            if isStale(kind: .cask) {
+                scheduleCaskBackgroundRefreshIfNeeded()
+            }
+            return cached
+        }
+
+        return try await refreshCaskAwaitingSharedTask()
+    }
+
+    private func scheduleFormulaBackgroundRefreshIfNeeded() {
+        guard formulaRefreshTask == nil else { return }
+        Task { @MainActor [self] in
+            _ = try? await refreshFormulaAwaitingSharedTask()
+        }
+    }
+
+    private func scheduleCaskBackgroundRefreshIfNeeded() {
+        guard caskRefreshTask == nil else { return }
+        Task { @MainActor [self] in
+            _ = try? await refreshCaskAwaitingSharedTask()
+        }
+    }
+
+    private func refreshFormulaAwaitingSharedTask() async throws -> FormulaCatalogueJSON {
+        if let existingTask = formulaRefreshTask {
+            return try await existingTask.value
+        }
+
+        let task = Task { try await performFormulaRefresh() }
+        formulaRefreshTask = task
+        do {
+            let value = try await task.value
+            formulaRefreshTask = nil
+            return value
+        } catch {
+            formulaRefreshTask = nil
+            throw error
+        }
+    }
+
+    private func refreshCaskAwaitingSharedTask() async throws -> CaskCatalogueJSON {
+        if let existingTask = caskRefreshTask {
+            return try await existingTask.value
+        }
+
+        let task = Task { try await performCaskRefresh() }
+        caskRefreshTask = task
+        do {
+            let value = try await task.value
+            caskRefreshTask = nil
+            return value
+        } catch {
+            caskRefreshTask = nil
+            throw error
+        }
+    }
+
+    private func performFormulaRefresh() async throws -> FormulaCatalogueJSON {
+        let etag = await cache.etag(for: .formula)
+        let response = try await apiClient.fetchFormulaCatalogue(etag: etag)
+        switch response {
+        case .notModified:
+            updateLastRefresh(kind: .formula)
+            if let cached = await cache.formulaCatalogue() {
+                return cached
+            }
+            throw CatalogueRepositoryError.cacheMissingAfterNotModified(kind: .formula)
+        case let .updated(data: data, etag: nextETag):
+            let rawData = try encodeFormulaPayload(data)
+            try await cache.updateFormulaCatalogue(
+                with: rawData,
+                etag: nextETag,
+            )
+            updateLastRefresh(kind: .formula)
+            return data
+        }
+    }
+
+    private func performCaskRefresh() async throws -> CaskCatalogueJSON {
+        let etag = await cache.etag(for: .cask)
+        let response = try await apiClient.fetchCaskCatalogue(etag: etag)
+        switch response {
+        case .notModified:
+            updateLastRefresh(kind: .cask)
+            if let cached = await cache.caskCatalogue() {
+                return cached
+            }
+            throw CatalogueRepositoryError.cacheMissingAfterNotModified(kind: .cask)
+        case let .updated(data: data, etag: nextETag):
+            let rawData = try encodeCaskPayload(data)
+            try await cache.updateCaskCatalogue(
+                with: rawData,
+                etag: nextETag,
+            )
+            updateLastRefresh(kind: .cask)
+            return data
+        }
+    }
+
+    private func updateLastRefresh(kind: CatalogueCache.CatalogueKind) {
+        userDefaults.set(now(), forKey: lastRefreshKey(for: kind))
+    }
+
+    private func isStale(kind: CatalogueCache.CatalogueKind) -> Bool {
+        guard let refreshedAt = userDefaults.object(forKey: lastRefreshKey(for: kind)) as? Date else {
+            return true
+        }
+        return now().timeIntervalSince(refreshedAt) >= ttl
+    }
+
+    private func lastRefreshKey(for kind: CatalogueCache.CatalogueKind) -> String {
+        switch kind {
+        case .formula:
+            DefaultsKey.formulaLastRefresh
+        case .cask:
+            DefaultsKey.caskLastRefresh
+        }
+    }
+
+    private func encodeFormulaPayload(_ catalogue: FormulaCatalogueJSON) throws -> Data {
+        try JSONEncoder().encode(catalogue.items)
+    }
+
+    private func encodeCaskPayload(_ catalogue: CaskCatalogueJSON) throws -> Data {
+        try JSONEncoder().encode(catalogue.items)
+    }
+}

--- a/Brew/Repositories/CatalogueRepository.swift
+++ b/Brew/Repositories/CatalogueRepository.swift
@@ -215,9 +215,7 @@ final class BrewCatalogueRepository: CatalogueRepository {
                 description: $0.description,
                 homepage: $0.homepage,
                 latestVersion: $0.stableVersion,
-                installedVersions: [],
                 dependencies: $0.dependencyReferences,
-                outdated: false,
             )
         }
     }
@@ -231,9 +229,7 @@ final class BrewCatalogueRepository: CatalogueRepository {
                 description: $0.description,
                 homepage: $0.homepage,
                 latestVersion: $0.stableVersion,
-                installedVersions: [],
                 dependencies: $0.dependencyReferences,
-                outdated: false,
             )
         }
     }

--- a/Brew/Repositories/DiscoverPackagesRepository.swift
+++ b/Brew/Repositories/DiscoverPackagesRepository.swift
@@ -1,0 +1,69 @@
+//
+//  DiscoverPackagesRepository.swift
+//  Brew
+//
+
+import Foundation
+
+@MainActor
+protocol DiscoverPackagesRepository: Sendable {
+    func loadTopPackages(
+        limit: Int,
+        window: BrewAnalyticsWindow,
+    ) async throws -> DiscoverTopPackagesSnapshot
+}
+
+extension DiscoverPackagesRepository {
+    func loadTopPackages(
+        limit: Int = 10,
+        window: BrewAnalyticsWindow = .days30,
+    ) async throws -> DiscoverTopPackagesSnapshot {
+        try await loadTopPackages(limit: limit, window: window)
+    }
+}
+
+struct BrewDiscoverPackagesRepository: DiscoverPackagesRepository {
+    private let apiClient: any BrewAPIClient
+
+    init(apiClient: any BrewAPIClient) {
+        self.apiClient = apiClient
+    }
+
+    static func live() -> BrewDiscoverPackagesRepository {
+        BrewDiscoverPackagesRepository(apiClient: URLSessionBrewAPIClient.live())
+    }
+
+    func loadTopPackages(
+        limit: Int = 10,
+        window: BrewAnalyticsWindow = .days30,
+    ) async throws -> DiscoverTopPackagesSnapshot {
+        async let formulaAnalytics = apiClient.fetchFormulaInstallOnRequestAnalytics(window: window)
+        async let caskAnalytics = apiClient.fetchCaskInstallAnalytics(window: window)
+
+        let formulae = try await topPackages(from: formulaAnalytics, limit: limit)
+        let casks = try await topPackages(from: caskAnalytics, limit: limit)
+        return DiscoverTopPackagesSnapshot(topFormulae: formulae, topCasks: casks)
+    }
+
+    private func topPackages(from analytics: BrewAnalyticsJSON, limit: Int) -> [DiscoverTopPackage] {
+        let validatedLimit = max(0, limit)
+        guard validatedLimit > 0 else {
+            return []
+        }
+
+        return analytics.packageCounts
+            .sorted(by: sortByInstallCountDescendingThenNameAscending)
+            .prefix(validatedLimit)
+            .map { DiscoverTopPackage(reference: $0.reference, installCount: $0.count) }
+    }
+
+    private func sortByInstallCountDescendingThenNameAscending(
+        _ lhs: BrewAnalyticsPackageCount,
+        _ rhs: BrewAnalyticsPackageCount,
+    ) -> Bool {
+        if lhs.count == rhs.count {
+            return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+        }
+        return lhs.count > rhs.count
+    }
+}

--- a/Brew/Repositories/InstalledDependentsRepository.swift
+++ b/Brew/Repositories/InstalledDependentsRepository.swift
@@ -8,5 +8,5 @@ import Foundation
 /// Reverse dependency lookups over the installed inventory snapshot.
 @MainActor
 protocol InstalledDependentsRepository: Sendable {
-    func installedDependents(for packageID: BrewPackage.ID) async -> [BrewPackage]
+    func installedDependents(for packageID: InstalledBrewPackage.ID) async -> [InstalledBrewPackage]
 }

--- a/Brew/Repositories/InstalledInventoryReading.swift
+++ b/Brew/Repositories/InstalledInventoryReading.swift
@@ -8,5 +8,5 @@ import Foundation
 /// Read-only access to the cached installed inventory snapshot.
 @MainActor
 protocol InstalledInventoryReading: Sendable {
-    func installedPackageIDs() async -> Set<BrewPackage.ID>
+    func installedPackageIDs() async -> Set<InstalledBrewPackage.ID>
 }

--- a/Brew/Repositories/InstalledPackagesRepository.swift
+++ b/Brew/Repositories/InstalledPackagesRepository.swift
@@ -8,11 +8,11 @@ import Foundation
 /// Loads installed formulae and casks — swap `BrewInstalledPackagesRepository` / test doubles (`CONVENTIONS.md` — Testing).
 @MainActor
 protocol InstalledPackagesRepository: Sendable {
-    func loadInstalledPackages(forceRefresh: Bool) async throws -> [BrewPackage]
+    func loadInstalledPackages(forceRefresh: Bool) async throws -> [InstalledBrewPackage]
 }
 
 extension InstalledPackagesRepository {
-    func loadInstalledPackages() async throws -> [BrewPackage] {
+    func loadInstalledPackages() async throws -> [InstalledBrewPackage] {
         try await loadInstalledPackages(forceRefresh: false)
     }
 }

--- a/Brew/Services/API/CatalogueCache.swift
+++ b/Brew/Services/API/CatalogueCache.swift
@@ -1,0 +1,123 @@
+//
+//  CatalogueCache.swift
+//  Brew
+//
+
+import Foundation
+
+actor CatalogueCache {
+    enum CatalogueKind: String {
+        case formula
+        case cask
+    }
+
+    private enum DefaultsKey {
+        static let formulaETag = "CatalogueCache.formula.etag"
+        static let caskETag = "CatalogueCache.cask.etag"
+    }
+
+    private let fileManager: FileManager
+    private let userDefaults: UserDefaults
+    private let cacheDirectoryURL: URL
+    private let decoder = JSONDecoder()
+
+    private var formulaData: FormulaCatalogueJSON?
+    private var caskData: CaskCatalogueJSON?
+
+    init(
+        fileManager: FileManager = .default,
+        userDefaults: UserDefaults = .standard,
+        cacheDirectoryURL: URL? = nil,
+    ) async {
+        self.fileManager = fileManager
+        self.userDefaults = userDefaults
+        let resolvedURL = cacheDirectoryURL ?? Self.defaultCacheDirectoryURL(fileManager: fileManager)
+        self.cacheDirectoryURL = resolvedURL
+        async let formula = Task.detached {
+            Self.loadCache(at: Self.formulaCacheURL(in: resolvedURL), as: FormulaCatalogueJSON.self)
+        }.value
+        async let cask = Task.detached {
+            Self.loadCache(at: Self.caskCacheURL(in: resolvedURL), as: CaskCatalogueJSON.self)
+        }.value
+        (formulaData, caskData) = await (formula, cask)
+    }
+
+    func formulaCatalogue() async -> FormulaCatalogueJSON? {
+        formulaData
+    }
+
+    func caskCatalogue() async -> CaskCatalogueJSON? {
+        caskData
+    }
+
+    func etag(for kind: CatalogueKind) async -> String? {
+        userDefaults.string(forKey: etagKey(for: kind))
+    }
+
+    func updateFormulaCatalogue(with rawData: Data, etag: String?) async throws {
+        let decoded = try decoder.decode(FormulaCatalogueJSON.self, from: rawData)
+        try writeCache(rawData, to: formulaCacheFileURL)
+        formulaData = decoded
+        persistETag(etag, for: .formula)
+    }
+
+    func updateCaskCatalogue(with rawData: Data, etag: String?) async throws {
+        let decoded = try decoder.decode(CaskCatalogueJSON.self, from: rawData)
+        try writeCache(rawData, to: caskCacheFileURL)
+        caskData = decoded
+        persistETag(etag, for: .cask)
+    }
+
+    private func writeCache(_ data: Data, to url: URL) throws {
+        try fileManager.createDirectory(at: cacheDirectoryURL, withIntermediateDirectories: true)
+        try data.write(to: url, options: .atomic)
+    }
+
+    private func persistETag(_ etag: String?, for kind: CatalogueKind) {
+        let key = etagKey(for: kind)
+        if let etag {
+            userDefaults.set(etag, forKey: key)
+        } else {
+            userDefaults.removeObject(forKey: key)
+        }
+    }
+
+    private func etagKey(for kind: CatalogueKind) -> String {
+        switch kind {
+        case .formula:
+            DefaultsKey.formulaETag
+        case .cask:
+            DefaultsKey.caskETag
+        }
+    }
+
+    private var formulaCacheFileURL: URL {
+        Self.formulaCacheURL(in: cacheDirectoryURL)
+    }
+
+    private var caskCacheFileURL: URL {
+        Self.caskCacheURL(in: cacheDirectoryURL)
+    }
+}
+
+private extension CatalogueCache {
+    nonisolated static func defaultCacheDirectoryURL(fileManager: FileManager) -> URL {
+        if let appSupportURL = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
+            return appSupportURL.appendingPathComponent("Brew", isDirectory: true)
+        }
+        return fileManager.temporaryDirectory.appendingPathComponent("Brew", isDirectory: true)
+    }
+
+    nonisolated static func formulaCacheURL(in directoryURL: URL) -> URL {
+        directoryURL.appendingPathComponent("formula-cache.json")
+    }
+
+    nonisolated static func caskCacheURL(in directoryURL: URL) -> URL {
+        directoryURL.appendingPathComponent("cask-cache.json")
+    }
+
+    nonisolated static func loadCache<T: Decodable>(at url: URL, as type: T.Type) -> T? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? JSONDecoder().decode(type, from: data)
+    }
+}

--- a/Brew/Services/API/CatalogueCache.swift
+++ b/Brew/Services/API/CatalogueCache.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-actor CatalogueCache {
+actor CatalogueCache: CatalogueCaching {
     enum CatalogueKind: String {
         case formula
         case cask
@@ -23,23 +23,45 @@ actor CatalogueCache {
 
     private var formulaData: FormulaCatalogueJSON?
     private var caskData: CaskCatalogueJSON?
+    private var hasPrepared = false
+    private var prepareTask: Task<(FormulaCatalogueJSON?, CaskCatalogueJSON?), Never>?
 
     init(
         fileManager: FileManager = .default,
         userDefaults: UserDefaults = .standard,
         cacheDirectoryURL: URL? = nil,
-    ) async {
+    ) {
         self.fileManager = fileManager
         self.userDefaults = userDefaults
         let resolvedURL = cacheDirectoryURL ?? Self.defaultCacheDirectoryURL(fileManager: fileManager)
         self.cacheDirectoryURL = resolvedURL
-        async let formula = Task.detached {
-            Self.loadCache(at: Self.formulaCacheURL(in: resolvedURL), as: FormulaCatalogueJSON.self)
-        }.value
-        async let cask = Task.detached {
-            Self.loadCache(at: Self.caskCacheURL(in: resolvedURL), as: CaskCatalogueJSON.self)
-        }.value
-        (formulaData, caskData) = await (formula, cask)
+    }
+
+    func prepare() async {
+        if hasPrepared {
+            return
+        }
+
+        if let inFlightTask = prepareTask {
+            let (loadedFormula, loadedCask) = await inFlightTask.value
+            applyPreparedData(formula: loadedFormula, cask: loadedCask)
+            hasPrepared = true
+            return
+        }
+
+        let formulaCacheURL = Self.formulaCacheURL(in: cacheDirectoryURL)
+        let caskCacheURL = Self.caskCacheURL(in: cacheDirectoryURL)
+
+        let task = Task(priority: .utility) {
+            async let formula = Self.loadCache(at: formulaCacheURL, as: FormulaCatalogueJSON.self)
+            async let cask = Self.loadCache(at: caskCacheURL, as: CaskCatalogueJSON.self)
+            return await (formula, cask)
+        }
+        prepareTask = task
+        let (loadedFormula, loadedCask) = await task.value
+        prepareTask = nil
+        applyPreparedData(formula: loadedFormula, cask: loadedCask)
+        hasPrepared = true
     }
 
     func formulaCatalogue() async -> FormulaCatalogueJSON? {
@@ -97,6 +119,15 @@ actor CatalogueCache {
 
     private var caskCacheFileURL: URL {
         Self.caskCacheURL(in: cacheDirectoryURL)
+    }
+
+    private func applyPreparedData(formula: FormulaCatalogueJSON?, cask: CaskCatalogueJSON?) {
+        if formulaData == nil, let formula {
+            formulaData = formula
+        }
+        if caskData == nil, let cask {
+            caskData = cask
+        }
     }
 }
 

--- a/Brew/Services/API/CatalogueCacheEnvironment.swift
+++ b/Brew/Services/API/CatalogueCacheEnvironment.swift
@@ -1,0 +1,11 @@
+//
+//  CatalogueCacheEnvironment.swift
+//  Brew
+//
+
+import SwiftUI
+
+extension EnvironmentValues {
+    /// Inject from ``BrewApp``; otherwise a default cache is created for previews and unscoped subtrees.
+    @Entry var catalogueCache = CatalogueCache()
+}

--- a/Brew/Services/API/CatalogueCaching.swift
+++ b/Brew/Services/API/CatalogueCaching.swift
@@ -1,0 +1,14 @@
+//
+//  CatalogueCaching.swift
+//  Brew
+//
+
+import Foundation
+
+protocol CatalogueCaching: Sendable {
+    func formulaCatalogue() async -> FormulaCatalogueJSON?
+    func caskCatalogue() async -> CaskCatalogueJSON?
+    func etag(for kind: CatalogueCache.CatalogueKind) async -> String?
+    func updateFormulaCatalogue(with rawData: Data, etag: String?) async throws
+    func updateCaskCatalogue(with rawData: Data, etag: String?) async throws
+}

--- a/Brew/Services/API/CatalogueJSON.swift
+++ b/Brew/Services/API/CatalogueJSON.swift
@@ -1,0 +1,117 @@
+//
+//  CatalogueJSON.swift
+//  Brew
+//
+
+import Foundation
+
+struct FormulaCatalogueJSON: Decodable {
+    let items: [FormulaCatalogueItemJSON]
+    let decodeFailures: [CatalogueItemDecodeFailure]
+
+    init(from decoder: Decoder) throws {
+        (items, decodeFailures) = try decodeCatalogueItems(from: decoder, as: FormulaCatalogueItemJSON.self)
+    }
+}
+
+struct CaskCatalogueJSON: Decodable {
+    let items: [CaskCatalogueItemJSON]
+    let decodeFailures: [CatalogueItemDecodeFailure]
+
+    init(from decoder: Decoder) throws {
+        (items, decodeFailures) = try decodeCatalogueItems(from: decoder, as: CaskCatalogueItemJSON.self)
+    }
+}
+
+struct CatalogueItemDecodeFailure: Equatable {
+    let index: Int
+    let underlying: String
+}
+
+struct FormulaCatalogueItemJSON: Decodable {
+    let name: String
+    let desc: String
+    let homepage: String
+    let versions: CatalogueVersionsJSON
+    let analytics: CatalogueAnalyticsJSON
+}
+
+struct CaskCatalogueItemJSON: Decodable {
+    let name: String
+    let desc: String
+    let homepage: String
+    let versions: CatalogueVersionsJSON
+    let analytics: CatalogueAnalyticsJSON
+}
+
+struct CatalogueVersionsJSON: Decodable {
+    let stable: String
+}
+
+struct CatalogueAnalyticsJSON: Decodable {
+    let install: CatalogueInstallAnalyticsJSON
+}
+
+struct CatalogueInstallAnalyticsJSON: Decodable {
+    let days30: Int
+
+    private enum CodingKeys: String, CodingKey {
+        case days30 = "30d"
+    }
+}
+
+extension FormulaCatalogueItemJSON {
+    var description: String {
+        desc
+    }
+
+    var stableVersion: String {
+        versions.stable
+    }
+
+    var analyticsInstall30d: Int {
+        analytics.install.days30
+    }
+}
+
+extension CaskCatalogueItemJSON {
+    var description: String {
+        desc
+    }
+
+    var stableVersion: String {
+        versions.stable
+    }
+
+    var analyticsInstall30d: Int {
+        analytics.install.days30
+    }
+}
+
+private func decodeCatalogueItems<Item: Decodable>(
+    from decoder: Decoder,
+    as _: Item.Type,
+) throws -> ([Item], [CatalogueItemDecodeFailure]) {
+    var container = try decoder.unkeyedContainer()
+    var decodedItems: [Item] = []
+    var failures: [CatalogueItemDecodeFailure] = []
+    decodedItems.reserveCapacity(container.count ?? 0)
+
+    while !container.isAtEnd {
+        let index = container.currentIndex
+        let itemDecoder = try container.superDecoder()
+        do {
+            let item = try Item(from: itemDecoder)
+            decodedItems.append(item)
+        } catch {
+            failures.append(
+                CatalogueItemDecodeFailure(
+                    index: index,
+                    underlying: String(describing: error),
+                ),
+            )
+        }
+    }
+
+    return (decodedItems, failures)
+}

--- a/Brew/Services/API/CatalogueJSON.swift
+++ b/Brew/Services/API/CatalogueJSON.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-struct FormulaCatalogueJSON: Decodable {
+nonisolated struct FormulaCatalogueJSON: Codable {
     let items: [FormulaCatalogueItemJSON]
     let decodeFailures: [CatalogueItemDecodeFailure]
 
@@ -14,7 +14,7 @@ struct FormulaCatalogueJSON: Decodable {
     }
 }
 
-struct CaskCatalogueJSON: Decodable {
+nonisolated struct CaskCatalogueJSON: Codable {
     let items: [CaskCatalogueItemJSON]
     let decodeFailures: [CatalogueItemDecodeFailure]
 
@@ -23,12 +23,12 @@ struct CaskCatalogueJSON: Decodable {
     }
 }
 
-struct CatalogueItemDecodeFailure: Equatable {
+nonisolated struct CatalogueItemDecodeFailure: Codable, Equatable {
     let index: Int
     let underlying: String
 }
 
-struct FormulaCatalogueItemJSON: Decodable {
+nonisolated struct FormulaCatalogueItemJSON: Codable {
     let name: String
     let desc: String
     let homepage: String
@@ -36,7 +36,7 @@ struct FormulaCatalogueItemJSON: Decodable {
     let analytics: CatalogueAnalyticsJSON
 }
 
-struct CaskCatalogueItemJSON: Decodable {
+nonisolated struct CaskCatalogueItemJSON: Codable {
     let name: String
     let desc: String
     let homepage: String
@@ -44,15 +44,15 @@ struct CaskCatalogueItemJSON: Decodable {
     let analytics: CatalogueAnalyticsJSON
 }
 
-struct CatalogueVersionsJSON: Decodable {
+nonisolated struct CatalogueVersionsJSON: Codable {
     let stable: String
 }
 
-struct CatalogueAnalyticsJSON: Decodable {
+nonisolated struct CatalogueAnalyticsJSON: Codable {
     let install: CatalogueInstallAnalyticsJSON
 }
 
-struct CatalogueInstallAnalyticsJSON: Decodable {
+nonisolated struct CatalogueInstallAnalyticsJSON: Codable {
     let days30: Int
 
     private enum CodingKeys: String, CodingKey {
@@ -88,7 +88,7 @@ extension CaskCatalogueItemJSON {
     }
 }
 
-private func decodeCatalogueItems<Item: Decodable>(
+private nonisolated func decodeCatalogueItems<Item: Decodable>(
     from decoder: Decoder,
     as _: Item.Type,
 ) throws -> ([Item], [CatalogueItemDecodeFailure]) {

--- a/Brew/Services/API/CatalogueJSON.swift
+++ b/Brew/Services/API/CatalogueJSON.swift
@@ -34,6 +34,26 @@ nonisolated struct FormulaCatalogueItemJSON: Codable {
     let homepage: String
     let versions: CatalogueVersionsJSON
     let analytics: CatalogueAnalyticsJSON
+    let dependencies: [String]
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decode(String.self, forKey: .name)
+        desc = try container.decode(String.self, forKey: .desc)
+        homepage = try container.decode(String.self, forKey: .homepage)
+        versions = try container.decode(CatalogueVersionsJSON.self, forKey: .versions)
+        analytics = try container.decode(CatalogueAnalyticsJSON.self, forKey: .analytics)
+        dependencies = container.decodeStringArray(forKey: .dependencies)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case desc
+        case homepage
+        case versions
+        case analytics
+        case dependencies
+    }
 }
 
 nonisolated struct CaskCatalogueItemJSON: Codable {
@@ -42,6 +62,29 @@ nonisolated struct CaskCatalogueItemJSON: Codable {
     let homepage: String
     let versions: CatalogueVersionsJSON
     let analytics: CatalogueAnalyticsJSON
+    let dependencies: [String]
+    let dependsOn: CatalogueDependsOnJSON?
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decode(String.self, forKey: .name)
+        desc = try container.decode(String.self, forKey: .desc)
+        homepage = try container.decode(String.self, forKey: .homepage)
+        versions = try container.decode(CatalogueVersionsJSON.self, forKey: .versions)
+        analytics = try container.decode(CatalogueAnalyticsJSON.self, forKey: .analytics)
+        dependencies = container.decodeStringArray(forKey: .dependencies)
+        dependsOn = try? container.decode(CatalogueDependsOnJSON.self, forKey: .dependsOn)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case desc
+        case homepage
+        case versions
+        case analytics
+        case dependencies
+        case dependsOn = "depends_on"
+    }
 }
 
 nonisolated struct CatalogueVersionsJSON: Codable {
@@ -60,6 +103,22 @@ nonisolated struct CatalogueInstallAnalyticsJSON: Codable {
     }
 }
 
+nonisolated struct CatalogueDependsOnJSON: Codable {
+    let formula: [String]
+    let cask: [String]
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        formula = container.decodeStringArray(forKey: .formula)
+        cask = container.decodeStringArray(forKey: .cask)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case formula
+        case cask
+    }
+}
+
 extension FormulaCatalogueItemJSON {
     var description: String {
         desc
@@ -71,6 +130,10 @@ extension FormulaCatalogueItemJSON {
 
     var analyticsInstall30d: Int {
         analytics.install.days30
+    }
+
+    var dependencyReferences: [HomebrewPackageReference] {
+        HomebrewPackageReference.formulaDependencies(from: dependencies)
     }
 }
 
@@ -85,6 +148,17 @@ extension CaskCatalogueItemJSON {
 
     var analyticsInstall30d: Int {
         analytics.install.days30
+    }
+
+    var dependencyReferences: [HomebrewPackageReference] {
+        let formulaDependencies = HomebrewPackageReference.formulaDependencies(
+            from: dependencies + (dependsOn?.formula ?? []),
+        )
+        let caskDependencies = (dependsOn?.cask ?? []).compactMap { token -> HomebrewPackageReference? in
+            let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : .cask(token: trimmed)
+        }
+        return HomebrewPackageReference.uniqueReferences(formulaDependencies + caskDependencies)
     }
 }
 
@@ -114,4 +188,20 @@ private nonisolated func decodeCatalogueItems<Item: Decodable>(
     }
 
     return (decodedItems, failures)
+}
+
+private extension KeyedDecodingContainer {
+    func decodeStringArray(forKey key: Key) -> [String] {
+        if let values = try? decode([String].self, forKey: key) {
+            return values.compactMap { value in
+                let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+                return trimmed.isEmpty ? nil : trimmed
+            }
+        }
+        if let value = try? decode(String.self, forKey: key) {
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? [] : [trimmed]
+        }
+        return []
+    }
 }

--- a/Brew/Services/BrewAPIClient.swift
+++ b/Brew/Services/BrewAPIClient.swift
@@ -177,7 +177,3 @@ private enum Endpoint {
         }
     }
 }
-
-struct FormulaCatalogueJSON: Decodable {}
-
-struct CaskCatalogueJSON: Decodable {}

--- a/Brew/Services/BrewAPIClient.swift
+++ b/Brew/Services/BrewAPIClient.swift
@@ -5,10 +5,16 @@
 
 import Foundation
 
-@MainActor
 protocol BrewAPIClient: Sendable {
     func fetchFormulaInstallOnRequestAnalytics(window: BrewAnalyticsWindow) async throws -> BrewAnalyticsJSON
     func fetchCaskInstallAnalytics(window: BrewAnalyticsWindow) async throws -> BrewAnalyticsJSON
+    func fetchFormulaCatalogue(etag: String?) async throws -> CatalogueResponse<FormulaCatalogueJSON>
+    func fetchCaskCatalogue(etag: String?) async throws -> CatalogueResponse<CaskCatalogueJSON>
+}
+
+enum CatalogueResponse<T> {
+    case notModified
+    case updated(data: T, etag: String?)
 }
 
 enum BrewAPIClientError: Error, Equatable {
@@ -52,6 +58,14 @@ struct URLSessionBrewAPIClient: BrewAPIClient {
         try await fetchAnalytics(for: .caskInstall(window: window))
     }
 
+    func fetchFormulaCatalogue(etag: String?) async throws -> CatalogueResponse<FormulaCatalogueJSON> {
+        try await fetchConditionalCatalogue(for: .formulaCatalogue, etag: etag, as: FormulaCatalogueJSON.self)
+    }
+
+    func fetchCaskCatalogue(etag: String?) async throws -> CatalogueResponse<CaskCatalogueJSON> {
+        try await fetchConditionalCatalogue(for: .caskCatalogue, etag: etag, as: CaskCatalogueJSON.self)
+    }
+
     private func fetchAnalytics(for endpoint: Endpoint) async throws -> BrewAnalyticsJSON {
         let request = try makeRequest(for: endpoint)
 
@@ -80,6 +94,47 @@ struct URLSessionBrewAPIClient: BrewAPIClient {
         }
     }
 
+    private func fetchConditionalCatalogue<T: Decodable>(
+        for endpoint: Endpoint,
+        etag: String?,
+        as type: T.Type,
+    ) async throws -> CatalogueResponse<T> {
+        var headers: [String: String] = [:]
+        if let etag {
+            headers["If-None-Match"] = etag
+        }
+        let request = try makeRequest(for: endpoint, headers: headers)
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await fetchData(request)
+        } catch {
+            throw BrewAPIClientError.transport(underlying: String(describing: error))
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw BrewAPIClientError.invalidResponse
+        }
+
+        switch httpResponse.statusCode {
+        case 304:
+            return .notModified
+        case 200:
+            do {
+                let payload = try decoder.decode(type, from: data)
+                let responseETag = httpResponse.value(forHTTPHeaderField: "ETag")
+                return .updated(data: payload, etag: responseETag)
+            } catch {
+                throw BrewAPIClientError.decoding(underlying: String(describing: error))
+            }
+        default:
+            let bodyData = Data(data.prefix(250))
+            let bodySnippet = String(bytes: bodyData, encoding: .utf8) ?? ""
+            throw BrewAPIClientError.httpStatus(code: httpResponse.statusCode, bodySnippet: bodySnippet)
+        }
+    }
+
     private func makeRequest(for endpoint: Endpoint) throws -> URLRequest {
         guard let url = URL(string: endpoint.path, relativeTo: baseURL)?.absoluteURL else {
             throw BrewAPIClientError.invalidURL(path: endpoint.path)
@@ -87,6 +142,14 @@ struct URLSessionBrewAPIClient: BrewAPIClient {
 
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
+        return request
+    }
+
+    private func makeRequest(for endpoint: Endpoint, headers: [String: String]) throws -> URLRequest {
+        var request = try makeRequest(for: endpoint)
+        for (header, value) in headers {
+            request.setValue(value, forHTTPHeaderField: header)
+        }
         return request
     }
 
@@ -98,6 +161,8 @@ struct URLSessionBrewAPIClient: BrewAPIClient {
 private enum Endpoint {
     case formulaInstallOnRequest(window: BrewAnalyticsWindow)
     case caskInstall(window: BrewAnalyticsWindow)
+    case formulaCatalogue
+    case caskCatalogue
 
     var path: String {
         switch self {
@@ -105,6 +170,14 @@ private enum Endpoint {
             "/api/analytics/install-on-request/homebrew-core/\(window.rawValue).json"
         case let .caskInstall(window):
             "/api/analytics/cask-install/homebrew-cask/\(window.rawValue).json"
+        case .formulaCatalogue:
+            "/api/formula.json"
+        case .caskCatalogue:
+            "/api/cask.json"
         }
     }
 }
+
+struct FormulaCatalogueJSON: Decodable {}
+
+struct CaskCatalogueJSON: Decodable {}

--- a/Brew/Services/BrewAPIClient.swift
+++ b/Brew/Services/BrewAPIClient.swift
@@ -1,0 +1,110 @@
+//
+//  BrewAPIClient.swift
+//  Brew
+//
+
+import Foundation
+
+@MainActor
+protocol BrewAPIClient: Sendable {
+    func fetchFormulaInstallOnRequestAnalytics(window: BrewAnalyticsWindow) async throws -> BrewAnalyticsJSON
+    func fetchCaskInstallAnalytics(window: BrewAnalyticsWindow) async throws -> BrewAnalyticsJSON
+}
+
+enum BrewAPIClientError: Error, Equatable {
+    case invalidURL(path: String)
+    case transport(underlying: String)
+    case invalidResponse
+    case httpStatus(code: Int, bodySnippet: String)
+    case decoding(underlying: String)
+}
+
+struct URLSessionBrewAPIClient: BrewAPIClient {
+    private let baseURL: URL
+    private let fetchData: @Sendable (URLRequest) async throws -> (Data, URLResponse)
+    private let decoder: JSONDecoder
+
+    init(
+        baseURL: URL = Self.defaultBaseURL,
+        decoder: JSONDecoder = JSONDecoder(),
+        fetchData: @escaping @Sendable (URLRequest) async throws -> (Data, URLResponse),
+    ) {
+        self.baseURL = baseURL
+        self.decoder = decoder
+        self.fetchData = fetchData
+    }
+
+    init(session: URLSession, baseURL: URL = Self.defaultBaseURL, decoder: JSONDecoder = JSONDecoder()) {
+        self.init(baseURL: baseURL, decoder: decoder) { request in
+            try await session.data(for: request)
+        }
+    }
+
+    static func live() -> URLSessionBrewAPIClient {
+        URLSessionBrewAPIClient(session: URLSession.shared)
+    }
+
+    func fetchFormulaInstallOnRequestAnalytics(window: BrewAnalyticsWindow) async throws -> BrewAnalyticsJSON {
+        try await fetchAnalytics(for: .formulaInstallOnRequest(window: window))
+    }
+
+    func fetchCaskInstallAnalytics(window: BrewAnalyticsWindow) async throws -> BrewAnalyticsJSON {
+        try await fetchAnalytics(for: .caskInstall(window: window))
+    }
+
+    private func fetchAnalytics(for endpoint: Endpoint) async throws -> BrewAnalyticsJSON {
+        let request = try makeRequest(for: endpoint)
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await fetchData(request)
+        } catch {
+            throw BrewAPIClientError.transport(underlying: String(describing: error))
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw BrewAPIClientError.invalidResponse
+        }
+
+        guard (200 ... 299).contains(httpResponse.statusCode) else {
+            let bodyData = Data(data.prefix(250))
+            let bodySnippet = String(bytes: bodyData, encoding: .utf8) ?? ""
+            throw BrewAPIClientError.httpStatus(code: httpResponse.statusCode, bodySnippet: bodySnippet)
+        }
+
+        do {
+            return try decoder.decode(BrewAnalyticsJSON.self, from: data)
+        } catch {
+            throw BrewAPIClientError.decoding(underlying: String(describing: error))
+        }
+    }
+
+    private func makeRequest(for endpoint: Endpoint) throws -> URLRequest {
+        guard let url = URL(string: endpoint.path, relativeTo: baseURL)?.absoluteURL else {
+            throw BrewAPIClientError.invalidURL(path: endpoint.path)
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        return request
+    }
+
+    private nonisolated static var defaultBaseURL: URL {
+        URL(string: "https://formulae.brew.sh") ?? URL(fileURLWithPath: "/")
+    }
+}
+
+private enum Endpoint {
+    case formulaInstallOnRequest(window: BrewAnalyticsWindow)
+    case caskInstall(window: BrewAnalyticsWindow)
+
+    var path: String {
+        switch self {
+        case let .formulaInstallOnRequest(window):
+            "/api/analytics/install-on-request/homebrew-core/\(window.rawValue).json"
+        case let .caskInstall(window):
+            "/api/analytics/cask-install/homebrew-cask/\(window.rawValue).json"
+        }
+    }
+}

--- a/Brew/Services/BrewCommand/BrewOperationID+Homebrew.swift
+++ b/Brew/Services/BrewCommand/BrewOperationID+Homebrew.swift
@@ -11,7 +11,7 @@ extension BrewOperationID {
         rawValue = "\(kind.rawValue):\(name)"
     }
 
-    init(package: BrewPackage) {
+    init(package: InstalledBrewPackage) {
         self.init(kind: package.kind, name: package.name)
     }
 }

--- a/Brew/Services/BrewCommand/JSON/BrewInfoJSON+Mapping.swift
+++ b/Brew/Services/BrewCommand/JSON/BrewInfoJSON+Mapping.swift
@@ -6,50 +6,53 @@
 import Foundation
 
 extension BrewInfoJSON {
-    func installedPackages() -> [BrewPackage] {
+    func installedPackages() -> [InstalledBrewPackage] {
         let formulaPackages = formulae.map(\.asBrewPackage)
         let caskPackages = casks.map(\.asBrewPackage)
         return (formulaPackages + caskPackages).sorted(by: Self.sortByName)
     }
 
-    private nonisolated static func sortByName(_ lhs: BrewPackage, _ rhs: BrewPackage) -> Bool {
-        lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+    private nonisolated static func sortByName(_ lhs: InstalledBrewPackage, _ rhs: InstalledBrewPackage) -> Bool {
+        lhs.package.name.localizedCaseInsensitiveCompare(rhs.package.name) == .orderedAscending
     }
 }
 
 private extension BrewInfoFormula {
-    var asBrewPackage: BrewPackage {
+    var asBrewPackage: InstalledBrewPackage {
         let installedVersions = installed
             .compactMap(\.version)
             .compactMap(BrewInfoJSON.trimmedOrNil(_:))
-        let runtimeDependencies = dependencies
-        return BrewPackage(
-            name: name,
-            displayName: BrewInfoJSON.trimmedOrNil(fullName) ?? name,
-            kind: .formula,
-            description: BrewInfoJSON.trimmedOrEmpty(desc),
-            homepage: BrewInfoJSON.trimmedOrEmpty(homepage),
-            latestVersion: BrewInfoJSON.trimmedOrEmpty(versions.stable),
+        return InstalledBrewPackage(
+            package: BrewPackage(
+                name: name,
+                displayName: BrewInfoJSON.trimmedOrNil(fullName) ?? name,
+                kind: .formula,
+                description: BrewInfoJSON.trimmedOrEmpty(desc),
+                homepage: BrewInfoJSON.trimmedOrEmpty(homepage),
+                latestVersion: BrewInfoJSON.trimmedOrEmpty(versions.stable),
+                dependencies: HomebrewPackageReference.formulaDependencies(from: dependencies),
+            ),
             installedVersions: installedVersions,
-            dependencies: HomebrewPackageReference.formulaDependencies(from: runtimeDependencies),
             outdated: outdated,
         )
     }
 }
 
 private extension BrewInfoCask {
-    var asBrewPackage: BrewPackage {
+    var asBrewPackage: InstalledBrewPackage {
         let installed = BrewInfoJSON.uniqueNonEmpty(installedVersions)
         let latest = BrewInfoJSON.trimmedOrNil(versions.stable) ?? BrewInfoJSON.trimmedOrNil(version) ?? ""
-        return BrewPackage(
-            name: token,
-            displayName: BrewInfoJSON.trimmedOrNil(firstDisplayName) ?? token,
-            kind: .cask,
-            description: BrewInfoJSON.trimmedOrEmpty(desc),
-            homepage: BrewInfoJSON.trimmedOrEmpty(homepage),
-            latestVersion: latest,
+        return InstalledBrewPackage(
+            package: BrewPackage(
+                name: token,
+                displayName: BrewInfoJSON.trimmedOrNil(firstDisplayName) ?? token,
+                kind: .cask,
+                description: BrewInfoJSON.trimmedOrEmpty(desc),
+                homepage: BrewInfoJSON.trimmedOrEmpty(homepage),
+                latestVersion: latest,
+                dependencies: HomebrewPackageReference.uniqueReferences(dependencies),
+            ),
             installedVersions: installed,
-            dependencies: HomebrewPackageReference.uniqueReferences(dependencies),
             outdated: outdated,
         )
     }

--- a/Brew/Services/BrewCommand/PackageUninstallCommand.swift
+++ b/Brew/Services/BrewCommand/PackageUninstallCommand.swift
@@ -10,7 +10,7 @@ struct PackageUninstallCommand: BrewMutatingCommand {
     let packageName: String
     let kind: InstalledPackageKind
 
-    init(package: BrewPackage) {
+    init(package: InstalledBrewPackage) {
         packageName = package.name
         kind = package.kind
     }

--- a/Brew/Services/BrewCommand/PackageUpgradeCommand.swift
+++ b/Brew/Services/BrewCommand/PackageUpgradeCommand.swift
@@ -12,7 +12,7 @@ struct PackageUpgradeCommand: BrewMutatingCommand {
     let packageName: String
     let kind: InstalledPackageKind
 
-    init(package: BrewPackage) {
+    init(package: InstalledBrewPackage) {
         packageName = package.name
         kind = package.kind
     }

--- a/Brew/Services/InstalledInventory/InstalledInventoryCache.swift
+++ b/Brew/Services/InstalledInventory/InstalledInventoryCache.swift
@@ -8,8 +8,8 @@ import Foundation
 /// Shared installed-inventory storage with TTL semantics. Domain reads (packages, dependents) go through repositories, not this actor.
 actor InstalledInventoryCache {
     enum CacheResult {
-        case fresh([BrewPackage])
-        case stale([BrewPackage])
+        case fresh([InstalledBrewPackage])
+        case stale([InstalledBrewPackage])
         case empty
     }
 

--- a/Brew/Services/InstalledInventory/InstalledInventorySnapshot.swift
+++ b/Brew/Services/InstalledInventory/InstalledInventorySnapshot.swift
@@ -9,10 +9,10 @@ struct InstalledInventorySnapshot: Equatable {
     nonisolated static let defaultTTL: TimeInterval = 3600
 
     var fetchedAt: Date
-    let packages: [BrewPackage]
+    let packages: [InstalledBrewPackage]
     let graph: PackageDependencyGraph
 
-    init(fetchedAt: Date, packages: [BrewPackage]) {
+    init(fetchedAt: Date, packages: [InstalledBrewPackage]) {
         self.fetchedAt = fetchedAt
         self.packages = packages
         graph = PackageDependencyGraph(packages: packages)

--- a/BrewTests/BrewAPIClientCatalogueURLSessionIntegrationTests.swift
+++ b/BrewTests/BrewAPIClientCatalogueURLSessionIntegrationTests.swift
@@ -41,7 +41,21 @@ struct BrewAPICatalogueIntegrationTests {
         try StubURLProtocol.register(
             [
                 .successWithStatus(
-                    data: Data("{}".utf8),
+                    data: Data(
+                        """
+                        [
+                          {
+                            "name": "iterm2",
+                            "desc": "Terminal emulator",
+                            "homepage": "https://iterm2.com",
+                            "versions": { "stable": "3.5.0" },
+                            "analytics": {
+                              "install": { "30d": 1234 }
+                            }
+                          }
+                        ]
+                        """.utf8,
+                    ),
                     statusCode: 200,
                     headers: ["ETag": returnedETag],
                 ),
@@ -60,8 +74,90 @@ struct BrewAPICatalogueIntegrationTests {
         switch response {
         case .notModified:
             Issue.record("Expected .updated for 200 response")
-        case let .updated(data: _, etag):
+        case let .updated(data: data, etag):
+            #expect(data.items.count == 1)
+            #expect(data.decodeFailures.isEmpty)
+            #expect(data.items.first?.name == "iterm2")
+            #expect(data.items.first?.description == "Terminal emulator")
+            #expect(data.items.first?.homepage == "https://iterm2.com")
+            #expect(data.items.first?.stableVersion == "3.5.0")
+            #expect(data.items.first?.analyticsInstall30d == 1234)
             #expect(etag == returnedETag)
+        }
+    }
+
+    @Test @MainActor func `fetch formula catalogue collects decode failure on missing required fields`() async throws {
+        let baseURL = makeStubBaseURL()
+        try StubURLProtocol.register(
+            [
+                .successWithStatus(
+                    data: Data(
+                        """
+                        [
+                          {
+                            "name": "wget"
+                          }
+                        ]
+                        """.utf8,
+                    ),
+                    statusCode: 200,
+                    headers: ["ETag": #""catalogue-etag-789""#],
+                ),
+            ],
+            forHost: #require(baseURL.host),
+        )
+        let session = makeStubbedSession()
+        let client = URLSessionBrewAPIClient(session: session, baseURL: baseURL)
+
+        let response = try await client.fetchFormulaCatalogue(etag: nil)
+        switch response {
+        case .notModified:
+            Issue.record("Expected .updated for 200 response")
+        case let .updated(data: data, etag: _):
+            #expect(data.items.isEmpty)
+            #expect(data.decodeFailures.count == 1)
+            #expect(data.decodeFailures.first?.index == 0)
+        }
+    }
+
+    @Test @MainActor func `fetch formula catalogue keeps valid items when one item fails decoding`() async throws {
+        let baseURL = makeStubBaseURL()
+        try StubURLProtocol.register(
+            [
+                .successWithStatus(
+                    data: Data(
+                        """
+                        [
+                          {
+                            "name": "wget",
+                            "desc": "Network downloader",
+                            "homepage": "https://www.gnu.org/software/wget/",
+                            "versions": { "stable": "1.24.5" },
+                            "analytics": { "install": { "30d": 5000 } }
+                          },
+                          {
+                            "name": "broken-item"
+                          }
+                        ]
+                        """.utf8,
+                    ),
+                    statusCode: 200,
+                ),
+            ],
+            forHost: #require(baseURL.host),
+        )
+        let session = makeStubbedSession()
+        let client = URLSessionBrewAPIClient(session: session, baseURL: baseURL)
+
+        let response = try await client.fetchFormulaCatalogue(etag: nil)
+        switch response {
+        case .notModified:
+            Issue.record("Expected .updated for 200 response")
+        case let .updated(data: data, etag: _):
+            #expect(data.items.count == 1)
+            #expect(data.items.first?.name == "wget")
+            #expect(data.decodeFailures.count == 1)
+            #expect(data.decodeFailures.first?.index == 1)
         }
     }
 }

--- a/BrewTests/BrewAPIClientCatalogueURLSessionIntegrationTests.swift
+++ b/BrewTests/BrewAPIClientCatalogueURLSessionIntegrationTests.swift
@@ -1,0 +1,67 @@
+//
+//  BrewAPIClientCatalogueURLSessionIntegrationTests.swift
+//  BrewTests
+//
+
+@testable import Brew
+import Foundation
+import Testing
+
+struct BrewAPICatalogueIntegrationTests {
+    @Test @MainActor func `fetch formula catalogue sends if-none-match and returns not modified on 304`() async throws {
+        let baseURL = makeStubBaseURL()
+        let expectedURL = URL(string: "/api/formula.json", relativeTo: baseURL)?.absoluteURL
+        let existingETag = #""catalogue-etag-123""#
+        try StubURLProtocol.register(
+            [.successWithStatus(data: Data(), statusCode: 304)],
+            forHost: #require(baseURL.host),
+        )
+        let session = makeStubbedSession()
+        let client = URLSessionBrewAPIClient(session: session, baseURL: baseURL)
+
+        let response = try await client.fetchFormulaCatalogue(etag: existingETag)
+        let requests = try StubURLProtocol.requests(forHost: #require(baseURL.host))
+        #expect(requests.count == 1)
+        #expect(requests.first?.url == expectedURL)
+        #expect(requests.first?.httpMethod == "GET")
+        #expect(requests.first?.value(forHTTPHeaderField: "If-None-Match") == existingETag)
+
+        switch response {
+        case .notModified:
+            break
+        case .updated:
+            Issue.record("Expected .notModified for 304 response")
+        }
+    }
+
+    @Test @MainActor func `fetch cask catalogue returns updated payload and response etag on 200`() async throws {
+        let baseURL = makeStubBaseURL()
+        let expectedURL = URL(string: "/api/cask.json", relativeTo: baseURL)?.absoluteURL
+        let returnedETag = #""catalogue-etag-456""#
+        try StubURLProtocol.register(
+            [
+                .successWithStatus(
+                    data: Data("{}".utf8),
+                    statusCode: 200,
+                    headers: ["ETag": returnedETag],
+                ),
+            ],
+            forHost: #require(baseURL.host),
+        )
+        let session = makeStubbedSession()
+        let client = URLSessionBrewAPIClient(session: session, baseURL: baseURL)
+
+        let response = try await client.fetchCaskCatalogue(etag: nil)
+        let requests = try StubURLProtocol.requests(forHost: #require(baseURL.host))
+        #expect(requests.count == 1)
+        #expect(requests.first?.url == expectedURL)
+        #expect(requests.first?.value(forHTTPHeaderField: "If-None-Match") == nil)
+
+        switch response {
+        case .notModified:
+            Issue.record("Expected .updated for 200 response")
+        case let .updated(data: _, etag):
+            #expect(etag == returnedETag)
+        }
+    }
+}

--- a/BrewTests/BrewAPIClientURLSessionIntegrationTests.swift
+++ b/BrewTests/BrewAPIClientURLSessionIntegrationTests.swift
@@ -1,0 +1,339 @@
+//
+//  BrewAPIClientURLSessionIntegrationTests.swift
+//  BrewTests
+//
+
+@testable import Brew
+import Foundation
+import Testing
+
+struct BrewAPIClientURLSessionIntegrationTests {
+    @Test @MainActor func `fetch formula analytics decodes payload`() async throws {
+        let baseURL = makeStubBaseURL()
+        let expectedURL = URL(
+            string: "/api/analytics/install-on-request/homebrew-core/30d.json",
+            relativeTo: baseURL,
+        )?.absoluteURL
+        try StubURLProtocol.register(
+            [
+                .successWithStatus(
+                    data: Data(
+                        """
+                        {
+                          "category": "formula_install_on_request",
+                          "total_items": 2,
+                          "total_count": 1200,
+                          "start_date": "2026-04-17",
+                          "end_date": "2026-05-17",
+                          "formulae": {
+                            "wget": [{ "formula": "wget", "count": "1,000" }],
+                            "bat": [{ "formula": "bat", "count": "200" }]
+                          }
+                        }
+                        """.utf8,
+                    ),
+                    statusCode: 200,
+                ),
+            ],
+            forHost: #require(baseURL.host),
+        )
+        let session = makeStubbedSession()
+        let client = URLSessionBrewAPIClient(session: session, baseURL: baseURL)
+
+        let result = try await client.fetchFormulaInstallOnRequestAnalytics(window: .days30)
+        let requests = try StubURLProtocol.requests(forHost: #require(baseURL.host))
+        #expect(requests.count == 1)
+        #expect(requests.first?.url == expectedURL)
+        #expect(requests.first?.httpMethod == "GET")
+        #expect(result.category == "formula_install_on_request")
+        #expect(result.totalCount == 1200)
+
+        let countsByName = Dictionary(uniqueKeysWithValues: result.packageCounts.map { ($0.name, $0.count) })
+        #expect(countsByName["wget"] == 1000)
+        #expect(countsByName["bat"] == 200)
+    }
+
+    @Test @MainActor func `fetch cask analytics hits cask endpoint`() async throws {
+        let baseURL = makeStubBaseURL()
+        let expectedURL = URL(
+            string: "/api/analytics/cask-install/homebrew-cask/90d.json",
+            relativeTo: baseURL,
+        )?.absoluteURL
+        try StubURLProtocol.register(
+            [
+                .successWithStatus(
+                    data: Data(
+                        """
+                        {
+                          "category": "cask_install",
+                          "total_items": 1,
+                          "total_count": 50,
+                          "start_date": "2026-02-17",
+                          "end_date": "2026-05-17",
+                          "formulae": {
+                            "iterm2": [{ "cask": "iterm2", "count": "50" }]
+                          }
+                        }
+                        """.utf8,
+                    ),
+                    statusCode: 200,
+                ),
+            ],
+            forHost: #require(baseURL.host),
+        )
+        let session = makeStubbedSession()
+        let client = URLSessionBrewAPIClient(session: session, baseURL: baseURL)
+
+        _ = try await client.fetchCaskInstallAnalytics(window: .days90)
+        let requests = try StubURLProtocol.requests(forHost: #require(baseURL.host))
+        #expect(requests.first?.url == expectedURL)
+    }
+
+    @Test @MainActor func `fetch throws http status error for non success response`() async throws {
+        let baseURL = makeStubBaseURL()
+        try StubURLProtocol.register(
+            [.successWithStatus(data: Data("{\"error\":\"bad\"}".utf8), statusCode: 500)],
+            forHost: #require(baseURL.host),
+        )
+        let session = makeStubbedSession()
+        let client = URLSessionBrewAPIClient(session: session, baseURL: baseURL)
+
+        await #expect(throws: BrewAPIClientError.self) {
+            _ = try await client.fetchFormulaInstallOnRequestAnalytics(window: .days30)
+        }
+    }
+
+    @Test @MainActor func `fetch throws decoding error for invalid JSON`() async throws {
+        let baseURL = makeStubBaseURL()
+        try StubURLProtocol.register(
+            [.successWithStatus(data: Data("{ this-is-not-json }".utf8), statusCode: 200)],
+            forHost: #require(baseURL.host),
+        )
+        let session = makeStubbedSession()
+        let client = URLSessionBrewAPIClient(session: session, baseURL: baseURL)
+
+        await #expect(throws: BrewAPIClientError.self) {
+            _ = try await client.fetchFormulaInstallOnRequestAnalytics(window: .days30)
+        }
+    }
+
+    @Test @MainActor func `fetch throws decoding error when required fields are missing`() async throws {
+        let baseURL = makeStubBaseURL()
+        try StubURLProtocol.register(
+            [
+                .successWithStatus(
+                    data: Data(
+                        """
+                        {
+                          "category": "formula_install_on_request",
+                          "total_items": 2,
+                          "start_date": "2026-04-17",
+                          "end_date": "2026-05-17",
+                          "formulae": {
+                            "wget": [{ "formula": "wget", "count": "1000" }]
+                          }
+                        }
+                        """.utf8,
+                    ),
+                    statusCode: 200,
+                ),
+            ],
+            forHost: #require(baseURL.host),
+        )
+        let session = makeStubbedSession()
+        let client = URLSessionBrewAPIClient(session: session, baseURL: baseURL)
+
+        await #expect(throws: BrewAPIClientError.self) {
+            _ = try await client.fetchFormulaInstallOnRequestAnalytics(window: .days30)
+        }
+    }
+
+    @Test @MainActor func `fetch throws decoding error when entry count is malformed`() async throws {
+        let baseURL = makeStubBaseURL()
+        try StubURLProtocol.register(
+            [
+                .successWithStatus(
+                    data: Data(
+                        """
+                        {
+                          "category": "formula_install_on_request",
+                          "total_items": 2,
+                          "total_count": 1200,
+                          "start_date": "2026-04-17",
+                          "end_date": "2026-05-17",
+                          "formulae": {
+                            "wget": [{ "formula": "wget", "count": "not-a-number" }]
+                          }
+                        }
+                        """.utf8,
+                    ),
+                    statusCode: 200,
+                ),
+            ],
+            forHost: #require(baseURL.host),
+        )
+        let session = makeStubbedSession()
+        let client = URLSessionBrewAPIClient(session: session, baseURL: baseURL)
+
+        await #expect(throws: BrewAPIClientError.self) {
+            _ = try await client.fetchFormulaInstallOnRequestAnalytics(window: .days30)
+        }
+    }
+
+    @Test @MainActor func `fetch throws decoding error when entry package identity is missing`() async throws {
+        let baseURL = makeStubBaseURL()
+        try StubURLProtocol.register(
+            [
+                .successWithStatus(
+                    data: Data(
+                        """
+                        {
+                          "category": "formula_install_on_request",
+                          "total_items": 2,
+                          "total_count": 1200,
+                          "start_date": "2026-04-17",
+                          "end_date": "2026-05-17",
+                          "formulae": {
+                            "wget": [{ "count": "1000" }]
+                          }
+                        }
+                        """.utf8,
+                    ),
+                    statusCode: 200,
+                ),
+            ],
+            forHost: #require(baseURL.host),
+        )
+        let session = makeStubbedSession()
+        let client = URLSessionBrewAPIClient(session: session, baseURL: baseURL)
+
+        await #expect(throws: BrewAPIClientError.self) {
+            _ = try await client.fetchFormulaInstallOnRequestAnalytics(window: .days30)
+        }
+    }
+
+    @Test @MainActor func `fetch throws transport error when request execution fails`() async throws {
+        let baseURL = makeStubBaseURL()
+        try StubURLProtocol.register(
+            [.failure(URLError(.timedOut))],
+            forHost: #require(baseURL.host),
+        )
+        let session = makeStubbedSession()
+        let client = URLSessionBrewAPIClient(session: session, baseURL: baseURL)
+
+        await #expect(throws: BrewAPIClientError.self) {
+            _ = try await client.fetchFormulaInstallOnRequestAnalytics(window: .days30)
+        }
+    }
+
+    @Test @MainActor func `fetch throws invalid response when URL response is not HTTP`() async throws {
+        let baseURL = makeStubBaseURL()
+        let responseURL = try #require(URL(string: "https://formulae.brew.sh"))
+        try StubURLProtocol.register(
+            [
+                .successWithResponse(
+                    data: Data(),
+                    response: URLResponse(
+                        url: responseURL,
+                        mimeType: "application/json",
+                        expectedContentLength: 0,
+                        textEncodingName: nil,
+                    ),
+                ),
+            ],
+            forHost: #require(baseURL.host),
+        )
+        let session = makeStubbedSession()
+        let client = URLSessionBrewAPIClient(session: session, baseURL: baseURL)
+
+        await #expect(throws: BrewAPIClientError.self) {
+            _ = try await client.fetchFormulaInstallOnRequestAnalytics(window: .days30)
+        }
+    }
+}
+
+private func makeStubbedSession() -> URLSession {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [StubURLProtocol.self]
+    return URLSession(configuration: configuration)
+}
+
+private func makeStubBaseURL() -> URL {
+    URL(string: "https://stub-\(UUID().uuidString).local") ?? URL(fileURLWithPath: "/")
+}
+
+private final class StubURLProtocol: URLProtocol {
+    enum StubbedResult {
+        case successWithStatus(data: Data, statusCode: Int)
+        case successWithResponse(data: Data, response: URLResponse)
+        case failure(Error)
+    }
+
+    private static let lock = NSLock()
+    private static var queuedResultsByHost: [String: [StubbedResult]] = [:]
+    private static var requestsByHost: [String: [URLRequest]] = [:]
+
+    static func register(_ results: [StubbedResult], forHost host: String) {
+        lock.lock()
+        queuedResultsByHost[host] = results
+        requestsByHost[host] = []
+        lock.unlock()
+    }
+
+    static func requests(forHost host: String) -> [URLRequest] {
+        lock.lock()
+        let requests = requestsByHost[host] ?? []
+        lock.unlock()
+        return requests
+    }
+
+    // swiftlint:disable:next static_over_final_class
+    override class func canInit(with _: URLRequest) -> Bool {
+        true
+    }
+
+    // swiftlint:disable:next static_over_final_class
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let host = request.url?.host else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+
+        let result: StubbedResult
+        Self.lock.lock()
+        Self.requestsByHost[host, default: []].append(request)
+        var queuedResults = Self.queuedResultsByHost[host] ?? []
+        if queuedResults.isEmpty {
+            result = .failure(URLError(.badServerResponse))
+        } else {
+            result = queuedResults.removeFirst()
+            Self.queuedResultsByHost[host] = queuedResults
+        }
+        Self.lock.unlock()
+
+        switch result {
+        case let .successWithStatus(data, statusCode):
+            if let url = request.url,
+               let response = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil)
+            {
+                client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                client?.urlProtocol(self, didLoad: data)
+                client?.urlProtocolDidFinishLoading(self)
+            } else {
+                client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            }
+        case let .successWithResponse(data, response):
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        case let .failure(error):
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}

--- a/BrewTests/BrewAPIClientURLSessionIntegrationTests.swift
+++ b/BrewTests/BrewAPIClientURLSessionIntegrationTests.swift
@@ -252,19 +252,19 @@ struct BrewAPIClientURLSessionIntegrationTests {
     }
 }
 
-private func makeStubbedSession() -> URLSession {
+func makeStubbedSession() -> URLSession {
     let configuration = URLSessionConfiguration.ephemeral
     configuration.protocolClasses = [StubURLProtocol.self]
     return URLSession(configuration: configuration)
 }
 
-private func makeStubBaseURL() -> URL {
+func makeStubBaseURL() -> URL {
     URL(string: "https://stub-\(UUID().uuidString).local") ?? URL(fileURLWithPath: "/")
 }
 
-private final class StubURLProtocol: URLProtocol {
+final class StubURLProtocol: URLProtocol {
     enum StubbedResult {
-        case successWithStatus(data: Data, statusCode: Int)
+        case successWithStatus(data: Data, statusCode: Int, headers: [String: String] = [:])
         case successWithResponse(data: Data, response: URLResponse)
         case failure(Error)
     }
@@ -316,9 +316,9 @@ private final class StubURLProtocol: URLProtocol {
         Self.lock.unlock()
 
         switch result {
-        case let .successWithStatus(data, statusCode):
+        case let .successWithStatus(data, statusCode, headers):
             if let url = request.url,
-               let response = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil)
+               let response = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: headers)
             {
                 client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
                 client?.urlProtocol(self, didLoad: data)

--- a/BrewTests/BrewCatalogueRepositoryTests.swift
+++ b/BrewTests/BrewCatalogueRepositoryTests.swift
@@ -15,7 +15,7 @@ struct BrewCatalogueRepositoryTests {
             formulaHandler: { _ in throw BrewAPIClientError.transport(underlying: "offline") },
             caskHandler: { _ in .notModified },
         )
-        let cache = await CatalogueCache(
+        let cache = CatalogueCache(
             userDefaults: fixture.userDefaults,
             cacheDirectoryURL: fixture.cacheDirectoryURL,
         )
@@ -36,7 +36,7 @@ struct BrewCatalogueRepositoryTests {
         let fixture = TestFixture()
         defer { fixture.cleanup() }
 
-        let cache = await CatalogueCache(
+        let cache = CatalogueCache(
             userDefaults: fixture.userDefaults,
             cacheDirectoryURL: fixture.cacheDirectoryURL,
         )
@@ -80,7 +80,7 @@ struct BrewCatalogueRepositoryTests {
         let fixture = TestFixture()
         defer { fixture.cleanup() }
 
-        let cache = await CatalogueCache(
+        let cache = CatalogueCache(
             userDefaults: fixture.userDefaults,
             cacheDirectoryURL: fixture.cacheDirectoryURL,
         )
@@ -113,7 +113,7 @@ struct BrewCatalogueRepositoryTests {
         let fixture = TestFixture()
         defer { fixture.cleanup() }
 
-        let cache = await CatalogueCache(
+        let cache = CatalogueCache(
             userDefaults: fixture.userDefaults,
             cacheDirectoryURL: fixture.cacheDirectoryURL,
         )
@@ -147,6 +147,62 @@ struct BrewCatalogueRepositoryTests {
         #expect(firstResult.items.first?.name == "deduped")
         #expect(secondResult.items.first?.name == "deduped")
         #expect(await apiClient.formulaCallCount() == 1)
+    }
+
+    @Test @MainActor func `force refresh not modified throws when cache has no formula payload`() async throws {
+        let fixture = TestFixture()
+        defer { fixture.cleanup() }
+
+        let cache = MockCatalogueCache(formulaETag: #""etag-current""#)
+        let apiClient = StubCatalogueAPIClient(
+            formulaHandler: { _ in .notModified },
+            caskHandler: { _ in .notModified },
+        )
+        let repository = BrewCatalogueRepository(
+            apiClient: apiClient,
+            cache: cache,
+            userDefaults: fixture.userDefaults,
+            now: Date.init,
+            ttl: 60,
+        )
+
+        do {
+            _ = try await repository.loadFormulaCatalogue(forceRefresh: true)
+            #expect(Bool(false), "Expected cache-missing error for not-modified response.")
+        } catch let error as CatalogueRepositoryError {
+            #expect(error == .cacheMissingAfterNotModified(kind: .formula))
+        }
+        #expect(await apiClient.recordedFormulaETags() == [#""etag-current""#])
+    }
+
+    @Test @MainActor func `force refresh updated response persists through cache protocol`() async throws {
+        let fixture = TestFixture()
+        defer { fixture.cleanup() }
+
+        let cache = MockCatalogueCache(formulaETag: #""etag-prev""#)
+        let rawData = fixture.formulaCacheJSON(name: "wget", installs: 777)
+        let payload = try JSONDecoder().decode(FormulaCatalogueJSON.self, from: rawData)
+        let apiClient = StubCatalogueAPIClient(
+            formulaHandler: { _ in
+                .updated(data: payload, etag: #""etag-next""#)
+            },
+            caskHandler: { _ in .notModified },
+        )
+        let repository = BrewCatalogueRepository(
+            apiClient: apiClient,
+            cache: cache,
+            userDefaults: fixture.userDefaults,
+            now: Date.init,
+            ttl: 60,
+        )
+
+        let refreshed = try await repository.loadFormulaCatalogue(forceRefresh: true)
+
+        #expect(refreshed.items.first?.name == "wget")
+        #expect(await apiClient.recordedFormulaETags() == [#""etag-prev""#])
+        #expect(await cache.formulaUpdateCount() == 1)
+        #expect(await cache.latestFormulaETag() == #""etag-next""#)
+        #expect(await cache.formulaCatalogue()?.items.first?.name == "wget")
     }
 }
 
@@ -219,6 +275,63 @@ private actor DeferredFormulaStubCatalogueAPIClient: BrewAPIClient {
     func resumeFormula(with response: CatalogueResponse<FormulaCatalogueJSON>) {
         continuation?.resume(returning: response)
         continuation = nil
+    }
+}
+
+private actor MockCatalogueCache: CatalogueCaching {
+    private let decoder = JSONDecoder()
+    private var formulaData: FormulaCatalogueJSON?
+    private var caskData: CaskCatalogueJSON?
+    private var formulaETag: String?
+    private var caskETag: String?
+    private var formulaUpdates: [(etag: String?, rawData: Data)] = []
+
+    init(
+        formulaData: FormulaCatalogueJSON? = nil,
+        caskData: CaskCatalogueJSON? = nil,
+        formulaETag: String? = nil,
+        caskETag: String? = nil,
+    ) {
+        self.formulaData = formulaData
+        self.caskData = caskData
+        self.formulaETag = formulaETag
+        self.caskETag = caskETag
+    }
+
+    func formulaCatalogue() async -> FormulaCatalogueJSON? {
+        formulaData
+    }
+
+    func caskCatalogue() async -> CaskCatalogueJSON? {
+        caskData
+    }
+
+    func etag(for kind: CatalogueCache.CatalogueKind) async -> String? {
+        switch kind {
+        case .formula:
+            formulaETag
+        case .cask:
+            caskETag
+        }
+    }
+
+    func updateFormulaCatalogue(with rawData: Data, etag: String?) async throws {
+        formulaData = try decoder.decode(FormulaCatalogueJSON.self, from: rawData)
+        formulaETag = etag
+        formulaUpdates.append((etag: etag, rawData: rawData))
+    }
+
+    func updateCaskCatalogue(with rawData: Data, etag: String?) async throws {
+        caskData = try decoder.decode(CaskCatalogueJSON.self, from: rawData)
+        caskETag = etag
+    }
+
+    func formulaUpdateCount() -> Int {
+        formulaUpdates.count
+    }
+
+    func latestFormulaETag() -> String? {
+        formulaUpdates.last?.etag
     }
 }
 

--- a/BrewTests/BrewCatalogueRepositoryTests.swift
+++ b/BrewTests/BrewCatalogueRepositoryTests.swift
@@ -40,7 +40,11 @@ struct BrewCatalogueRepositoryTests {
             userDefaults: fixture.userDefaults,
             cacheDirectoryURL: fixture.cacheDirectoryURL,
         )
-        let staleData = fixture.formulaCacheJSON(name: "stale", installs: 123)
+        let staleData = fixture.formulaCacheJSON(
+            name: "stale",
+            installs: 123,
+            dependencies: ["openssl@3"],
+        )
         try await cache.updateFormulaCatalogue(with: staleData, etag: #""etag-stale""#)
         fixture.userDefaults.set(Date(timeIntervalSinceReferenceDate: 0), forKey: fixture.formulaLastRefreshKey)
 
@@ -62,14 +66,15 @@ struct BrewCatalogueRepositoryTests {
         )
 
         let first = try await repository.loadFormulaCatalogue()
-        #expect(first.items.first?.name == "stale")
+        #expect(first.first?.name == "stale")
+        #expect(first.first?.dependencies == [.formula(name: "openssl@3")])
 
         #expect(await waitUntil {
             await apiClient.formulaCallCount() == 1
         })
         #expect(await waitUntil {
             let latest = try await repository.loadFormulaCatalogue()
-            return latest.items.first?.name == "fresh"
+            return latest.first?.name == "fresh"
         })
         let etags = await apiClient.recordedFormulaETags()
         #expect(etags.first == #""etag-stale""#)
@@ -84,7 +89,11 @@ struct BrewCatalogueRepositoryTests {
             userDefaults: fixture.userDefaults,
             cacheDirectoryURL: fixture.cacheDirectoryURL,
         )
-        let staleData = fixture.formulaCacheJSON(name: "cached", installs: 5)
+        let staleData = fixture.formulaCacheJSON(
+            name: "cached",
+            installs: 5,
+            dependencies: ["pkg-config", "openssl@3"],
+        )
         try await cache.updateFormulaCatalogue(with: staleData, etag: #""etag-current""#)
         let staleDate = Date(timeIntervalSinceReferenceDate: 0)
         fixture.userDefaults.set(staleDate, forKey: fixture.formulaLastRefreshKey)
@@ -102,7 +111,8 @@ struct BrewCatalogueRepositoryTests {
         )
 
         let refreshed = try await repository.loadFormulaCatalogue(forceRefresh: true)
-        #expect(refreshed.items.first?.name == "cached")
+        #expect(refreshed.first?.name == "cached")
+        #expect(refreshed.first?.dependencies == [.formula(name: "pkg-config"), .formula(name: "openssl@3")])
         #expect(await apiClient.recordedFormulaETags() == [#""etag-current""#])
 
         let updatedDate = fixture.userDefaults.object(forKey: fixture.formulaLastRefreshKey) as? Date
@@ -144,8 +154,8 @@ struct BrewCatalogueRepositoryTests {
 
         let firstResult = try await first
         let secondResult = try await second
-        #expect(firstResult.items.first?.name == "deduped")
-        #expect(secondResult.items.first?.name == "deduped")
+        #expect(firstResult.first?.name == "deduped")
+        #expect(secondResult.first?.name == "deduped")
         #expect(await apiClient.formulaCallCount() == 1)
     }
 
@@ -198,11 +208,50 @@ struct BrewCatalogueRepositoryTests {
 
         let refreshed = try await repository.loadFormulaCatalogue(forceRefresh: true)
 
-        #expect(refreshed.items.first?.name == "wget")
+        #expect(refreshed.first?.name == "wget")
         #expect(await apiClient.recordedFormulaETags() == [#""etag-prev""#])
         #expect(await cache.formulaUpdateCount() == 1)
         #expect(await cache.latestFormulaETag() == #""etag-next""#)
         #expect(await cache.formulaCatalogue()?.items.first?.name == "wget")
+    }
+
+    @Test @MainActor func `load cask catalogue maps formula and cask dependencies`() async throws {
+        let fixture = TestFixture()
+        defer { fixture.cleanup() }
+
+        let cache = CatalogueCache(
+            userDefaults: fixture.userDefaults,
+            cacheDirectoryURL: fixture.cacheDirectoryURL,
+        )
+        let rawData = fixture.caskCacheJSON(
+            name: "docker-desktop",
+            installs: 420,
+            dependencies: ["colima"],
+            formulaDependsOn: ["docker"],
+            caskDependsOn: ["iterm2"],
+        )
+        let payload = try JSONDecoder().decode(CaskCatalogueJSON.self, from: rawData)
+        let apiClient = StubCatalogueAPIClient(
+            formulaHandler: { _ in .notModified },
+            caskHandler: { _ in .updated(data: payload, etag: #""cask-etag""#) },
+        )
+        let repository = BrewCatalogueRepository(
+            apiClient: apiClient,
+            cache: cache,
+            userDefaults: fixture.userDefaults,
+            now: Date.init,
+        )
+
+        let packages = try await repository.loadCaskCatalogue(forceRefresh: true)
+        let cask = try #require(packages.first)
+        #expect(cask.name == "docker-desktop")
+        #expect(
+            cask.dependencies == [
+                .formula(name: "colima"),
+                .formula(name: "docker"),
+                .cask(token: "iterm2"),
+            ],
+        )
     }
 }
 
@@ -355,8 +404,9 @@ private struct TestFixture {
         userDefaults.removePersistentDomain(forName: userDefaultsSuiteName)
     }
 
-    func formulaCacheJSON(name: String, installs: Int) -> Data {
-        Data(
+    func formulaCacheJSON(name: String, installs: Int, dependencies: [String] = []) -> Data {
+        let dependenciesJSON = dependenciesJSONLiteral(from: dependencies)
+        return Data(
             """
             [
               {
@@ -364,11 +414,47 @@ private struct TestFixture {
                 "desc": "Formula \(name)",
                 "homepage": "https://example.com/\(name)",
                 "versions": { "stable": "1.0.0" },
-                "analytics": { "install": { "30d": \(installs) } }
+                "analytics": { "install": { "30d": \(installs) } },
+                "dependencies": \(dependenciesJSON)
               }
             ]
             """.utf8,
         )
+    }
+
+    func caskCacheJSON(
+        name: String,
+        installs: Int,
+        dependencies: [String] = [],
+        formulaDependsOn: [String] = [],
+        caskDependsOn: [String] = [],
+    ) -> Data {
+        let dependenciesJSON = dependenciesJSONLiteral(from: dependencies)
+        let formulaDependsOnJSON = dependenciesJSONLiteral(from: formulaDependsOn)
+        let caskDependsOnJSON = dependenciesJSONLiteral(from: caskDependsOn)
+        return Data(
+            """
+            [
+              {
+                "name": "\(name)",
+                "desc": "Cask \(name)",
+                "homepage": "https://example.com/\(name)",
+                "versions": { "stable": "2.0.0" },
+                "analytics": { "install": { "30d": \(installs) } },
+                "dependencies": \(dependenciesJSON),
+                "depends_on": {
+                  "formula": \(formulaDependsOnJSON),
+                  "cask": \(caskDependsOnJSON)
+                }
+              }
+            ]
+            """.utf8,
+        )
+    }
+
+    private func dependenciesJSONLiteral(from dependencies: [String]) -> String {
+        let quoted = dependencies.map { "\"\($0)\"" }.joined(separator: ", ")
+        return "[\(quoted)]"
     }
 }
 

--- a/BrewTests/BrewCatalogueRepositoryTests.swift
+++ b/BrewTests/BrewCatalogueRepositoryTests.swift
@@ -1,0 +1,276 @@
+//
+//  BrewCatalogueRepositoryTests.swift
+//  BrewTests
+//
+
+@testable import Brew
+import Foundation
+import Testing
+
+struct BrewCatalogueRepositoryTests {
+    @Test @MainActor func `cold start surfaces fetch errors`() async throws {
+        let fixture = TestFixture()
+        defer { fixture.cleanup() }
+        let apiClient = StubCatalogueAPIClient(
+            formulaHandler: { _ in throw BrewAPIClientError.transport(underlying: "offline") },
+            caskHandler: { _ in .notModified },
+        )
+        let cache = await CatalogueCache(
+            userDefaults: fixture.userDefaults,
+            cacheDirectoryURL: fixture.cacheDirectoryURL,
+        )
+        let repository = BrewCatalogueRepository(
+            apiClient: apiClient,
+            cache: cache,
+            userDefaults: fixture.userDefaults,
+            now: Date.init,
+        )
+
+        await #expect(throws: BrewAPIClientError.self) {
+            _ = try await repository.loadFormulaCatalogue()
+        }
+        #expect(await apiClient.formulaCallCount() == 1)
+    }
+
+    @Test @MainActor func `stale formula returns cached value and refreshes in background`() async throws {
+        let fixture = TestFixture()
+        defer { fixture.cleanup() }
+
+        let cache = await CatalogueCache(
+            userDefaults: fixture.userDefaults,
+            cacheDirectoryURL: fixture.cacheDirectoryURL,
+        )
+        let staleData = fixture.formulaCacheJSON(name: "stale", installs: 123)
+        try await cache.updateFormulaCatalogue(with: staleData, etag: #""etag-stale""#)
+        fixture.userDefaults.set(Date(timeIntervalSinceReferenceDate: 0), forKey: fixture.formulaLastRefreshKey)
+
+        let refreshedRawData = fixture.formulaCacheJSON(name: "fresh", installs: 999)
+        let refreshedPayload = try JSONDecoder().decode(FormulaCatalogueJSON.self, from: refreshedRawData)
+        let apiClient = StubCatalogueAPIClient(
+            formulaHandler: { _ in
+                try await Task.sleep(nanoseconds: 100_000_000)
+                return .updated(data: refreshedPayload, etag: #""etag-fresh""#)
+            },
+            caskHandler: { _ in .notModified },
+        )
+        let repository = BrewCatalogueRepository(
+            apiClient: apiClient,
+            cache: cache,
+            userDefaults: fixture.userDefaults,
+            now: Date.init,
+            ttl: 60,
+        )
+
+        let first = try await repository.loadFormulaCatalogue()
+        #expect(first.items.first?.name == "stale")
+
+        #expect(await waitUntil {
+            await apiClient.formulaCallCount() == 1
+        })
+        #expect(await waitUntil {
+            let latest = try await repository.loadFormulaCatalogue()
+            return latest.items.first?.name == "fresh"
+        })
+        let etags = await apiClient.recordedFormulaETags()
+        #expect(etags.first == #""etag-stale""#)
+        #expect(!etags.isEmpty)
+    }
+
+    @Test @MainActor func `not modified refresh updates last refresh and keeps cached data`() async throws {
+        let fixture = TestFixture()
+        defer { fixture.cleanup() }
+
+        let cache = await CatalogueCache(
+            userDefaults: fixture.userDefaults,
+            cacheDirectoryURL: fixture.cacheDirectoryURL,
+        )
+        let staleData = fixture.formulaCacheJSON(name: "cached", installs: 5)
+        try await cache.updateFormulaCatalogue(with: staleData, etag: #""etag-current""#)
+        let staleDate = Date(timeIntervalSinceReferenceDate: 0)
+        fixture.userDefaults.set(staleDate, forKey: fixture.formulaLastRefreshKey)
+
+        let apiClient = StubCatalogueAPIClient(
+            formulaHandler: { _ in .notModified },
+            caskHandler: { _ in .notModified },
+        )
+        let repository = BrewCatalogueRepository(
+            apiClient: apiClient,
+            cache: cache,
+            userDefaults: fixture.userDefaults,
+            now: Date.init,
+            ttl: 60,
+        )
+
+        let refreshed = try await repository.loadFormulaCatalogue(forceRefresh: true)
+        #expect(refreshed.items.first?.name == "cached")
+        #expect(await apiClient.recordedFormulaETags() == [#""etag-current""#])
+
+        let updatedDate = fixture.userDefaults.object(forKey: fixture.formulaLastRefreshKey) as? Date
+        #expect((updatedDate ?? .distantPast) > staleDate)
+    }
+
+    @Test @MainActor func `force refresh deduplicates in flight request task`() async throws {
+        let fixture = TestFixture()
+        defer { fixture.cleanup() }
+
+        let cache = await CatalogueCache(
+            userDefaults: fixture.userDefaults,
+            cacheDirectoryURL: fixture.cacheDirectoryURL,
+        )
+        let apiClient = DeferredFormulaStubCatalogueAPIClient()
+        let repository = BrewCatalogueRepository(
+            apiClient: apiClient,
+            cache: cache,
+            userDefaults: fixture.userDefaults,
+            now: Date.init,
+        )
+
+        async let first = repository.loadFormulaCatalogue(forceRefresh: true)
+        async let second = repository.loadFormulaCatalogue(forceRefresh: true)
+
+        #expect(await waitUntil {
+            await apiClient.formulaCallCount() == 1
+        })
+        let dedupedPayload = try JSONDecoder().decode(
+            FormulaCatalogueJSON.self,
+            from: fixture.formulaCacheJSON(name: "deduped", installs: 99),
+        )
+        await apiClient.resumeFormula(
+            with: .updated(
+                data: dedupedPayload,
+                etag: #""etag-deduped""#,
+            ),
+        )
+
+        let firstResult = try await first
+        let secondResult = try await second
+        #expect(firstResult.items.first?.name == "deduped")
+        #expect(secondResult.items.first?.name == "deduped")
+        #expect(await apiClient.formulaCallCount() == 1)
+    }
+}
+
+private actor StubCatalogueAPIClient: BrewAPIClient {
+    typealias FormulaHandler = @Sendable (String?) async throws -> CatalogueResponse<FormulaCatalogueJSON>
+    typealias CaskHandler = @Sendable (String?) async throws -> CatalogueResponse<CaskCatalogueJSON>
+
+    private let formulaHandler: FormulaHandler
+    private let caskHandler: CaskHandler
+    private var formulaETags: [String?] = []
+
+    init(formulaHandler: @escaping FormulaHandler, caskHandler: @escaping CaskHandler) {
+        self.formulaHandler = formulaHandler
+        self.caskHandler = caskHandler
+    }
+
+    func fetchFormulaInstallOnRequestAnalytics(window _: BrewAnalyticsWindow) async throws -> BrewAnalyticsJSON {
+        throw BrewAPIClientError.invalidResponse
+    }
+
+    func fetchCaskInstallAnalytics(window _: BrewAnalyticsWindow) async throws -> BrewAnalyticsJSON {
+        throw BrewAPIClientError.invalidResponse
+    }
+
+    func fetchFormulaCatalogue(etag: String?) async throws -> CatalogueResponse<FormulaCatalogueJSON> {
+        formulaETags.append(etag)
+        return try await formulaHandler(etag)
+    }
+
+    func fetchCaskCatalogue(etag: String?) async throws -> CatalogueResponse<CaskCatalogueJSON> {
+        try await caskHandler(etag)
+    }
+
+    func formulaCallCount() -> Int {
+        formulaETags.count
+    }
+
+    func recordedFormulaETags() -> [String?] {
+        formulaETags
+    }
+}
+
+private actor DeferredFormulaStubCatalogueAPIClient: BrewAPIClient {
+    private var formulaETags: [String?] = []
+    private var continuation: CheckedContinuation<CatalogueResponse<FormulaCatalogueJSON>, Error>?
+
+    func fetchFormulaInstallOnRequestAnalytics(window _: BrewAnalyticsWindow) async throws -> BrewAnalyticsJSON {
+        throw BrewAPIClientError.invalidResponse
+    }
+
+    func fetchCaskInstallAnalytics(window _: BrewAnalyticsWindow) async throws -> BrewAnalyticsJSON {
+        throw BrewAPIClientError.invalidResponse
+    }
+
+    func fetchFormulaCatalogue(etag: String?) async throws -> CatalogueResponse<FormulaCatalogueJSON> {
+        formulaETags.append(etag)
+        return try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func fetchCaskCatalogue(etag _: String?) async throws -> CatalogueResponse<CaskCatalogueJSON> {
+        .notModified
+    }
+
+    func formulaCallCount() -> Int {
+        formulaETags.count
+    }
+
+    func resumeFormula(with response: CatalogueResponse<FormulaCatalogueJSON>) {
+        continuation?.resume(returning: response)
+        continuation = nil
+    }
+}
+
+private struct TestFixture {
+    let cacheDirectoryURL: URL
+    let userDefaults: UserDefaults
+    let userDefaultsSuiteName: String
+    let formulaLastRefreshKey = "CatalogueRepository.formula.lastRefresh"
+
+    init() {
+        let id = UUID().uuidString
+        cacheDirectoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BrewCatalogueRepositoryTests-\(id)", isDirectory: true)
+        userDefaultsSuiteName = "BrewCatalogueRepositoryTests.\(id)"
+        userDefaults = UserDefaults(suiteName: userDefaultsSuiteName) ?? .standard
+        userDefaults.removePersistentDomain(forName: userDefaultsSuiteName)
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: cacheDirectoryURL)
+        userDefaults.removePersistentDomain(forName: userDefaultsSuiteName)
+    }
+
+    func formulaCacheJSON(name: String, installs: Int) -> Data {
+        Data(
+            """
+            [
+              {
+                "name": "\(name)",
+                "desc": "Formula \(name)",
+                "homepage": "https://example.com/\(name)",
+                "versions": { "stable": "1.0.0" },
+                "analytics": { "install": { "30d": \(installs) } }
+              }
+            ]
+            """.utf8,
+        )
+    }
+}
+
+private func waitUntil(
+    timeoutNanoseconds: UInt64 = 2_000_000_000,
+    pollNanoseconds: UInt64 = 20_000_000,
+    condition: @escaping @Sendable () async throws -> Bool,
+) async -> Bool {
+    let start = DispatchTime.now().uptimeNanoseconds
+    while DispatchTime.now().uptimeNanoseconds - start < timeoutNanoseconds {
+        let matches = try? await condition()
+        if matches == true {
+            return true
+        }
+        try? await Task.sleep(nanoseconds: pollNanoseconds)
+    }
+    return false
+}

--- a/BrewTests/BrewDiscoverPackagesRepositoryTests.swift
+++ b/BrewTests/BrewDiscoverPackagesRepositoryTests.swift
@@ -151,6 +151,14 @@ private struct MockBrewAPIClient: BrewAPIClient {
     func fetchCaskInstallAnalytics(window _: BrewAnalyticsWindow) async throws -> BrewAnalyticsJSON {
         caskAnalytics
     }
+
+    func fetchFormulaCatalogue(etag _: String?) async throws -> CatalogueResponse<FormulaCatalogueJSON> {
+        .notModified
+    }
+
+    func fetchCaskCatalogue(etag _: String?) async throws -> CatalogueResponse<CaskCatalogueJSON> {
+        .notModified
+    }
 }
 
 @MainActor
@@ -160,6 +168,14 @@ private struct ThrowingBrewAPIClient: BrewAPIClient {
     }
 
     func fetchCaskInstallAnalytics(window _: BrewAnalyticsWindow) async throws -> BrewAnalyticsJSON {
+        throw BrewAPIClientError.transport(underlying: "offline")
+    }
+
+    func fetchFormulaCatalogue(etag _: String?) async throws -> CatalogueResponse<FormulaCatalogueJSON> {
+        throw BrewAPIClientError.transport(underlying: "offline")
+    }
+
+    func fetchCaskCatalogue(etag _: String?) async throws -> CatalogueResponse<CaskCatalogueJSON> {
         throw BrewAPIClientError.transport(underlying: "offline")
     }
 }

--- a/BrewTests/BrewDiscoverPackagesRepositoryTests.swift
+++ b/BrewTests/BrewDiscoverPackagesRepositoryTests.swift
@@ -1,0 +1,169 @@
+//
+//  BrewDiscoverPackagesRepositoryTests.swift
+//  BrewTests
+//
+
+@testable import Brew
+import Foundation
+import Testing
+
+struct BrewDiscoverPackagesRepositoryTests {
+    @Test @MainActor func `loadTopPackages sorts descending and applies limit`() async throws {
+        let formulaAnalytics = try analytics(
+            from: """
+            {
+              "category": "formula_install_on_request",
+              "total_items": 3,
+              "total_count": 2300,
+              "start_date": "2026-04-17",
+              "end_date": "2026-05-17",
+              "formulae": {
+                "wget": [{ "formula": "wget", "count": "500" }],
+                "bat": [{ "formula": "bat", "count": "1,500" }],
+                "fd": [{ "formula": "fd", "count": "300" }]
+              }
+            }
+            """,
+        )
+        let caskAnalytics = try analytics(
+            from: """
+            {
+              "category": "cask_install",
+              "total_items": 3,
+              "total_count": 900,
+              "start_date": "2026-04-17",
+              "end_date": "2026-05-17",
+              "formulae": {
+                "iterm2": [{ "cask": "iterm2", "count": "400" }],
+                "raycast": [{ "cask": "raycast", "count": "450" }],
+                "docker-desktop": [{ "cask": "docker-desktop", "count": "50" }]
+              }
+            }
+            """,
+        )
+
+        let repository = BrewDiscoverPackagesRepository(
+            apiClient: MockBrewAPIClient(
+                formulaAnalytics: formulaAnalytics,
+                caskAnalytics: caskAnalytics,
+            ),
+        )
+
+        let snapshot = try await repository.loadTopPackages(limit: 2, window: .days30)
+        #expect(snapshot.topFormulae == [
+            DiscoverTopPackage(reference: .formula(name: "bat"), installCount: 1500),
+            DiscoverTopPackage(reference: .formula(name: "wget"), installCount: 500),
+        ])
+        #expect(snapshot.topCasks == [
+            DiscoverTopPackage(reference: .cask(token: "raycast"), installCount: 450),
+            DiscoverTopPackage(reference: .cask(token: "iterm2"), installCount: 400),
+        ])
+    }
+
+    @Test @MainActor func `loadTopPackages supports string counts and tie break sorting`() async throws {
+        let formulaAnalytics = try analytics(
+            from: """
+            {
+              "category": "formula_install_on_request",
+              "total_items": "2",
+              "total_count": "1,000",
+              "start_date": "2026-04-17",
+              "end_date": "2026-05-17",
+              "formulae": {
+                "alpha": [{ "formula": "alpha", "count": "400" }],
+                "beta": [{ "formula": "beta", "count": "400" }]
+              }
+            }
+            """,
+        )
+        let caskAnalytics = try analytics(
+            from: """
+            {
+              "category": "cask_install",
+              "total_items": 1,
+              "total_count": 40,
+              "start_date": "2026-04-17",
+              "end_date": "2026-05-17",
+              "formulae": {
+                "gamma": [{ "cask": "gamma", "count": "40" }]
+              }
+            }
+            """,
+        )
+        let repository = BrewDiscoverPackagesRepository(
+            apiClient: MockBrewAPIClient(
+                formulaAnalytics: formulaAnalytics,
+                caskAnalytics: caskAnalytics,
+            ),
+        )
+
+        let snapshot = try await repository.loadTopPackages(limit: 10, window: .days30)
+        #expect(snapshot.topFormulae == [
+            DiscoverTopPackage(reference: .formula(name: "alpha"), installCount: 400),
+            DiscoverTopPackage(reference: .formula(name: "beta"), installCount: 400),
+        ])
+    }
+
+    @Test @MainActor func `loadTopPackages returns empty lists when limit is zero`() async throws {
+        let analyticsPayload = try analytics(
+            from: """
+            {
+              "category": "formula_install_on_request",
+              "total_items": 1,
+              "total_count": 10,
+              "start_date": "2026-04-17",
+              "end_date": "2026-05-17",
+              "formulae": {
+                "wget": [{ "formula": "wget", "count": "10" }]
+              }
+            }
+            """,
+        )
+        let repository = BrewDiscoverPackagesRepository(
+            apiClient: MockBrewAPIClient(
+                formulaAnalytics: analyticsPayload,
+                caskAnalytics: analyticsPayload,
+            ),
+        )
+
+        let snapshot = try await repository.loadTopPackages(limit: 0, window: .days30)
+        #expect(snapshot.topFormulae.isEmpty)
+        #expect(snapshot.topCasks.isEmpty)
+    }
+
+    @Test @MainActor func `loadTopPackages forwards client errors`() async throws {
+        let repository = BrewDiscoverPackagesRepository(apiClient: ThrowingBrewAPIClient())
+        await #expect(throws: BrewAPIClientError.self) {
+            _ = try await repository.loadTopPackages(limit: 10, window: .days30)
+        }
+    }
+}
+
+@MainActor
+private struct MockBrewAPIClient: BrewAPIClient {
+    let formulaAnalytics: BrewAnalyticsJSON
+    let caskAnalytics: BrewAnalyticsJSON
+
+    func fetchFormulaInstallOnRequestAnalytics(window _: BrewAnalyticsWindow) async throws -> BrewAnalyticsJSON {
+        formulaAnalytics
+    }
+
+    func fetchCaskInstallAnalytics(window _: BrewAnalyticsWindow) async throws -> BrewAnalyticsJSON {
+        caskAnalytics
+    }
+}
+
+@MainActor
+private struct ThrowingBrewAPIClient: BrewAPIClient {
+    func fetchFormulaInstallOnRequestAnalytics(window _: BrewAnalyticsWindow) async throws -> BrewAnalyticsJSON {
+        throw BrewAPIClientError.transport(underlying: "offline")
+    }
+
+    func fetchCaskInstallAnalytics(window _: BrewAnalyticsWindow) async throws -> BrewAnalyticsJSON {
+        throw BrewAPIClientError.transport(underlying: "offline")
+    }
+}
+
+private func analytics(from json: String) throws -> BrewAnalyticsJSON {
+    try JSONDecoder().decode(BrewAnalyticsJSON.self, from: Data(json.utf8))
+}

--- a/BrewTests/BrewInstalledPackagesCacheTests.swift
+++ b/BrewTests/BrewInstalledPackagesCacheTests.swift
@@ -51,8 +51,8 @@ struct BrewInstalledPackagesCacheTests {
     @Test @MainActor func `inventory reading exposes cached ids`() async {
         let cache = InstalledInventoryCache()
         let packages = [
-            BrewPackage.fixture(name: "openssl@3", kind: .formula),
-            BrewPackage.fixture(name: "wget", kind: .formula, dependencies: [.formula(name: "openssl@3")]),
+            InstalledBrewPackage.fixture(name: "openssl@3", kind: .formula),
+            InstalledBrewPackage.fixture(name: "wget", kind: .formula, dependencies: [.formula(name: "openssl@3")]),
         ]
         await cache.replace(InstalledInventorySnapshot(fetchedAt: .now, packages: packages))
         let repository = InstalledPackagesTestSupport.repository(

--- a/BrewTests/BrewInstalledPackagesRepositoryTests.swift
+++ b/BrewTests/BrewInstalledPackagesRepositoryTests.swift
@@ -268,7 +268,7 @@ struct BrewInstalledPackagesRepositoryTests {
 }
 
 @MainActor
-private func package(named name: String, in packages: [BrewPackage]) -> BrewPackage? {
+private func package(named name: String, in packages: [InstalledBrewPackage]) -> InstalledBrewPackage? {
     packages.first { $0.name == name }
 }
 

--- a/BrewTests/CatalogueCacheTests.swift
+++ b/BrewTests/CatalogueCacheTests.swift
@@ -1,0 +1,133 @@
+//
+//  CatalogueCacheTests.swift
+//  BrewTests
+//
+
+@testable import Brew
+import Foundation
+import Testing
+
+struct CatalogueCacheTests {
+    @Test @MainActor func `init loads formula and cask cache from disk`() async throws {
+        let fixture = TestFixture()
+        defer { fixture.cleanup() }
+
+        let formulaRawData = fixture.formulaCacheJSON(name: "wget", installs: 100)
+        let caskRawData = fixture.caskCacheJSON(name: "iterm2", installs: 200)
+        try fixture.writeFormulaCache(formulaRawData)
+        try fixture.writeCaskCache(caskRawData)
+        fixture.userDefaults.set(#""formula-etag""#, forKey: fixture.formulaETagKey)
+        fixture.userDefaults.set(#""cask-etag""#, forKey: fixture.caskETagKey)
+
+        let cache = await CatalogueCache(
+            userDefaults: fixture.userDefaults,
+            cacheDirectoryURL: fixture.cacheDirectoryURL,
+        )
+
+        #expect(await cache.formulaCatalogue()?.items.first?.name == "wget")
+        #expect(await cache.caskCatalogue()?.items.first?.name == "iterm2")
+        #expect(await cache.etag(for: .formula) == #""formula-etag""#)
+        #expect(await cache.etag(for: .cask) == #""cask-etag""#)
+    }
+
+    @Test @MainActor func `first read returns preloaded cache`() async throws {
+        let fixture = TestFixture()
+        defer { fixture.cleanup() }
+        let formulaRawData = fixture.formulaCacheJSON(name: "curl", installs: 321)
+        try fixture.writeFormulaCache(formulaRawData)
+
+        let cache = await CatalogueCache(
+            userDefaults: fixture.userDefaults,
+            cacheDirectoryURL: fixture.cacheDirectoryURL,
+        )
+
+        #expect(await cache.formulaCatalogue()?.items.first?.name == "curl")
+    }
+
+    @Test @MainActor func `update formula cache persists raw body and etag`() async throws {
+        let fixture = TestFixture()
+        defer { fixture.cleanup() }
+        let cache = await CatalogueCache(
+            userDefaults: fixture.userDefaults,
+            cacheDirectoryURL: fixture.cacheDirectoryURL,
+        )
+        let updatedRawData = fixture.formulaCacheJSON(name: "git", installs: 999)
+
+        try await cache.updateFormulaCatalogue(with: updatedRawData, etag: #""formula-new""#)
+
+        #expect(await cache.formulaCatalogue()?.items.first?.name == "git")
+        #expect(await cache.etag(for: .formula) == #""formula-new""#)
+
+        let persistedRawData = try Data(contentsOf: fixture.formulaCacheURL)
+        #expect(persistedRawData == updatedRawData)
+    }
+}
+
+private struct TestFixture {
+    let cacheDirectoryURL: URL
+    let formulaCacheURL: URL
+    let caskCacheURL: URL
+    let userDefaults: UserDefaults
+    let userDefaultsSuiteName: String
+
+    let formulaETagKey = "CatalogueCache.formula.etag"
+    let caskETagKey = "CatalogueCache.cask.etag"
+
+    init() {
+        let id = UUID().uuidString
+        cacheDirectoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CatalogueCacheTests-\(id)", isDirectory: true)
+        formulaCacheURL = cacheDirectoryURL.appendingPathComponent("formula-cache.json")
+        caskCacheURL = cacheDirectoryURL.appendingPathComponent("cask-cache.json")
+        userDefaultsSuiteName = "CatalogueCacheTests.\(id)"
+        userDefaults = UserDefaults(suiteName: userDefaultsSuiteName) ?? .standard
+        userDefaults.removePersistentDomain(forName: userDefaultsSuiteName)
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: cacheDirectoryURL)
+        userDefaults.removePersistentDomain(forName: userDefaultsSuiteName)
+    }
+
+    func writeFormulaCache(_ data: Data) throws {
+        try FileManager.default.createDirectory(at: cacheDirectoryURL, withIntermediateDirectories: true)
+        try data.write(to: formulaCacheURL, options: .atomic)
+    }
+
+    func writeCaskCache(_ data: Data) throws {
+        try FileManager.default.createDirectory(at: cacheDirectoryURL, withIntermediateDirectories: true)
+        try data.write(to: caskCacheURL, options: .atomic)
+    }
+
+    func formulaCacheJSON(name: String, installs: Int) -> Data {
+        Data(
+            """
+            [
+              {
+                "name": "\(name)",
+                "desc": "Formula \(name)",
+                "homepage": "https://example.com/\(name)",
+                "versions": { "stable": "1.0.0" },
+                "analytics": { "install": { "30d": \(installs) } }
+              }
+            ]
+            """.utf8,
+        )
+    }
+
+    func caskCacheJSON(name: String, installs: Int) -> Data {
+        Data(
+            """
+            [
+              {
+                "name": "\(name)",
+                "desc": "Cask \(name)",
+                "homepage": "https://example.com/\(name)",
+                "versions": { "stable": "2.0.0" },
+                "analytics": { "install": { "30d": \(installs) } }
+              }
+            ]
+            """.utf8,
+        )
+    }
+}

--- a/BrewTests/CatalogueCacheTests.swift
+++ b/BrewTests/CatalogueCacheTests.swift
@@ -8,7 +8,7 @@ import Foundation
 import Testing
 
 struct CatalogueCacheTests {
-    @Test @MainActor func `init loads formula and cask cache from disk`() async throws {
+    @Test @MainActor func `prepare loads formula and cask cache from disk`() async throws {
         let fixture = TestFixture()
         defer { fixture.cleanup() }
 
@@ -19,10 +19,11 @@ struct CatalogueCacheTests {
         fixture.userDefaults.set(#""formula-etag""#, forKey: fixture.formulaETagKey)
         fixture.userDefaults.set(#""cask-etag""#, forKey: fixture.caskETagKey)
 
-        let cache = await CatalogueCache(
+        let cache = CatalogueCache(
             userDefaults: fixture.userDefaults,
             cacheDirectoryURL: fixture.cacheDirectoryURL,
         )
+        await cache.prepare()
 
         #expect(await cache.formulaCatalogue()?.items.first?.name == "wget")
         #expect(await cache.caskCatalogue()?.items.first?.name == "iterm2")
@@ -30,16 +31,17 @@ struct CatalogueCacheTests {
         #expect(await cache.etag(for: .cask) == #""cask-etag""#)
     }
 
-    @Test @MainActor func `first read returns preloaded cache`() async throws {
+    @Test @MainActor func `first read returns prepared cache`() async throws {
         let fixture = TestFixture()
         defer { fixture.cleanup() }
         let formulaRawData = fixture.formulaCacheJSON(name: "curl", installs: 321)
         try fixture.writeFormulaCache(formulaRawData)
 
-        let cache = await CatalogueCache(
+        let cache = CatalogueCache(
             userDefaults: fixture.userDefaults,
             cacheDirectoryURL: fixture.cacheDirectoryURL,
         )
+        await cache.prepare()
 
         #expect(await cache.formulaCatalogue()?.items.first?.name == "curl")
     }
@@ -47,7 +49,7 @@ struct CatalogueCacheTests {
     @Test @MainActor func `update formula cache persists raw body and etag`() async throws {
         let fixture = TestFixture()
         defer { fixture.cleanup() }
-        let cache = await CatalogueCache(
+        let cache = CatalogueCache(
             userDefaults: fixture.userDefaults,
             cacheDirectoryURL: fixture.cacheDirectoryURL,
         )
@@ -60,6 +62,24 @@ struct CatalogueCacheTests {
 
         let persistedRawData = try Data(contentsOf: fixture.formulaCacheURL)
         #expect(persistedRawData == updatedRawData)
+    }
+
+    @Test @MainActor func `prepare does not overwrite in memory updates`() async throws {
+        let fixture = TestFixture()
+        defer { fixture.cleanup() }
+
+        try fixture.writeFormulaCache(fixture.formulaCacheJSON(name: "stale", installs: 1))
+        let cache = CatalogueCache(
+            userDefaults: fixture.userDefaults,
+            cacheDirectoryURL: fixture.cacheDirectoryURL,
+        )
+        let updatedRawData = fixture.formulaCacheJSON(name: "fresh", installs: 500)
+        try await cache.updateFormulaCatalogue(with: updatedRawData, etag: #""formula-fresh""#)
+
+        await cache.prepare()
+
+        #expect(await cache.formulaCatalogue()?.items.first?.name == "fresh")
+        #expect(await cache.etag(for: .formula) == #""formula-fresh""#)
     }
 }
 

--- a/BrewTests/InstalledDetailMutationParityTests.swift
+++ b/BrewTests/InstalledDetailMutationParityTests.swift
@@ -87,7 +87,7 @@ struct InstalledDetailMutationParityTests {
             package: package,
             brewCommandCenter: ConstantPhaseCommandCenter(phase: .running(.uninstallFormula)),
             installedDependentsRepository: StubInstalledDependentsRepository { packageID in
-                packageID == package.id ? [.fixture(name: "curl")] : []
+                packageID == package.id ? [InstalledBrewPackage.fixture(name: "curl")] : []
             },
         )
 

--- a/BrewTests/InstalledDetailsViewModelTests.swift
+++ b/BrewTests/InstalledDetailsViewModelTests.swift
@@ -10,7 +10,11 @@ import Testing
 struct InstalledDetailsViewModelTests {
     @Test @MainActor func `packageName uses package display name`() {
         let viewModel = makeInstalledDetailsViewModel(
-            package: .fixture(name: "visual-studio-code", displayName: "Visual Studio Code", kind: .cask),
+            package: InstalledBrewPackage.fixture(
+                name: "visual-studio-code",
+                displayName: "Visual Studio Code",
+                kind: .cask,
+            ),
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
         #expect(viewModel.packageName == "Visual Studio Code")
@@ -46,7 +50,7 @@ struct InstalledDetailsViewModelTests {
 
     @Test @MainActor func `upgradeDisplayCommand reflects formula name`() {
         let viewModel = makeInstalledDetailsViewModel(
-            package: .fixture(name: "wget", kind: .formula),
+            package: InstalledBrewPackage.fixture(name: "wget", kind: .formula),
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
         #expect(viewModel.upgradeItem.displayCommand == "brew upgrade --formula wget")
@@ -54,7 +58,7 @@ struct InstalledDetailsViewModelTests {
 
     @Test @MainActor func `upgradeDisplayCommand uses cask terminal flags`() {
         let viewModel = makeInstalledDetailsViewModel(
-            package: .fixture(name: "docker", kind: .cask),
+            package: InstalledBrewPackage.fixture(name: "docker", kind: .cask),
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
         #expect(viewModel.upgradeItem.displayCommand == "brew upgrade --cask docker")
@@ -62,7 +66,7 @@ struct InstalledDetailsViewModelTests {
 
     @Test @MainActor func `upgradeDisplayCommand updates when package name changes`() {
         let viewModel = makeInstalledDetailsViewModel(
-            package: .fixture(name: "wget", kind: .formula),
+            package: InstalledBrewPackage.fixture(name: "wget", kind: .formula),
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
         viewModel.update(package: details(name: "wget@2"))
@@ -71,7 +75,7 @@ struct InstalledDetailsViewModelTests {
 
     @Test @MainActor func `uninstallDisplayCommand reflects formula name`() {
         let viewModel = makeInstalledDetailsViewModel(
-            package: .fixture(name: "wget", kind: .formula),
+            package: InstalledBrewPackage.fixture(name: "wget", kind: .formula),
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
         #expect(viewModel.uninstallItem.displayCommand == "brew uninstall --formula wget")
@@ -79,7 +83,7 @@ struct InstalledDetailsViewModelTests {
 
     @Test @MainActor func `uninstallDisplayCommand uses cask terminal flags`() {
         let viewModel = makeInstalledDetailsViewModel(
-            package: .fixture(name: "docker", kind: .cask),
+            package: InstalledBrewPackage.fixture(name: "docker", kind: .cask),
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
         #expect(viewModel.uninstallItem.displayCommand == "brew uninstall --cask docker")
@@ -87,7 +91,7 @@ struct InstalledDetailsViewModelTests {
 
     @Test @MainActor func `uninstallDisplayCommand updates when package name changes`() {
         let viewModel = makeInstalledDetailsViewModel(
-            package: .fixture(name: "wget", kind: .formula),
+            package: InstalledBrewPackage.fixture(name: "wget", kind: .formula),
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
         viewModel.update(package: details(name: "wget@2"))
@@ -147,7 +151,7 @@ struct InstalledDetailsViewModelTests {
 
     @Test @MainActor func `uninstall presentation uses package name`() {
         let viewModel = makeInstalledDetailsViewModel(
-            package: .fixture(name: "wget", kind: .formula),
+            package: InstalledBrewPackage.fixture(name: "wget", kind: .formula),
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
         #expect(viewModel.uninstallItem.primaryButtonTitle == "Uninstall")
@@ -169,7 +173,7 @@ struct InstalledDetailsViewModelTests {
             package: package,
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
             installedDependentsRepository: StubInstalledDependentsRepository { packageID in
-                packageID == package.id ? [.fixture(name: "curl")] : []
+                packageID == package.id ? [InstalledBrewPackage.fixture(name: "curl")] : []
             },
         )
         await viewModel.refreshRelationships()
@@ -185,7 +189,7 @@ struct InstalledDetailsViewModelTests {
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
             installedDependentsRepository: StubInstalledDependentsRepository { packageID in
                 packageID == package.id
-                    ? [.fixture(name: "curl"), .fixture(name: "node")]
+                    ? [InstalledBrewPackage.fixture(name: "curl"), InstalledBrewPackage.fixture(name: "node")]
                     : []
             },
         )
@@ -202,7 +206,7 @@ struct InstalledDetailsViewModelTests {
             package: openssl,
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
             installedDependentsRepository: StubInstalledDependentsRepository { packageID in
-                packageID == wget.id ? [.fixture(name: "curl")] : []
+                packageID == wget.id ? [InstalledBrewPackage.fixture(name: "curl")] : []
             },
         )
         await viewModel.refreshRelationships()
@@ -212,7 +216,7 @@ struct InstalledDetailsViewModelTests {
     }
 
     @Test @MainActor func `refreshRelationships marks installed and missing dependency refs`() async {
-        let package = BrewPackage.fixture(
+        let package = InstalledBrewPackage.fixture(
             name: "wget",
             kind: .formula,
             dependencies: [.formula(name: "openssl@3"), .formula(name: "zlib")],
@@ -236,7 +240,7 @@ struct InstalledDetailsViewModelTests {
 
     @Test @MainActor func `update package clears dependency relationships`() async {
         let viewModel = makeInstalledDetailsViewModel(
-            package: BrewPackage.fixture(
+            package: InstalledBrewPackage.fixture(
                 name: "wget",
                 kind: .formula,
                 dependencies: [.formula(name: "openssl@3")],
@@ -245,7 +249,7 @@ struct InstalledDetailsViewModelTests {
             installedInventoryReading: StubInstalledInventoryReading(installedIDs: ["formula:openssl@3"]),
         )
         await viewModel.refreshRelationships()
-        viewModel.update(package: BrewPackage.fixture(name: "curl", kind: .formula))
+        viewModel.update(package: InstalledBrewPackage.fixture(name: "curl", kind: .formula))
         #expect(viewModel.dependencyRelationships.isEmpty)
     }
 
@@ -255,11 +259,11 @@ struct InstalledDetailsViewModelTests {
             package: package,
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
             installedDependentsRepository: StubInstalledDependentsRepository { packageID in
-                packageID == package.id ? [.fixture(name: "curl")] : []
+                packageID == package.id ? [InstalledBrewPackage.fixture(name: "curl")] : []
             },
         )
         await viewModel.refreshRelationships()
-        viewModel.update(package: BrewPackage.fixture(name: "wget", kind: .formula))
+        viewModel.update(package: InstalledBrewPackage.fixture(name: "wget", kind: .formula))
         #expect(viewModel.dependentRelationships.isEmpty)
     }
 
@@ -473,7 +477,7 @@ private struct GenericUpgradeError: Error {}
 extension InstalledDetailsViewModelTests {
     @Test @MainActor func `handleUninstallPrimaryButtonTapped sets showUninstallConfirmation when not blocked`() {
         let viewModel = makeInstalledDetailsViewModel(
-            package: .fixture(name: "wget", kind: .formula),
+            package: InstalledBrewPackage.fixture(name: "wget", kind: .formula),
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
         viewModel.handleUninstallPrimaryButtonTapped()
@@ -487,7 +491,7 @@ extension InstalledDetailsViewModelTests {
             package: package,
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
             installedDependentsRepository: StubInstalledDependentsRepository { packageID in
-                packageID == package.id ? [.fixture(name: "curl")] : []
+                packageID == package.id ? [InstalledBrewPackage.fixture(name: "curl")] : []
             },
         )
         await viewModel.refreshRelationships()
@@ -502,13 +506,13 @@ extension InstalledDetailsViewModelTests {
             package: package,
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
             installedDependentsRepository: StubInstalledDependentsRepository { packageID in
-                packageID == package.id ? [.fixture(name: "curl")] : []
+                packageID == package.id ? [InstalledBrewPackage.fixture(name: "curl")] : []
             },
         )
         await viewModel.refreshRelationships()
         viewModel.handleUninstallPrimaryButtonTapped()
         #expect(viewModel.showUninstallBlockedCallout)
-        viewModel.update(package: .fixture(name: "wget", kind: .formula))
+        viewModel.update(package: InstalledBrewPackage.fixture(name: "wget", kind: .formula))
         #expect(!viewModel.showUninstallBlockedCallout)
         #expect(!viewModel.showUninstallConfirmation)
     }

--- a/BrewTests/InstalledDetailsViewModelTestsSupport.swift
+++ b/BrewTests/InstalledDetailsViewModelTestsSupport.swift
@@ -224,7 +224,7 @@ func withInstalledDetailPhaseObservation(
 
 @MainActor
 func makeInstalledDetailsViewModel(
-    package: BrewPackage,
+    package: InstalledBrewPackage,
     brewCommandCenter: any BrewCommandCenter = NoopBrewCommandCenter.forTesting(),
     installedDependentsRepository: (any InstalledDependentsRepository)? = nil,
     installedInventoryReading: (any InstalledInventoryReading)? = nil,
@@ -241,16 +241,18 @@ func details(
     name: String,
     kind: InstalledPackageKind = .formula,
     version: String = "1.0.0",
-) -> BrewPackage {
-    BrewPackage(
-        name: name,
-        displayName: name,
-        kind: kind,
-        description: "desc",
-        homepage: "",
-        latestVersion: version,
+) -> InstalledBrewPackage {
+    InstalledBrewPackage(
+        package: BrewPackage(
+            name: name,
+            displayName: name,
+            kind: kind,
+            description: "desc",
+            homepage: "",
+            latestVersion: version,
+            dependencies: [],
+        ),
         installedVersions: [version],
-        dependencies: [],
         outdated: false,
     )
 }

--- a/BrewTests/InstalledInventorySnapshotTests.swift
+++ b/BrewTests/InstalledInventorySnapshotTests.swift
@@ -35,8 +35,8 @@ struct InstalledInventorySnapshotTests {
 
     @Test func `graph matches standalone dependency graph for packages`() {
         let packages = [
-            BrewPackage.fixture(name: "openssl@3", kind: .formula, dependencies: []),
-            BrewPackage.fixture(name: "node", kind: .formula, dependencies: [.formula(name: "openssl@3")]),
+            InstalledBrewPackage.fixture(name: "openssl@3", kind: .formula, dependencies: []),
+            InstalledBrewPackage.fixture(name: "node", kind: .formula, dependencies: [.formula(name: "openssl@3")]),
         ]
         let snapshot = InstalledInventorySnapshot(fetchedAt: .now, packages: packages)
         let standalone = PackageDependencyGraph(packages: packages)

--- a/BrewTests/InstalledListRowViewModelTests.swift
+++ b/BrewTests/InstalledListRowViewModelTests.swift
@@ -10,7 +10,11 @@ import Testing
 @MainActor
 struct InstalledListRowViewModelTests {
     @Test func `name uses package display name`() {
-        let package = BrewPackage.fixture(name: "visual-studio-code", displayName: "Visual Studio Code", kind: .cask)
+        let package = InstalledBrewPackage.fixture(
+            name: "visual-studio-code",
+            displayName: "Visual Studio Code",
+            kind: .cask,
+        )
         let viewModel = InstalledListRowViewModel(
             package: package,
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
@@ -19,7 +23,7 @@ struct InstalledListRowViewModelTests {
     }
 
     @Test func `observeRowUpdates applies first phase from noop center`() async {
-        let package = BrewPackage.fixture(name: "git", kind: .formula)
+        let package = InstalledBrewPackage.fixture(name: "git", kind: .formula)
         let center = NoopBrewCommandCenter.forTesting()
         let viewModel = InstalledListRowViewModel(package: package, brewCommandCenter: center)
         #expect(!viewModel.showsUpgradeBusy)
@@ -30,7 +34,7 @@ struct InstalledListRowViewModelTests {
     }
 
     @Test func `observeRowUpdates ends on last phased stream emission`() async {
-        var package = BrewPackage.fixture(name: "git", kind: .formula)
+        var package = InstalledBrewPackage.fixture(name: "git", kind: .formula)
         package.outdated = true
         let center = PhaseSequenceCommandCenter(phases: [.running(.upgradeFormula), .idle])
         let viewModel = InstalledListRowViewModel(package: package, brewCommandCenter: center)
@@ -41,7 +45,7 @@ struct InstalledListRowViewModelTests {
     }
 
     @Test func `observeRowUpdates latches uninstall busy after running to idle`() async {
-        let package = BrewPackage.fixture(name: "git", kind: .formula)
+        let package = InstalledBrewPackage.fixture(name: "git", kind: .formula)
         let center = PhaseSequenceCommandCenter(phases: [.running(.uninstallFormula), .idle])
         let viewModel = InstalledListRowViewModel(package: package, brewCommandCenter: center)
         await viewModel.observeRowUpdates()
@@ -52,7 +56,7 @@ struct InstalledListRowViewModelTests {
     }
 
     @Test func `update package clears upgrade busy latch and operation busy`() async {
-        var package = BrewPackage.fixture(name: "git", kind: .formula)
+        var package = InstalledBrewPackage.fixture(name: "git", kind: .formula)
         package.outdated = true
         let center = PhaseSequenceCommandCenter(phases: [.running(.upgradeFormula), .idle])
         let viewModel = InstalledListRowViewModel(package: package, brewCommandCenter: center)
@@ -60,7 +64,7 @@ struct InstalledListRowViewModelTests {
         #expect(viewModel.showsUpgradeBusy)
         #expect(viewModel.showsOperationBusy)
 
-        let refreshedPackage = BrewPackage.fixture(name: "git", kind: .formula)
+        let refreshedPackage = InstalledBrewPackage.fixture(name: "git", kind: .formula)
         viewModel.update(package: refreshedPackage)
 
         #expect(!viewModel.showsUpgradeBusy)
@@ -70,14 +74,14 @@ struct InstalledListRowViewModelTests {
     }
 
     @Test func `update package clears uninstall busy latch and operation busy`() async {
-        let package = BrewPackage.fixture(name: "git", kind: .formula)
+        let package = InstalledBrewPackage.fixture(name: "git", kind: .formula)
         let center = PhaseSequenceCommandCenter(phases: [.running(.uninstallFormula), .idle])
         let viewModel = InstalledListRowViewModel(package: package, brewCommandCenter: center)
         await viewModel.observeRowUpdates()
         #expect(viewModel.showsUninstallBusy)
         #expect(viewModel.showsOperationBusy)
 
-        let refreshedPackage = BrewPackage.fixture(name: "git", kind: .formula, description: "Updated")
+        let refreshedPackage = InstalledBrewPackage.fixture(name: "git", kind: .formula, description: "Updated")
         viewModel.update(package: refreshedPackage)
 
         #expect(!viewModel.showsUpgradeBusy)
@@ -87,7 +91,7 @@ struct InstalledListRowViewModelTests {
     }
 
     @Test func `update package flips row version presentation when outdated changes`() {
-        let current = BrewPackage.fixture(
+        let current = InstalledBrewPackage.fixture(
             name: "git",
             kind: .formula,
             description: "VCS",
@@ -107,7 +111,7 @@ struct InstalledListRowViewModelTests {
             Issue.record("expected installed versionPresentation before update")
         }
 
-        let outdated = BrewPackage.fixture(
+        let outdated = InstalledBrewPackage.fixture(
             name: "git",
             kind: .formula,
             description: "VCS",

--- a/BrewTests/InstalledPackageRowPresentationTests.swift
+++ b/BrewTests/InstalledPackageRowPresentationTests.swift
@@ -8,14 +8,14 @@ import Testing
 
 struct InstalledPackageRowPresentationTests {
     @Test func `id differs by kind for same name`() {
-        let formula = BrewPackage.fixture(name: "foo", kind: .formula)
-        let cask = BrewPackage.fixture(name: "foo", kind: .cask)
+        let formula = InstalledBrewPackage.fixture(name: "foo", kind: .formula)
+        let cask = InstalledBrewPackage.fixture(name: "foo", kind: .cask)
         #expect(formula.id != cask.id)
     }
 
     @Test @MainActor func `row vm formats version labels`() {
         let vm = InstalledListRowViewModel(
-            package: .fixture(
+            package: InstalledBrewPackage.fixture(
                 name: "git",
                 kind: .formula,
                 latestVersion: "2.1.0",
@@ -31,7 +31,7 @@ struct InstalledPackageRowPresentationTests {
 
     @Test @MainActor func `row vm accessibility summary includes update line`() {
         let vm = InstalledListRowViewModel(
-            package: .fixture(
+            package: InstalledBrewPackage.fixture(
                 name: "Git",
                 kind: .formula,
                 description: "DVCS",

--- a/BrewTests/InstalledViewModelPresentationTests.swift
+++ b/BrewTests/InstalledViewModelPresentationTests.swift
@@ -148,13 +148,13 @@ struct InstalledViewModelPresentationTests {
 private struct FailingInstalledRepository: InstalledPackagesRepository {
     let error: Error
 
-    func loadInstalledPackages(forceRefresh _: Bool) async throws -> [BrewPackage] {
+    func loadInstalledPackages(forceRefresh _: Bool) async throws -> [InstalledBrewPackage] {
         throw error
     }
 }
 
 @MainActor
-private func selectedFormulaRow(from vm: InstalledViewModel) -> BrewPackage? {
+private func selectedFormulaRow(from vm: InstalledViewModel) -> InstalledBrewPackage? {
     guard case let .loaded(content) = vm.state else {
         return nil
     }

--- a/BrewTests/InstalledViewModelTests.swift
+++ b/BrewTests/InstalledViewModelTests.swift
@@ -110,11 +110,11 @@ struct InstalledViewModelTests {
     }
 
     @Test @MainActor func `refresh preserves selection when package still exists`() async {
-        let firstSnapshot: [BrewPackage] = [
+        let firstSnapshot: [InstalledBrewPackage] = [
             .fixture(name: "git", kind: .formula, latestVersion: "1.0.0", installedVersions: ["1.0.0"]),
             .fixture(name: "wget", kind: .formula, latestVersion: "1.0.0", installedVersions: ["1.0.0"]),
         ]
-        let secondSnapshot: [BrewPackage] = [
+        let secondSnapshot: [InstalledBrewPackage] = [
             .fixture(name: "git", kind: .formula, latestVersion: "2.0.0", installedVersions: ["2.0.0"]),
             .fixture(name: "wget", kind: .formula, latestVersion: "1.0.0", installedVersions: ["1.0.0"]),
         ]
@@ -133,11 +133,11 @@ struct InstalledViewModelTests {
     }
 
     @Test @MainActor func `refresh repoints selection when selected package disappears`() async {
-        let firstSnapshot: [BrewPackage] = [
+        let firstSnapshot: [InstalledBrewPackage] = [
             .fixture(name: "git", kind: .formula),
             .fixture(name: "wget", kind: .formula),
         ]
-        let secondSnapshot: [BrewPackage] = [
+        let secondSnapshot: [InstalledBrewPackage] = [
             .fixture(name: "wget", kind: .formula),
         ]
         let repo = SequentialSnapshotsInstalledRepository(snapshots: [firstSnapshot, secondSnapshot])
@@ -146,12 +146,12 @@ struct InstalledViewModelTests {
             brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
         await vm.load()
-        let removedSelectionID: BrewPackage.ID = "formula:git"
+        let removedSelectionID: InstalledBrewPackage.ID = "formula:git"
         vm.setSelection(removedSelectionID)
 
         await vm.refresh()
 
-        let expectedFallbackID: BrewPackage.ID = "formula:wget"
+        let expectedFallbackID: InstalledBrewPackage.ID = "formula:wget"
         #expect(vm.selectedPackage?.id == expectedFallbackID)
     }
 
@@ -246,13 +246,13 @@ private func expectLoadCount(atLeast target: Int, repo: CountingInstalledReposit
 @MainActor
 private final class CountingInstalledRepository: InstalledPackagesRepository {
     private(set) var loadCallCount = 0
-    private let packages: [BrewPackage]
+    private let packages: [InstalledBrewPackage]
 
-    init(packages: [BrewPackage] = [.fixture(name: "git", kind: .formula)]) {
+    init(packages: [InstalledBrewPackage] = [.fixture(name: "git", kind: .formula)]) {
         self.packages = packages
     }
 
-    func loadInstalledPackages(forceRefresh _: Bool) async throws -> [BrewPackage] {
+    func loadInstalledPackages(forceRefresh _: Bool) async throws -> [InstalledBrewPackage] {
         loadCallCount += 1
         return packages
     }
@@ -260,14 +260,14 @@ private final class CountingInstalledRepository: InstalledPackagesRepository {
 
 @MainActor
 private final class SequentialSnapshotsInstalledRepository: InstalledPackagesRepository {
-    private var snapshots: [[BrewPackage]]
+    private var snapshots: [[InstalledBrewPackage]]
     private var index = 0
 
-    init(snapshots: [[BrewPackage]]) {
+    init(snapshots: [[InstalledBrewPackage]]) {
         self.snapshots = snapshots
     }
 
-    func loadInstalledPackages(forceRefresh _: Bool) async throws -> [BrewPackage] {
+    func loadInstalledPackages(forceRefresh _: Bool) async throws -> [InstalledBrewPackage] {
         guard !snapshots.isEmpty else {
             return []
         }

--- a/BrewTests/PackageDependencyGraphTests.swift
+++ b/BrewTests/PackageDependencyGraphTests.swift
@@ -9,9 +9,9 @@ import Testing
 struct PackageDependencyGraphTests {
     @Test func `installedDependents for package id returns sorted dependents`() {
         let packages = [
-            BrewPackage.fixture(name: "openssl@3", kind: .formula, dependencies: []),
-            BrewPackage.fixture(name: "node", kind: .formula, dependencies: [.formula(name: "openssl@3")]),
-            BrewPackage.fixture(name: "curl", kind: .formula, dependencies: [.formula(name: "openssl@3")]),
+            InstalledBrewPackage.fixture(name: "openssl@3", kind: .formula, dependencies: []),
+            InstalledBrewPackage.fixture(name: "node", kind: .formula, dependencies: [.formula(name: "openssl@3")]),
+            InstalledBrewPackage.fixture(name: "curl", kind: .formula, dependencies: [.formula(name: "openssl@3")]),
         ]
         let graph = PackageDependencyGraph(packages: packages)
         let openssl = packages[0]
@@ -20,23 +20,23 @@ struct PackageDependencyGraphTests {
 
     @Test func `installedDependents for package id is empty when id is unknown`() {
         let graph = PackageDependencyGraph(packages: [
-            BrewPackage.fixture(name: "wget", kind: .formula, dependencies: [.formula(name: "zlib")]),
+            InstalledBrewPackage.fixture(name: "wget", kind: .formula, dependencies: [.formula(name: "zlib")]),
         ])
-        #expect(graph.installedDependents(for: BrewPackage.ID("unknown")).isEmpty)
+        #expect(graph.installedDependents(for: InstalledBrewPackage.ID("unknown")).isEmpty)
     }
 
     @Test func `installedDependents for package id is empty when no installed package depends on id`() {
         let graph = PackageDependencyGraph(packages: [
-            BrewPackage.fixture(name: "wget", kind: .formula, dependencies: [.formula(name: "zlib")]),
+            InstalledBrewPackage.fixture(name: "wget", kind: .formula, dependencies: [.formula(name: "zlib")]),
         ])
         #expect(graph.installedDependents(for: "formula:openssl@3").isEmpty)
     }
 
     @Test func `installedDependents distinguishes formula and cask dependency references`() {
         let packages = [
-            BrewPackage.fixture(name: "shared", kind: .formula, dependencies: []),
-            BrewPackage.fixture(name: "shared", kind: .cask, dependencies: []),
-            BrewPackage.fixture(
+            InstalledBrewPackage.fixture(name: "shared", kind: .formula, dependencies: []),
+            InstalledBrewPackage.fixture(name: "shared", kind: .cask, dependencies: []),
+            InstalledBrewPackage.fixture(
                 name: "consumer",
                 kind: .cask,
                 dependencies: [.formula(name: "shared")],

--- a/BrewTests/PackageDetailMetadataItemTests.swift
+++ b/BrewTests/PackageDetailMetadataItemTests.swift
@@ -9,7 +9,7 @@ import Testing
 
 struct PackageDetailMetadataItemTests {
     @Test func `info command uses package name`() {
-        let item = PackageDetailMetadataItem(package: .fixture(name: "wget", kind: .formula))
+        let item = PackageDetailMetadataItem(package: InstalledBrewPackage.fixture(name: "wget", kind: .formula))
         #expect(item.infoCommand == "brew info wget")
     }
 

--- a/BrewTests/PackageRelationshipItemTests.swift
+++ b/BrewTests/PackageRelationshipItemTests.swift
@@ -46,7 +46,7 @@ struct PackageRelationshipItemTests {
     }
 
     @Test @MainActor func `dependent and dependents always mark installed`() {
-        let package = BrewPackage.fixture(name: "curl", displayName: "cURL", kind: .formula)
+        let package = InstalledBrewPackage.fixture(name: "curl", displayName: "cURL", kind: .formula)
         let dependent = PackageRelationshipItem.dependent(package)
         let dependents = PackageRelationshipItem.dependents([package])
 

--- a/BrewTests/PackageUninstallCommandTests.swift
+++ b/BrewTests/PackageUninstallCommandTests.swift
@@ -15,7 +15,7 @@ struct PackageUninstallCommandTests {
             commandRunner: runner,
             locator: BrewExecutableLocator(overrideURL: brewURL),
         )
-        let package = BrewPackage.fixture(name: "git", kind: .formula)
+        let package = InstalledBrewPackage.fixture(name: "git", kind: .formula)
         try await PackageUninstallCommand(package: package).run(in: ctx)
 
         #expect(await runner.lastExecutable == brewURL)
@@ -29,7 +29,7 @@ struct PackageUninstallCommandTests {
             commandRunner: runner,
             locator: BrewExecutableLocator(overrideURL: brewURL),
         )
-        let package = BrewPackage.fixture(name: "Slack", kind: .cask)
+        let package = InstalledBrewPackage.fixture(name: "Slack", kind: .cask)
         try await PackageUninstallCommand(package: package).run(in: ctx)
 
         #expect(await runner.lastArguments == ["uninstall", "--cask", "Slack"])
@@ -44,7 +44,7 @@ struct PackageUninstallCommandTests {
             commandRunner: runner,
             locator: BrewExecutableLocator(overrideURL: URL(fileURLWithPath: "/opt/homebrew/bin/brew")),
         )
-        let package = BrewPackage.fixture(name: "x", kind: .formula)
+        let package = InstalledBrewPackage.fixture(name: "x", kind: .formula)
         await #expect(throws: BrewCommandError.self) {
             try await PackageUninstallCommand(package: package).run(in: ctx)
         }

--- a/BrewTests/PackageUpgradeCommandTests.swift
+++ b/BrewTests/PackageUpgradeCommandTests.swift
@@ -9,7 +9,7 @@ import Testing
 
 struct PackageUpgradeCommandTests {
     @Test func `operation id from package matches package id`() {
-        let package = BrewPackage.fixture(name: "wget", kind: .formula)
+        let package = InstalledBrewPackage.fixture(name: "wget", kind: .formula)
         #expect(BrewOperationID(package: package).rawValue == package.id)
     }
 
@@ -20,7 +20,7 @@ struct PackageUpgradeCommandTests {
             commandRunner: runner,
             locator: BrewExecutableLocator(overrideURL: brewURL),
         )
-        let package = BrewPackage.fixture(name: "git", kind: .formula)
+        let package = InstalledBrewPackage.fixture(name: "git", kind: .formula)
         try await PackageUpgradeCommand(package: package).run(in: ctx)
 
         #expect(await runner.lastExecutable == brewURL)
@@ -34,7 +34,7 @@ struct PackageUpgradeCommandTests {
             commandRunner: runner,
             locator: BrewExecutableLocator(overrideURL: brewURL),
         )
-        let package = BrewPackage.fixture(name: "Slack", kind: .cask)
+        let package = InstalledBrewPackage.fixture(name: "Slack", kind: .cask)
         try await PackageUpgradeCommand(package: package).run(in: ctx)
 
         #expect(await runner.lastArguments == ["upgrade", "--cask", "Slack"])
@@ -49,7 +49,7 @@ struct PackageUpgradeCommandTests {
             commandRunner: runner,
             locator: BrewExecutableLocator(overrideURL: URL(fileURLWithPath: "/opt/homebrew/bin/brew")),
         )
-        let package = BrewPackage.fixture(name: "x", kind: .formula)
+        let package = InstalledBrewPackage.fixture(name: "x", kind: .formula)
         await #expect(throws: BrewCommandError.self) {
             try await PackageUpgradeCommand(package: package).run(in: ctx)
         }

--- a/BrewTests/TestSupport/BrewPackageFixtures.swift
+++ b/BrewTests/TestSupport/BrewPackageFixtures.swift
@@ -8,9 +8,7 @@ extension BrewPackage {
         description: String = "",
         homepage: String = "",
         latestVersion: String = "",
-        installedVersions: [String] = [],
         dependencies: [HomebrewPackageReference] = [],
-        outdated: Bool = false,
     ) -> BrewPackage {
         BrewPackage(
             name: name,
@@ -19,15 +17,47 @@ extension BrewPackage {
             description: description,
             homepage: homepage,
             latestVersion: latestVersion,
-            installedVersions: installedVersions,
             dependencies: dependencies,
-            outdated: outdated,
         )
     }
 }
 
 extension [BrewPackage] {
     static var empty: [BrewPackage] {
+        []
+    }
+}
+
+extension InstalledBrewPackage {
+    static func fixture(
+        name: String = "git",
+        displayName: String? = nil,
+        kind: HomebrewPackageKind = .formula,
+        description: String = "",
+        homepage: String = "",
+        latestVersion: String = "",
+        installedVersions: [String] = [],
+        dependencies: [HomebrewPackageReference] = [],
+        outdated: Bool = false,
+    ) -> InstalledBrewPackage {
+        InstalledBrewPackage(
+            package: .fixture(
+                name: name,
+                displayName: displayName,
+                kind: kind,
+                description: description,
+                homepage: homepage,
+                latestVersion: latestVersion,
+                dependencies: dependencies,
+            ),
+            installedVersions: installedVersions,
+            outdated: outdated,
+        )
+    }
+}
+
+extension [InstalledBrewPackage] {
+    static var empty: [InstalledBrewPackage] {
         []
     }
 }

--- a/BrewTests/TestSupport/EmptyInstalledDependentsRepository.swift
+++ b/BrewTests/TestSupport/EmptyInstalledDependentsRepository.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 struct EmptyInstalledDependentsRepository: InstalledDependentsRepository {
-    func installedDependents(for _: BrewPackage.ID) async -> [BrewPackage] {
+    func installedDependents(for _: InstalledBrewPackage.ID) async -> [InstalledBrewPackage] {
         []
     }
 }

--- a/BrewTests/TestSupport/EmptyInstalledInventoryReading.swift
+++ b/BrewTests/TestSupport/EmptyInstalledInventoryReading.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 struct EmptyInstalledInventoryReading: InstalledInventoryReading {
-    func installedPackageIDs() async -> Set<BrewPackage.ID> {
+    func installedPackageIDs() async -> Set<InstalledBrewPackage.ID> {
         []
     }
 }

--- a/BrewTests/TestSupport/InstalledFeatureTestSupport.swift
+++ b/BrewTests/TestSupport/InstalledFeatureTestSupport.swift
@@ -4,8 +4,8 @@ import Foundation
 enum InstalledFeatureTestSupport {
     @MainActor
     static func loadedViewModel(
-        formulae: [BrewPackage] = [],
-        casks: [BrewPackage] = [],
+        formulae: [InstalledBrewPackage] = [],
+        casks: [InstalledBrewPackage] = [],
     ) async -> InstalledViewModel {
         let cache = InstalledInventoryCache()
         let snapshot = InstalledInventorySnapshot(fetchedAt: .now, packages: formulae + casks)
@@ -24,25 +24,25 @@ enum InstalledFeatureTestSupport {
 }
 
 struct StubInstalledPackagesRepository: InstalledPackagesRepository {
-    let snapshot: [BrewPackage]
+    let snapshot: [InstalledBrewPackage]
 
-    func loadInstalledPackages(forceRefresh _: Bool) async throws -> [BrewPackage] {
+    func loadInstalledPackages(forceRefresh _: Bool) async throws -> [InstalledBrewPackage] {
         snapshot
     }
 }
 
 struct StubInstalledDependentsRepository: InstalledDependentsRepository {
-    let provider: @Sendable (BrewPackage.ID) -> [BrewPackage]
+    let provider: @Sendable (InstalledBrewPackage.ID) -> [InstalledBrewPackage]
 
-    func installedDependents(for packageID: BrewPackage.ID) async -> [BrewPackage] {
+    func installedDependents(for packageID: InstalledBrewPackage.ID) async -> [InstalledBrewPackage] {
         provider(packageID)
     }
 }
 
 struct StubInstalledInventoryReading: InstalledInventoryReading {
-    let installedIDs: Set<BrewPackage.ID>
+    let installedIDs: Set<InstalledBrewPackage.ID>
 
-    func installedPackageIDs() async -> Set<BrewPackage.ID> {
+    func installedPackageIDs() async -> Set<InstalledBrewPackage.ID> {
         installedIDs
     }
 }

--- a/BrewTests/TestSupport/InstalledViewModelTestsSupport.swift
+++ b/BrewTests/TestSupport/InstalledViewModelTestsSupport.swift
@@ -11,9 +11,9 @@ import Testing
 
 struct VMStateSnapshot: Equatable {
     var state: InstalledLoadState
-    var formulaPackages: [BrewPackage]
-    var caskPackages: [BrewPackage]
-    var selectedPackageID: BrewPackage.ID?
+    var formulaPackages: [InstalledBrewPackage]
+    var caskPackages: [InstalledBrewPackage]
+    var selectedPackageID: InstalledBrewPackage.ID?
     var totalPackageCount: Int
 
     /// Rows cleared, load finished, after a failed `load()`.
@@ -69,20 +69,20 @@ struct OddRepositoryError: Error {}
 struct StubThrowingRepository: InstalledPackagesRepository {
     let error: Error
 
-    func loadInstalledPackages(forceRefresh _: Bool) async throws -> [BrewPackage] {
+    func loadInstalledPackages(forceRefresh _: Bool) async throws -> [InstalledBrewPackage] {
         throw error
     }
 }
 
 extension InstalledViewModel {
-    var loadedFormulaPackages: [BrewPackage] {
+    var loadedFormulaPackages: [InstalledBrewPackage] {
         guard case let .loaded(content) = state else {
             return []
         }
         return content.formulaPackages
     }
 
-    var loadedCaskPackages: [BrewPackage] {
+    var loadedCaskPackages: [InstalledBrewPackage] {
         guard case let .loaded(content) = state else {
             return []
         }

--- a/BrewTests/UninstallPackageItemTests.swift
+++ b/BrewTests/UninstallPackageItemTests.swift
@@ -8,24 +8,24 @@ import Testing
 
 struct UninstallPackageItemTests {
     @Test func `display command uses formula uninstall flag`() {
-        let item = UninstallPackageItem(package: .fixture(name: "wget", kind: .formula))
+        let item = UninstallPackageItem(package: InstalledBrewPackage.fixture(name: "wget", kind: .formula))
         #expect(item.displayCommand == "brew uninstall --formula wget")
     }
 
     @Test func `display command uses cask uninstall flag`() {
-        let item = UninstallPackageItem(package: .fixture(name: "docker", kind: .cask))
+        let item = UninstallPackageItem(package: InstalledBrewPackage.fixture(name: "docker", kind: .cask))
         #expect(item.displayCommand == "brew uninstall --cask docker")
     }
 
     @Test func `confirmation copy uses package name`() {
-        let item = UninstallPackageItem(package: .fixture(name: "wget", kind: .formula))
+        let item = UninstallPackageItem(package: InstalledBrewPackage.fixture(name: "wget", kind: .formula))
         #expect(item.primaryButtonTitle == "Uninstall")
         #expect(item.confirmationTitle == "Uninstall wget?")
         #expect(item.confirmationMessage == "This will remove wget from this Mac using Homebrew.")
     }
 
     @Test func `blocked copy is nil without dependents`() {
-        let item = UninstallPackageItem(package: .fixture(name: "ada-url", kind: .formula))
+        let item = UninstallPackageItem(package: InstalledBrewPackage.fixture(name: "ada-url", kind: .formula))
         #expect(!item.isBlockedByDependents)
         #expect(item.usedByBlockingBadgeTitle == nil)
         #expect(item.uninstallBlockedBannerLead == nil)
@@ -34,7 +34,7 @@ struct UninstallPackageItemTests {
 
     @Test func `blocked copy uses singular grammar for one dependent`() {
         let item = UninstallPackageItem(
-            package: .fixture(name: "ada-url", kind: .formula),
+            package: InstalledBrewPackage.fixture(name: "ada-url", kind: .formula),
             blockingDependentCount: 1,
         )
         #expect(
@@ -45,7 +45,7 @@ struct UninstallPackageItemTests {
 
     @Test func `blocked accessibility hint and callout content`() {
         let item = UninstallPackageItem(
-            package: .fixture(name: "ada-url", kind: .formula),
+            package: InstalledBrewPackage.fixture(name: "ada-url", kind: .formula),
             blockingDependentCount: 2,
         )
         #expect(
@@ -60,7 +60,7 @@ struct UninstallPackageItemTests {
 
     @Test func `blocked copy uses plural grammar for multiple dependents`() {
         let item = UninstallPackageItem(
-            package: .fixture(name: "ada-url", kind: .formula),
+            package: InstalledBrewPackage.fixture(name: "ada-url", kind: .formula),
             blockingDependentCount: 3,
         )
         #expect(item.isBlockedByDependents)

--- a/BrewTests/UpgradePackageItemTests.swift
+++ b/BrewTests/UpgradePackageItemTests.swift
@@ -8,37 +8,37 @@ import Testing
 
 struct UpgradePackageItemTests {
     @Test func `display command uses formula upgrade flag`() {
-        let item = UpgradePackageItem(package: .fixture(name: "wget", kind: .formula))
+        let item = UpgradePackageItem(package: InstalledBrewPackage.fixture(name: "wget", kind: .formula))
         #expect(item.displayCommand == "brew upgrade --formula wget")
     }
 
     @Test func `display command uses cask upgrade flag`() {
-        let item = UpgradePackageItem(package: .fixture(name: "docker", kind: .cask))
+        let item = UpgradePackageItem(package: InstalledBrewPackage.fixture(name: "docker", kind: .cask))
         #expect(item.displayCommand == "brew upgrade --cask docker")
     }
 
     @Test func `upgrade chrome follows package outdated status`() {
         let outdated = UpgradePackageItem(
-            package: .fixture(name: "wget", latestVersion: "2.0.0", outdated: true),
+            package: InstalledBrewPackage.fixture(name: "wget", latestVersion: "2.0.0", outdated: true),
         )
         #expect(outdated.showsUpgradeChrome)
 
         let current = UpgradePackageItem(
-            package: .fixture(name: "wget", latestVersion: "2.0.0", outdated: false),
+            package: InstalledBrewPackage.fixture(name: "wget", latestVersion: "2.0.0", outdated: false),
         )
         #expect(!current.showsUpgradeChrome)
     }
 
     @Test func `primary button title includes normalized version label`() {
         let item = UpgradePackageItem(
-            package: .fixture(name: "wget", latestVersion: "2.0.0", outdated: true),
+            package: InstalledBrewPackage.fixture(name: "wget", latestVersion: "2.0.0", outdated: true),
         )
         #expect(item.primaryButtonTitle == "Update to v2.0.0")
     }
 
     @Test func `primary button title is nil when no upgrade available`() {
         let item = UpgradePackageItem(
-            package: .fixture(name: "wget", latestVersion: "2.0.0", outdated: false),
+            package: InstalledBrewPackage.fixture(name: "wget", latestVersion: "2.0.0", outdated: false),
         )
         #expect(item.primaryButtonTitle == nil)
     }

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -55,6 +55,8 @@ UI in `Brew/` uses **semantic tokens** under [`Brew/Theme/`](Brew/Theme/) (`Brew
 
 **Domain-to-presentation mapping boundary:** Do not add UI-facing presentation properties/extensions directly on domain model types. Map domain models into presentation in one of two places only: (1) feature ViewModels for top-level surfaces, or (2) feature `*Item` types for subview/action-specific presentation data.
 
+**Package-domain lookup identity:** Any domain model that represents a Homebrew package (or list item directly backed by one) must expose a `HomebrewPackageReference` property for stable formula/cask lookup (`.formula(name:)` for formulae, `.cask(token:)` for casks).
+
 **Root view dependency ownership:** When a feature defines a `*Root` view wrapper, the root is the dependency-composition boundary for that surface. Root views must read app-level dependencies (for example `@Environment` values), construct and inject content-view dependencies, and own view-model lifecycle boundaries. Content views must focus on rendering and behavior and must not acquire those app-level dependencies directly when a root exists.
 
 **Anti-pattern to avoid:** Do not make a content view model optional only to work around dependency acquisition inside the content view. Keep dependency resolution in the root and inject non-optional dependencies into the content view.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -45,6 +45,8 @@ UI in `Brew/` uses **semantic tokens** under [`Brew/Theme/`](Brew/Theme/) (`Brew
 
 **Repository boundary:** Repositories are data-access adapters. They fetch/parse/map source data and expose that data to the app, but they do not invent extra informational or presentation values beyond what the source provides. Any hardcoded informational text, user guidance, or display-only derived strings belong in ViewModel/View layers (or another presentation-oriented layer), not repositories.
 
+**Transport boundary:** Do not expose `Codable` transport payload types (`*JSON`, DTOs, wire models) from service or repository APIs. Decode transport payloads at the boundary, then map to app-facing domain models (`Models/`) or explicit feature-layer data contracts before returning.
+
 **Command transparency:** When the UI exposes a Homebrew command, render a **copyable, user-facing command** that a person can run in Terminal (for example, `brew info <name>`). Do not display internal implementation flags used only for app parsing/workflow (for example, `--json=v2`) in user-visible command text.
 
 **MVVM boundary:** Keep views as passive as practical. Put view-facing UI policy, derived flags, and decision/branching logic in ViewModels (for example, split/detail visibility booleans and action-routing decisions). Views should primarily bind/render and forward actions. Keep view-layer branching limited to simple presentation branches (for example, loading/error/empty content blocks) and avoid embedding cross-state decision trees in views. Add unit tests for non-trivial ViewModel-derived UI state.


### PR DESCRIPTION
# PR: Build Discover data layer foundations

## Summary

This PR lays the data-layer groundwork for Discover by adding Homebrew analytics/catalogue fetching, cache-backed catalogue refresh behavior, and repository/domain model updates needed to consume that data safely. It also separates installed-only package state from shared package domain state to keep boundaries clear as Discover grows.

## Changes

- Added Discover-facing Homebrew API client support and decoding:
  - `BrewAPIClient` / `URLSessionBrewAPIClient` analytics + catalogue fetch functions.
  - New transport models for analytics and catalogue payloads under `Services/API`.
- Added Discover repository foundations:
  - `DiscoverPackagesRepository` for top-package analytics snapshots.
  - `CatalogueRepository` orchestration for catalogue reads with freshness handling.
- Added catalogue cache infrastructure:
  - `CatalogueCache` actor + cache protocol/environment wiring.
  - Stale-while-revalidate behavior and cache persistence-oriented tests.
- Mapped catalogue transport models to domain package models in repository boundaries (transport types no longer returned from repo APIs).
- Split installed-specific package concerns from shared package domain:
  - Added `InstalledBrewPackage` and migrated installed/inventory/dependency/command wiring to use it.
  - Kept catalogue/discover surfaces on slim `BrewPackage`.
- Updated tests across API client, catalogue cache/repository, discover repository, and impacted installed-model consumers.
- Added/updated conventions and rules for codable-boundary and package-domain reference expectations.

## Why this split (optional)

This is intentionally an infrastructure-first PR: it lands the data contracts and repository/cache boundaries needed before richer Discover UI behavior is layered on top.

## Testing

- [ ] Local verification commands for this branch should be confirmed before merge.
- [ ] TODO: add exact commands/run results (format, lint, and relevant unit tests).

## PR checklist

- [x] Have you followed this repository's contribution and workflow guidance?
- [x] Have you explained what changed and why this should land now?
- [ ] Have you run relevant local checks for the changed scope?
- [ ] Are changes scoped and free of unrelated modifications?

-----

- [x] AI was used to generate or assist with generating this PR.
- [x] If yes, describe exactly how AI was used and what manual verification was performed.
  AI assistance was used for most implementation and test updates in this branch and for drafting this PR body from the repository template. Manual verification should include reviewer inspection of changed boundaries (API/repository/model split) and running the exact local checks listed in the Testing section once finalized.

-----

## Follow-ups (optional)

- Hook the new Discover data layer into complete UI flows and finalize user-facing loading/error behavior.
- Confirm and record final test/quality command outputs in this PR before merge.