### PR TITLE
Swiftsyntax linter

### DIFF
--- a/.cursor/rules/package-domain-reference.mdc
+++ b/.cursor/rules/package-domain-reference.mdc
@@ -7,6 +7,6 @@ alwaysApply: false
 
 # Package Domain Reference
 
-- Any domain model that represents a Homebrew package must expose a `HomebrewPackageReference` property for lookup identity.
+- Any domain model that represents a Homebrew package must expose `id` typed as `HomebrewPackageID` for lookup identity.
 - Use `.formula(name:)` for formula-backed models and `.cask(token:)` for cask-backed models.
-- Prefer deriving `name`/display fields from `HomebrewPackageReference.displayName` where practical to avoid duplicate identity sources.
+- Prefer deriving `name`/display fields from `HomebrewPackageID.name` where practical to avoid duplicate identity sources.

--- a/.github/workflows/swift_quality.yml
+++ b/.github/workflows/swift_quality.yml
@@ -68,9 +68,14 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: Tools/BrewUILint/.build
-          key: ${{ runner.os }}-brewuilint-${{ hashFiles('Tools/BrewUILint/Package.swift', 'Tools/BrewUILint/Package.resolved', 'Tools/BrewUILint/Sources/**') }}
+          key: ${{ runner.os }}-brewuilint-${{ hashFiles('Tools/BrewUILint/Package.swift', 'Tools/BrewUILint/Package.resolved', 'Tools/BrewUILint/Sources/**', 'Tools/BrewUILint/Plugins/**') }}
           restore-keys: |
             ${{ runner.os }}-brewuilint-
 
+      - name: Build BrewUILint
+        run: swift build --package-path Tools/BrewUILint -c release --enable-experimental-prebuilts
+
       - name: Run BrewUILint
-        run: swift run --package-path Tools/BrewUILint -c release BrewUILint $(find Brew -name '*.swift')
+        run: |
+          BREWUILINT="$(swift build --package-path Tools/BrewUILint -c release --show-bin-path)/BrewUILint"
+          "$BREWUILINT" $(find Brew -name '*.swift')

--- a/.github/workflows/swift_quality.yml
+++ b/.github/workflows/swift_quality.yml
@@ -78,4 +78,4 @@ jobs:
       - name: Run BrewUILint
         run: |
           BREWUILINT="$(swift build --package-path Tools/BrewUILint -c release --show-bin-path)/BrewUILint"
-          "$BREWUILINT" $(find Brew -name '*.swift')
+          find Brew -name '*.swift' -print0 | xargs -0 "$BREWUILINT"

--- a/.github/workflows/swift_quality.yml
+++ b/.github/workflows/swift_quality.yml
@@ -10,6 +10,7 @@ on:
       - ".swiftformat"
       - "Brewfile"
       - "Mintfile"
+      - "Tools/BrewUILint/**"
       - "scripts/bootstrap"
       - "scripts/pre-commit"
   pull_request:
@@ -20,6 +21,7 @@ on:
       - ".swiftformat"
       - "Brewfile"
       - "Mintfile"
+      - "Tools/BrewUILint/**"
       - "scripts/bootstrap"
       - "scripts/pre-commit"
 
@@ -28,7 +30,7 @@ permissions:
 
 jobs:
   swift-quality:
-    name: SwiftFormat + SwiftLint
+    name: SwiftFormat + SwiftLint + BrewUILint
     runs-on: macos-26
     env:
       MINT_PATH: ${{ github.workspace }}/mint
@@ -61,3 +63,16 @@ jobs:
 
       - name: Run SwiftLint (strict)
         run: mint run swiftlint lint --strict
+
+      - name: Cache BrewUILint build
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: Tools/BrewUILint/.build
+          key: ${{ runner.os }}-brewuilint-${{ hashFiles('Tools/BrewUILint/Package.swift', 'Tools/BrewUILint/Package.resolved', 'Tools/BrewUILint/Sources/**') }}
+          restore-keys: |
+            ${{ runner.os }}-brewuilint-
+
+      - name: Run BrewUILint
+        run: |
+          mapfile -t brew_sources < <(find Brew -name '*.swift' -print)
+          swift run --package-path Tools/BrewUILint -c release BrewUILint "${brew_sources[@]}"

--- a/.github/workflows/swift_quality.yml
+++ b/.github/workflows/swift_quality.yml
@@ -73,6 +73,4 @@ jobs:
             ${{ runner.os }}-brewuilint-
 
       - name: Run BrewUILint
-        run: |
-          mapfile -t brew_sources < <(find Brew -name '*.swift' -print)
-          swift run --package-path Tools/BrewUILint -c release BrewUILint "${brew_sources[@]}"
+        run: swift run --package-path Tools/BrewUILint -c release BrewUILint $(find Brew -name '*.swift')

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,8 +81,9 @@ When you change Swift sources or anything that affects Swift formatting or linti
 
 1. `mint run swiftformat --lint .`
 2. `mint run swiftlint lint --strict`
+3. `swift run --package-path Tools/BrewUILint -c release BrewUILint $(find Brew -name '*.swift')`
 
-The pre-commit hook formats and lints **staged** files only; these two commands validate the **whole** tree like CI and catch drift in unstaged paths.
+The pre-commit hook formats and lints **staged** files only; these commands validate the **whole** tree like CI and catch drift in unstaged paths.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,10 @@ When you change Swift sources or anything that affects Swift formatting or linti
 
 1. `mint run swiftformat --lint .`
 2. `mint run swiftlint lint --strict`
-3. `swift run --package-path Tools/BrewUILint -c release BrewUILint $(find Brew -name '*.swift')`
+3. BrewUILint (matches CI; first build is slow because it compiles `swift-syntax`):
+   - `swift build --package-path Tools/BrewUILint -c release --enable-experimental-prebuilts`
+   - `"$(swift build --package-path Tools/BrewUILint -c release --show-bin-path)/BrewUILint" $(find Brew -name '*.swift')`
+   - Keep `Tools/BrewUILint/.build` between runs; deleting it forces a full rebuild (~2+ minutes).
 
 The pre-commit hook formats and lints **staged** files only; these commands validate the **whole** tree like CI and catch drift in unstaged paths.
 

--- a/Brew.xcodeproj/project.pbxproj
+++ b/Brew.xcodeproj/project.pbxproj
@@ -217,12 +217,12 @@
 			);
 			mainGroup = EEC39EB62F5AB4B900269514;
 			minimizedProjectReferenceProxies = 1;
-			preferredProjectObjectVersion = 77;
-			productRefGroup = EEC39EC02F5AB4B900269514 /* Products */;
-			projectDirPath = "";
 			packageReferences = (
 				EEAA00012F70000000000001 /* XCLocalSwiftPackageReference "Tools/BrewUILint" */,
 			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = EEC39EC02F5AB4B900269514 /* Products */;
+			projectDirPath = "";
 			projectRoot = "";
 			targets = (
 				EEC39EBE2F5AB4B900269514 /* Brew */,
@@ -283,6 +283,10 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		EEAA00012F70000000000003 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = EEAA00012F70000000000002 /* BrewUILintPlugin */;
+		};
 		EEC39ECE2F5AB4B900269514 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = EEC39EBE2F5AB4B900269514 /* Brew */;
@@ -293,26 +297,7 @@
 			target = EEC39EBE2F5AB4B900269514 /* Brew */;
 			targetProxy = EEC39ED72F5AB4B900269514 /* PBXContainerItemProxy */;
 		};
-		EEAA00012F70000000000003 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			productRef = EEAA00012F70000000000002 /* BrewUILintPlugin */;
-		};
 /* End PBXTargetDependency section */
-
-/* Begin XCLocalSwiftPackageReference section */
-		EEAA00012F70000000000001 /* XCLocalSwiftPackageReference "Tools/BrewUILint" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = Tools/BrewUILint;
-		};
-/* End XCLocalSwiftPackageReference section */
-
-/* Begin XCSwiftPackageProductDependency section */
-		EEAA00012F70000000000002 /* BrewUILintPlugin */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = EEAA00012F70000000000001 /* XCLocalSwiftPackageReference "Tools/BrewUILint" */;
-			productName = "plugin:BrewUILintPlugin";
-		};
-/* End XCSwiftPackageProductDependency section */
 
 /* Begin XCBuildConfiguration section */
 		EEC39EDE2F5AB4B900269514 /* Debug */ = {
@@ -615,6 +600,21 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		EEAA00012F70000000000001 /* XCLocalSwiftPackageReference "Tools/BrewUILint" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Tools/BrewUILint;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		EEAA00012F70000000000002 /* BrewUILintPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = EEAA00012F70000000000001 /* XCLocalSwiftPackageReference "Tools/BrewUILint" */;
+			productName = "plugin:BrewUILintPlugin";
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = EEC39EB72F5AB4B900269514 /* Project object */;
 }

--- a/Brew.xcodeproj/project.pbxproj
+++ b/Brew.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				EEAA00012F70000000000003 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				EEC39EC12F5AB4B900269514 /* Brew */,
@@ -219,6 +220,9 @@
 			preferredProjectObjectVersion = 77;
 			productRefGroup = EEC39EC02F5AB4B900269514 /* Products */;
 			projectDirPath = "";
+			packageReferences = (
+				EEAA00012F70000000000001 /* XCLocalSwiftPackageReference "Tools/BrewUILint" */,
+			);
 			projectRoot = "";
 			targets = (
 				EEC39EBE2F5AB4B900269514 /* Brew */,
@@ -289,7 +293,26 @@
 			target = EEC39EBE2F5AB4B900269514 /* Brew */;
 			targetProxy = EEC39ED72F5AB4B900269514 /* PBXContainerItemProxy */;
 		};
+		EEAA00012F70000000000003 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = EEAA00012F70000000000002 /* BrewUILintPlugin */;
+		};
 /* End PBXTargetDependency section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		EEAA00012F70000000000001 /* XCLocalSwiftPackageReference "Tools/BrewUILint" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Tools/BrewUILint;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		EEAA00012F70000000000002 /* BrewUILintPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = EEAA00012F70000000000001 /* XCLocalSwiftPackageReference "Tools/BrewUILint" */;
+			productName = "plugin:BrewUILintPlugin";
+		};
+/* End XCSwiftPackageProductDependency section */
 
 /* Begin XCBuildConfiguration section */
 		EEC39EDE2F5AB4B900269514 /* Debug */ = {

--- a/Brew.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Brew.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "f643a9ba692112c683b49eb5cfeedddf95a3ede6d99e7b434e1467fd75e8c646",
+  "pins" : [
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Tools/BrewUILint/Package.resolved
+++ b/Tools/BrewUILint/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "1c4f91e5a1913c5b23a119848f5ba8693c26e566aca65b80118fe96f5c83a07e",
+  "pins" : [
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Tools/BrewUILint/Package.swift
+++ b/Tools/BrewUILint/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "BrewUILint",
+    platforms: [.macOS(.v14)],
+    products: [
+        .executable(name: "BrewUILint", targets: ["BrewUILint"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", exact: "602.0.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "BrewUILint",
+            dependencies: [
+                .product(name: "SwiftSyntax", package: "swift-syntax"),
+                .product(name: "SwiftParser", package: "swift-syntax"),
+            ],
+        ),
+    ],
+)

--- a/Tools/BrewUILint/Package.swift
+++ b/Tools/BrewUILint/Package.swift
@@ -6,6 +6,7 @@ let package = Package(
     platforms: [.macOS(.v14)],
     products: [
         .executable(name: "BrewUILint", targets: ["BrewUILint"]),
+        .plugin(name: "BrewUILintPlugin", targets: ["BrewUILintPlugin"]),
     ],
     dependencies: [
         .package(url: "https://github.com/swiftlang/swift-syntax.git", exact: "602.0.0"),
@@ -17,6 +18,11 @@ let package = Package(
                 .product(name: "SwiftSyntax", package: "swift-syntax"),
                 .product(name: "SwiftParser", package: "swift-syntax"),
             ],
+        ),
+        .plugin(
+            name: "BrewUILintPlugin",
+            capability: .buildTool(),
+            dependencies: ["BrewUILint"],
         ),
         .testTarget(
             name: "BrewUILintTests",

--- a/Tools/BrewUILint/Package.swift
+++ b/Tools/BrewUILint/Package.swift
@@ -18,5 +18,9 @@ let package = Package(
                 .product(name: "SwiftParser", package: "swift-syntax"),
             ],
         ),
+        .testTarget(
+            name: "BrewUILintTests",
+            dependencies: ["BrewUILint"],
+        ),
     ],
 )

--- a/Tools/BrewUILint/Plugins/BrewUILintPlugin/BrewUILintPlugin.swift
+++ b/Tools/BrewUILint/Plugins/BrewUILintPlugin/BrewUILintPlugin.swift
@@ -1,0 +1,50 @@
+import Foundation
+import PackagePlugin
+
+@main
+struct BrewUILintPlugin: BuildToolPlugin {
+    func createBuildCommands(
+        context: PluginContext,
+        target: Target,
+    ) throws -> [Command] {
+        guard let sourceFiles = target.sourceModule?.sourceFiles else {
+            return []
+        }
+
+        let brewUILint = try context.tool(named: "BrewUILint")
+        return sourceFiles.map(\.url).compactMap {
+            createBuildCommand(for: $0, with: brewUILint.url)
+        }
+    }
+
+    func createBuildCommand(for inputPath: URL, with executable: URL) -> Command? {
+        guard inputPath.pathExtension == "swift" else {
+            return nil
+        }
+
+        let fileName = inputPath.lastPathComponent
+        return .buildCommand(
+            displayName: "BrewUILint (\(fileName))",
+            executable: executable,
+            arguments: [inputPath.path],
+            inputFiles: [inputPath],
+            outputFiles: [],
+        )
+    }
+}
+
+#if canImport(XcodeProjectPlugin)
+    import XcodeProjectPlugin
+
+    extension BrewUILintPlugin: XcodeBuildToolPlugin {
+        func createBuildCommands(
+            context: XcodePluginContext,
+            target: XcodeTarget,
+        ) throws -> [Command] {
+            let brewUILint = try context.tool(named: "BrewUILint")
+            return target.inputFiles.map(\.url).compactMap {
+                createBuildCommand(for: $0, with: brewUILint.url)
+            }
+        }
+    }
+#endif

--- a/Tools/BrewUILint/Sources/BrewUILint/BrewUILint.swift
+++ b/Tools/BrewUILint/Sources/BrewUILint/BrewUILint.swift
@@ -1,0 +1,6 @@
+@main
+struct BrewUILintMain {
+    static func main() {
+        print("BrewUILint")
+    }
+}

--- a/Tools/BrewUILint/Sources/BrewUILint/BrewUILint.swift
+++ b/Tools/BrewUILint/Sources/BrewUILint/BrewUILint.swift
@@ -1,6 +1,23 @@
+import Foundation
+
 @main
 struct BrewUILintMain {
     static func main() {
-        print("BrewUILint")
+        let arguments = Array(CommandLine.arguments.dropFirst())
+        guard !arguments.isEmpty else {
+            fputs("usage: BrewUILint <file>...\n", stderr)
+            exit(2)
+        }
+
+        do {
+            let violations = try Runner.lint(files: arguments)
+            for violation in violations {
+                print(violation.xcodeFormatted)
+            }
+            exit(violations.isEmpty ? 0 : 1)
+        } catch {
+            fputs("BrewUILint: \(error)\n", stderr)
+            exit(2)
+        }
     }
 }

--- a/Tools/BrewUILint/Sources/BrewUILint/Core/Rule.swift
+++ b/Tools/BrewUILint/Sources/BrewUILint/Core/Rule.swift
@@ -1,0 +1,21 @@
+import SwiftSyntax
+
+protocol Rule {
+    static var identifier: String { get }
+    static var message: String { get }
+    func makeVisitor(context: RuleContext) -> SyntaxVisitor
+}
+
+struct Violation: Equatable {
+    let ruleID: String
+    let message: String
+    let line: Int
+    let column: Int
+    let file: String
+}
+
+extension Violation {
+    var xcodeFormatted: String {
+        "\(file):\(line):\(column): warning: \(message) (\(ruleID))"
+    }
+}

--- a/Tools/BrewUILint/Sources/BrewUILint/Core/Rule.swift
+++ b/Tools/BrewUILint/Sources/BrewUILint/Core/Rule.swift
@@ -3,6 +3,7 @@ import SwiftSyntax
 protocol Rule {
     static var identifier: String { get }
     static var message: String { get }
+    init()
     func makeVisitor(context: RuleContext) -> SyntaxVisitor
 }
 

--- a/Tools/BrewUILint/Sources/BrewUILint/Core/RuleContext.swift
+++ b/Tools/BrewUILint/Sources/BrewUILint/Core/RuleContext.swift
@@ -1,0 +1,28 @@
+import SwiftSyntax
+
+final class RuleContext {
+    var violations: [Violation] = []
+    let file: String
+    let converter: SourceLocationConverter
+
+    init(file: String, tree: SourceFileSyntax) {
+        self.file = file
+        converter = SourceLocationConverter(fileName: file, tree: tree)
+    }
+
+    func record(
+        rule: any Rule.Type,
+        at position: some SyntaxProtocol,
+    ) {
+        let location = position.startLocation(converter: converter)
+        violations.append(
+            Violation(
+                ruleID: rule.identifier,
+                message: rule.message,
+                line: location.line,
+                column: location.column,
+                file: file,
+            ),
+        )
+    }
+}

--- a/Tools/BrewUILint/Sources/BrewUILint/Core/RuleRegistry.swift
+++ b/Tools/BrewUILint/Sources/BrewUILint/Core/RuleRegistry.swift
@@ -1,3 +1,3 @@
 enum RuleRegistry {
-    static let allRules: [any Rule.Type] = []
+    static let allRules: [any Rule.Type] = [PackageIDRule.self]
 }

--- a/Tools/BrewUILint/Sources/BrewUILint/Core/RuleRegistry.swift
+++ b/Tools/BrewUILint/Sources/BrewUILint/Core/RuleRegistry.swift
@@ -1,0 +1,3 @@
+enum RuleRegistry {
+    static let allRules: [any Rule.Type] = []
+}

--- a/Tools/BrewUILint/Sources/BrewUILint/Core/Runner.swift
+++ b/Tools/BrewUILint/Sources/BrewUILint/Core/Runner.swift
@@ -1,0 +1,25 @@
+import Foundation
+import SwiftParser
+import SwiftSyntax
+
+enum Runner {
+    static func lint(files: [String]) throws -> [Violation] {
+        var allViolations: [Violation] = []
+
+        for path in files {
+            let source = try String(contentsOfFile: path, encoding: .utf8)
+            let tree = Parser.parse(source: source)
+            let context = RuleContext(file: path, tree: tree)
+
+            for ruleType in RuleRegistry.allRules {
+                let rule = ruleType.init()
+                let visitor = rule.makeVisitor(context: context)
+                visitor.walk(tree)
+            }
+
+            allViolations.append(contentsOf: context.violations)
+        }
+
+        return allViolations
+    }
+}

--- a/Tools/BrewUILint/Sources/BrewUILint/Rules/PackageIDRule.swift
+++ b/Tools/BrewUILint/Sources/BrewUILint/Rules/PackageIDRule.swift
@@ -1,0 +1,136 @@
+import SwiftSyntax
+
+struct PackageIDRule: Rule {
+    static let identifier = "package_id_type"
+    static let message =
+        "Types whose name contains 'Package' must declare `id` as `HomebrewPackageID` (or `HomebrewPackageID?`)."
+
+    func makeVisitor(context: RuleContext) -> SyntaxVisitor {
+        PackageIDVisitor(context: context)
+    }
+}
+
+private final class PackageIDVisitor: SyntaxVisitor {
+    private let context: RuleContext
+    private var enclosingTypeNames: [String] = []
+
+    init(context: RuleContext) {
+        self.context = context
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+        pushTypeName(node.name.text)
+        return .visitChildren
+    }
+
+    override func visitPost(_: StructDeclSyntax) {
+        popTypeName()
+    }
+
+    override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+        pushTypeName(node.name.text)
+        return .visitChildren
+    }
+
+    override func visitPost(_: ClassDeclSyntax) {
+        popTypeName()
+    }
+
+    override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+        pushTypeName(node.name.text)
+        return .visitChildren
+    }
+
+    override func visitPost(_: EnumDeclSyntax) {
+        popTypeName()
+    }
+
+    override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
+        pushTypeName(node.name.text)
+        return .visitChildren
+    }
+
+    override func visitPost(_: ActorDeclSyntax) {
+        popTypeName()
+    }
+
+    override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
+        pushTypeName(node.extendedType.trimmedDescription)
+        return .visitChildren
+    }
+
+    override func visitPost(_: ExtensionDeclSyntax) {
+        popTypeName()
+    }
+
+    override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+        guard isInsidePackageNamedType else {
+            return .skipChildren
+        }
+
+        for binding in node.bindings {
+            guard bindingPatternIsID(binding.pattern) else {
+                continue
+            }
+
+            guard let typeAnnotation = binding.typeAnnotation?.type else {
+                context.record(rule: PackageIDRule.self, at: binding)
+                continue
+            }
+
+            if !PackageIDTypeMatcher.isHomebrewPackageID(typeAnnotation) {
+                context.record(rule: PackageIDRule.self, at: typeAnnotation)
+            }
+        }
+
+        return .skipChildren
+    }
+
+    private var isInsidePackageNamedType: Bool {
+        enclosingTypeNames.contains { $0.contains("Package") }
+    }
+
+    private func pushTypeName(_ name: String) {
+        enclosingTypeNames.append(name)
+    }
+
+    private func popTypeName() {
+        _ = enclosingTypeNames.popLast()
+    }
+
+    private func bindingPatternIsID(_ pattern: PatternSyntax) -> Bool {
+        guard let identifierPattern = pattern.as(IdentifierPatternSyntax.self) else {
+            return false
+        }
+        return identifierPattern.identifier.text == "id"
+    }
+}
+
+private enum PackageIDTypeMatcher {
+    private static let canonicalTypeName = "HomebrewPackageID"
+
+    static func isHomebrewPackageID(_ type: TypeSyntax) -> Bool {
+        if let optional = type.as(OptionalTypeSyntax.self) {
+            return isHomebrewPackageID(optional.wrappedType)
+        }
+
+        if let identifierType = type.as(IdentifierTypeSyntax.self),
+           identifierType.name.text == "Self"
+        {
+            return true
+        }
+
+        if let memberType = type.as(MemberTypeSyntax.self) {
+            return memberType.baseType.trimmedDescription == canonicalTypeName
+        }
+
+        if let identifierType = type.as(IdentifierTypeSyntax.self),
+           identifierType.name.text == canonicalTypeName
+        {
+            return true
+        }
+
+        return type.trimmedDescription == canonicalTypeName
+    }
+}

--- a/Tools/BrewUILint/Sources/BrewUILint/Rules/PackageIDRule.swift
+++ b/Tools/BrewUILint/Sources/BrewUILint/Rules/PackageIDRule.swift
@@ -3,7 +3,7 @@ import SwiftSyntax
 struct PackageIDRule: Rule {
     static let identifier = "package_id_type"
     static let message =
-        "Types whose name contains 'Package' must declare `id` as `HomebrewPackageID` (or `HomebrewPackageID?`)."
+        "Types whose name ends with 'Package' must declare `id` as `HomebrewPackageID` (or `HomebrewPackageID?`)."
 
     func makeVisitor(context: RuleContext) -> SyntaxVisitor {
         PackageIDVisitor(context: context)
@@ -88,7 +88,13 @@ private final class PackageIDVisitor: SyntaxVisitor {
     }
 
     private var isInsidePackageNamedType: Bool {
-        enclosingTypeNames.contains { $0.contains("Package") }
+        enclosingTypeNames.contains(where: typeNameEndsWithPackage)
+    }
+
+    private func typeNameEndsWithPackage(_ typeName: String) -> Bool {
+        let simpleName = typeName.split(separator: ".").last.map(String.init) ?? typeName
+        let withoutGenerics = simpleName.split(separator: "<", maxSplits: 1).first.map(String.init) ?? simpleName
+        return withoutGenerics.hasSuffix("Package")
     }
 
     private func pushTypeName(_ name: String) {

--- a/Tools/BrewUILint/Tests/BrewUILintTests/.swiftlint.yml
+++ b/Tools/BrewUILint/Tests/BrewUILintTests/.swiftlint.yml
@@ -1,0 +1,3 @@
+parent_config: ../../../.swiftlint.yml
+identifier_name:
+  min_length: 2

--- a/Tools/BrewUILint/Tests/BrewUILintTests/PackageIDRuleTests.swift
+++ b/Tools/BrewUILint/Tests/BrewUILintTests/PackageIDRuleTests.swift
@@ -1,0 +1,85 @@
+@testable import BrewUILint
+import Testing
+
+@Suite("PackageIDRule")
+struct PackageIDRuleTests {
+    @Test
+    func `package type with canonical ID passes`() {
+        let source = """
+        struct BrewPackage {
+            var id: HomebrewPackageID
+        }
+        """
+        let violations = LintHarness.lintPackageIDRule(source)
+        #expect(violations.isEmpty)
+    }
+
+    @Test
+    func `package type with string ID fails`() {
+        let source = """
+        struct HomebrewPackage {
+            let id: String
+        }
+        """
+        let violations = LintHarness.lintPackageIDRule(source)
+        #expect(violations.count == 1)
+        #expect(violations[0].ruleID == PackageIDRule.identifier)
+    }
+
+    @Test
+    func `extension with wrong ID fails`() {
+        let source = """
+        extension InstalledBrewPackage {
+            var id: String { "x" }
+        }
+        """
+        let violations = LintHarness.lintPackageIDRule(source)
+        #expect(violations.count == 1)
+    }
+
+    @Test
+    func `nested package type fails`() {
+        let source = """
+        struct Container {
+            struct InnerPackageRow {
+                let id: Int
+            }
+        }
+        """
+        let violations = LintHarness.lintPackageIDRule(source)
+        #expect(violations.count == 1)
+    }
+
+    @Test
+    func `non package type ignored`() {
+        let source = """
+        struct RowModel {
+            let id: String
+        }
+        """
+        let violations = LintHarness.lintPackageIDRule(source)
+        #expect(violations.isEmpty)
+    }
+
+    @Test
+    func `package type non ID binding ignored`() {
+        let source = """
+        struct BrewPackage {
+            let packageID: String
+        }
+        """
+        let violations = LintHarness.lintPackageIDRule(source)
+        #expect(violations.isEmpty)
+    }
+
+    @Test
+    func `canonical identity enum self ID passes`() {
+        let source = """
+        enum HomebrewPackageID {
+            var id: Self { self }
+        }
+        """
+        let violations = LintHarness.lintPackageIDRule(source)
+        #expect(violations.isEmpty)
+    }
+}

--- a/Tools/BrewUILint/Tests/BrewUILintTests/PackageIDRuleTests.swift
+++ b/Tools/BrewUILint/Tests/BrewUILintTests/PackageIDRuleTests.swift
@@ -41,13 +41,24 @@ struct PackageIDRuleTests {
     func `nested package type fails`() {
         let source = """
         struct Container {
-            struct InnerPackageRow {
+            struct InnerPackage {
                 let id: Int
             }
         }
         """
         let violations = LintHarness.lintPackageIDRule(source)
         #expect(violations.count == 1)
+    }
+
+    @Test
+    func `package list type ignored`() {
+        let source = """
+        struct PackageList {
+            let id: String
+        }
+        """
+        let violations = LintHarness.lintPackageIDRule(source)
+        #expect(violations.isEmpty)
     }
 
     @Test
@@ -73,7 +84,7 @@ struct PackageIDRuleTests {
     }
 
     @Test
-    func `canonical identity enum self ID passes`() {
+    func `canonical identity enum ignored`() {
         let source = """
         enum HomebrewPackageID {
             var id: Self { self }

--- a/Tools/BrewUILint/Tests/BrewUILintTests/TestSupport/LintHarness.swift
+++ b/Tools/BrewUILint/Tests/BrewUILintTests/TestSupport/LintHarness.swift
@@ -1,0 +1,14 @@
+@testable import BrewUILint
+import SwiftParser
+import SwiftSyntax
+
+enum LintHarness {
+    static func lintPackageIDRule(_ source: String, file: String = "Test.swift") -> [Violation] {
+        let tree = Parser.parse(source: source)
+        let context = RuleContext(file: file, tree: tree)
+        let rule = PackageIDRule()
+        let visitor = rule.makeVisitor(context: context)
+        visitor.walk(tree)
+        return context.violations
+    }
+}

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -63,12 +63,14 @@ for index in "${!swift_files[@]}"; do
     fi
 
     is_partial=false
-    for partial in "${partially_staged_files[@]}"; do
-        if [[ "${file}" == "${partial}" ]]; then
-            is_partial=true
-            break
-        fi
-    done
+    if ((${#partially_staged_files[@]} > 0)); then
+        for partial in "${partially_staged_files[@]}"; do
+            if [[ "${file}" == "${partial}" ]]; then
+                is_partial=true
+                break
+            fi
+        done
+    fi
 
     if [[ "${is_partial}" == true ]]; then
         files_needing_manual_stage+=("${file}")


### PR DESCRIPTION
# PR: Add BrewUILint and enforce HomebrewPackageID on package models

## Summary

This PR is somewhat of a **proposal** for adding **BrewUILint**, a small SwiftSyntax-based linter that enforces that types whose names **end with** `Package` declare `id` as `HomebrewPackageID` (or optional/`Self` where appropriate).

I'd like **@MikeMcQuaid's** opinion on whether this approach makes sense for BrewUI, or whether the custom linter + CI + Xcode build-tool plugin is too heavy-handed compared with convention/docs alone.

## Changes

**BrewUILint (`Tools/BrewUILint/`)**
- New SwiftPM package (swift-syntax 602.0.0) with extensible `Rule` protocol, runner CLI, and first rule `PackageIDRule` (`package_id_type`).
- Swift Testing coverage for pass/fail cases, extensions, nested types, and negative cases (e.g. `PackageList` ignored).
- **CI:** `swift_quality.yml` runs release `BrewUILint` over `Brew/**/*.swift` with `.build` cache.
- **Xcode:** local package + `BrewUILintPlugin` on the **Brew** target for inline diagnostics during dev builds.
- **Docs:** `AGENTS.md` local parity command; `.cursor/rules/package-domain-reference.mdc` aligned to `HomebrewPackageID`.

**Tooling**
- Pre-commit: guard empty `partially_staged_files` when checking partially staged files after format/lint.

## Why this split (optional)

Identity cleanup and mechanical enforcement are landed together because the linter codifies the same invariant the model refactor establishes. If reviewers prefer a lighter approach, we could merge the identity changes without BrewUILint, or keep BrewUILint CI-only and drop the Xcode build-tool plugin.

## Testing

- [ ] Manual: introduce a deliberate violation (e.g. `struct BadPackage { let id: String }`) and confirm Xcode inline warning + CI failure

## PR checklist

- [x] Have you followed this repository's contribution and workflow guidance?
- [x] Have you explained what changed and why this should land now?
- [ ] Have you run relevant local checks for the changed scope?
- [x] Are changes scoped and free of unrelated modifications?

-----

- [x] AI was used to generate or assist with generating this PR.
- [x] If yes, describe exactly how AI was used and what manual verification was performed.
  AI assistance implemented the BrewUILint package (scaffold, rules, tests, CI, Xcode plugin) and this PR body. Manual verification included BrewUILint unit tests, full-tree lint, and a successful Brew app build with the plugin enabled. Full `mint` quality gates and Brew-Unit xcodebuild test should be run before merge.

-----

## Follow-ups (optional)

- Add more BrewUILint rules by conforming to `Rule` and appending to `RuleRegistry` (no new CI jobs).
- Consider pre-commit BrewUILint only if incremental cost is acceptable (currently CI + Xcode only).
