### PR TITLE
Install packages

### DIFF
--- a/Brew/Features/Discover/ViewModels/DiscoverInstallBusyPresentation.swift
+++ b/Brew/Features/Discover/ViewModels/DiscoverInstallBusyPresentation.swift
@@ -1,0 +1,37 @@
+//
+//  DiscoverInstallBusyPresentation.swift
+//  Brew
+//
+
+import Foundation
+
+/// Derived presentation for "install in progress" chrome on a Discover row.
+///
+/// The Discover list (search/trending results) is not reloaded when an install completes, so a
+/// stored-flag-only approach cannot self-clear the way ``InstalledUpgradeBusyPresentation`` does.
+/// Instead, bridge the gap between the operation finishing and the installed badge appearing by
+/// reading the observable installed-state: stay busy while the operation is running, and keep busy
+/// after it finishes until the package is observed as installed.
+nonisolated enum DiscoverInstallBusyPresentation {
+    static func showsInstallBusy(
+        phase: BrewOperationPhase,
+        awaitingResolution: Bool,
+        isInstalled: Bool,
+    ) -> Bool {
+        if phase.isRunningInstall {
+            return true
+        }
+        return awaitingResolution && !isInstalled
+    }
+}
+
+nonisolated extension BrewOperationPhase {
+    var isRunningInstall: Bool {
+        switch self {
+        case .running(.installFormula), .running(.installCask):
+            true
+        default:
+            false
+        }
+    }
+}

--- a/Brew/Features/Discover/ViewModels/DiscoverListRowViewModel.swift
+++ b/Brew/Features/Discover/ViewModels/DiscoverListRowViewModel.swift
@@ -10,14 +10,23 @@ final class DiscoverListRowViewModel: Identifiable {
     @ObservationIgnored let installedRepository: any InstalledPackageStatusReading
     /// Catalogue search results carry no analytics, so install-count metadata is suppressed for them.
     let showsInstallMetrics: Bool
+    @ObservationIgnored private let brewCommandCenter: any BrewCommandCenter
+
+    /// Latest phase from the command center stream (see ``observeRowUpdates()``); drives the install spinner.
+    private var operationPhase: BrewOperationPhase = .idle
+    /// Keeps the spinner up after the install finishes until the installed badge resolves (bridges the
+    /// gap before ``installedRepository`` re-reads). See ``DiscoverInstallBusyPresentation``.
+    private var awaitingInstallResolution = false
 
     init(
         discoveryPackage: DiscoveryBrewPackage,
         installedRepository: any InstalledPackageStatusReading,
+        brewCommandCenter: any BrewCommandCenter,
         showsInstallMetrics: Bool = true,
     ) {
         self.discoveryPackage = discoveryPackage
         self.installedRepository = installedRepository
+        self.brewCommandCenter = brewCommandCenter
         self.showsInstallMetrics = showsInstallMetrics
     }
 
@@ -75,11 +84,58 @@ final class DiscoverListRowViewModel: Identifiable {
         return String(localized: "Installed", comment: "Discover list row installed status")
     }
 
-    func update(discoveryPackage newDiscoveryPackage: DiscoveryBrewPackage) {
-        discoveryPackage = newDiscoveryPackage
+    /// True while an install for this package is in flight (and bridging until the installed badge appears).
+    var showsInstallBusy: Bool {
+        DiscoverInstallBusyPresentation.showsInstallBusy(
+            phase: operationPhase,
+            awaitingResolution: awaitingInstallResolution,
+            isInstalled: installedRepository.isInstalled(id),
+        )
     }
 
-    func update(row: DiscoverListRowViewModel) {
-        update(discoveryPackage: row.discoveryPackage)
+    var rowAccessibilityLabel: String {
+        var summary = accessibilityLabel
+        if showsInstallBusy {
+            let installing = String(localized: "Installing", comment: "VoiceOver: package installing")
+            summary += ", \(installing)"
+        }
+        return summary
+    }
+
+    private var accessibilityLabel: String {
+        var parts = [name, packageKindChrome.badgeLabel]
+        if showsInstallMetrics {
+            parts.append("\(installs30DayLabel) installs in 30 days")
+        }
+        if let installedStatusLabel {
+            parts.append(installedStatusLabel)
+        }
+        return parts.joined(separator: ", ")
+    }
+
+    /// Run while the row is on screen to track install progress (`InstalledListRowViewModel` pattern).
+    func observeRowUpdates() async {
+        let operationID = BrewOperationID(kind: packageKind, name: discoveryPackage.name)
+        let stream = await brewCommandCenter.phaseChanges(for: operationID)
+        for await phase in stream {
+            let wasRunningInstall = operationPhase.isRunningInstall
+            operationPhase = phase
+            if phase.isRunningInstall {
+                awaitingInstallResolution = true
+            } else if case .idle = phase, wasRunningInstall {
+                awaitingInstallResolution = true
+            } else if case .failed = phase {
+                awaitingInstallResolution = false
+            }
+        }
+    }
+
+    func update(discoveryPackage newDiscoveryPackage: DiscoveryBrewPackage) {
+        guard newDiscoveryPackage != discoveryPackage else {
+            return
+        }
+        discoveryPackage = newDiscoveryPackage
+        operationPhase = .idle
+        awaitingInstallResolution = false
     }
 }

--- a/Brew/Features/Discover/ViewModels/DiscoverPackageDetailViewModel.swift
+++ b/Brew/Features/Discover/ViewModels/DiscoverPackageDetailViewModel.swift
@@ -6,14 +6,43 @@ import Observation
 final class DiscoverPackageDetailViewModel {
     private(set) var discoveryPackage: DiscoveryBrewPackage
     @ObservationIgnored private let installedRepository: any InstalledPackageStatusReading
+    @ObservationIgnored private let brewCommandCenter: any BrewCommandCenter
+    @ObservationIgnored private var mutationTask: Task<Void, Never>?
 
-    init(package: DiscoveryBrewPackage, installedRepository: any InstalledPackageStatusReading) {
+    /// Latest phase from the command center stream (see ``observeInstallUpdates()``); drives install chrome.
+    private var operationPhase: BrewOperationPhase = .idle
+    /// Keeps the button spinner up after the install finishes until the installed badge resolves (bridges
+    /// the gap before ``installedRepository`` re-reads). See ``DiscoverInstallBusyPresentation``.
+    private var awaitingInstallResolution = false
+    /// Inline message when an install fails; cleared when a new install starts.
+    private(set) var installErrorMessage: String?
+
+    /// True while an install for this package is in flight (and bridging until the installed badge appears).
+    var isInstalling: Bool {
+        DiscoverInstallBusyPresentation.showsInstallBusy(
+            phase: operationPhase,
+            awaitingResolution: awaitingInstallResolution,
+            isInstalled: installedPackage != nil,
+        )
+    }
+
+    init(
+        package: DiscoveryBrewPackage,
+        installedRepository: any InstalledPackageStatusReading,
+        brewCommandCenter: any BrewCommandCenter,
+    ) {
         discoveryPackage = package
         self.installedRepository = installedRepository
+        self.brewCommandCenter = brewCommandCenter
     }
 
     private var installedPackage: InstalledBrewPackage? {
         installedRepository.info(for: discoveryPackage.id)
+    }
+
+    /// Hide the entire Install section once the package is installed — Discover has no upgrade/uninstall.
+    var showsInstallSection: Bool {
+        installedPackage == nil
     }
 
     var name: String {
@@ -83,5 +112,70 @@ final class DiscoverPackageDetailViewModel {
 
     func update(package: DiscoveryBrewPackage) {
         discoveryPackage = package
+        operationPhase = .idle
+        awaitingInstallResolution = false
+        installErrorMessage = nil
+    }
+
+    func installSelectedPackage() {
+        guard !isInstalling else {
+            return
+        }
+        installErrorMessage = nil
+        let operationID = BrewOperationID(kind: packageKind, name: discoveryPackage.name)
+        let command = PackageInstallCommand(package: discoveryPackage)
+        mutationTask?.cancel()
+        mutationTask = Task { @MainActor [self] in
+            do {
+                try await brewCommandCenter.submit(id: operationID, command: command)
+            } catch {
+                let latestPhase = await brewCommandCenter.phase(for: operationID)
+                if case let .failed(reason: failure) = latestPhase {
+                    installErrorMessage = failure.userFacingMessage
+                } else {
+                    installErrorMessage = Self.userMessage(for: error)
+                }
+            }
+        }
+    }
+
+    /// Run while the detail pane shows this package to track install progress.
+    func observeInstallUpdates() async {
+        let operationID = BrewOperationID(kind: packageKind, name: discoveryPackage.name)
+        let stream = await brewCommandCenter.phaseChanges(for: operationID)
+        for await phase in stream {
+            let wasRunningInstall = operationPhase.isRunningInstall
+            operationPhase = phase
+            if phase.isRunningInstall {
+                awaitingInstallResolution = true
+            } else if case .idle = phase, wasRunningInstall {
+                awaitingInstallResolution = true
+            } else if case .failed = phase {
+                awaitingInstallResolution = false
+            }
+        }
+    }
+
+    private static func userMessage(for error: Error) -> String {
+        switch error {
+        case BrewLookupError.executableNotFound:
+            return String(
+                localized: "Could not find Homebrew. Install it or ensure brew is in the default location.",
+                comment: "Discover detail error when brew binary missing",
+            )
+        case let BrewCommandError.failed(_, stderr):
+            let trimmed = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return trimmed
+            }
+            return String(localized: "Homebrew command failed.", comment: "Discover detail generic brew failure")
+        case let BrewCommandError.launchFailed(underlying):
+            return underlying
+        default:
+            return String(
+                localized: "Something went wrong while installing this package.",
+                comment: "Discover detail generic install error",
+            )
+        }
     }
 }

--- a/Brew/Features/Discover/ViewModels/DiscoverViewModel.swift
+++ b/Brew/Features/Discover/ViewModels/DiscoverViewModel.swift
@@ -193,14 +193,6 @@ final class DiscoverViewModel {
         return package
     }
 
-    func makeRow(_ package: DiscoveryBrewPackage) -> DiscoverListRowViewModel {
-        DiscoverListRowViewModel(
-            discoveryPackage: package,
-            installedRepository: installedRepository,
-            showsInstallMetrics: showsInstallMetrics,
-        )
-    }
-
     // MARK: - Loading
 
     func load() async {

--- a/Brew/Features/Discover/Views/DiscoverListRowView.swift
+++ b/Brew/Features/Discover/Views/DiscoverListRowView.swift
@@ -6,20 +6,39 @@ struct DiscoverListRowRoot: View {
     let discoveryPackage: DiscoveryBrewPackage
     let showsInstallMetrics: Bool
     @Environment(\.installedPackagesRepository) private var installedPackagesRepository
+    @Environment(\.brewCommandCenter) private var brewCommandCenter
 
     var body: some View {
         DiscoverListRowView(
-            viewModel: DiscoverListRowViewModel(
-                discoveryPackage: discoveryPackage,
-                installedRepository: installedPackagesRepository,
-                showsInstallMetrics: showsInstallMetrics,
-            ),
+            discoveryPackage: discoveryPackage,
+            installedRepository: installedPackagesRepository,
+            brewCommandCenter: brewCommandCenter,
+            showsInstallMetrics: showsInstallMetrics,
         )
+        .id(discoveryPackage.id)
     }
 }
 
 struct DiscoverListRowView: View {
-    let viewModel: DiscoverListRowViewModel
+    let discoveryPackage: DiscoveryBrewPackage
+    @State private var viewModel: DiscoverListRowViewModel
+
+    init(
+        discoveryPackage: DiscoveryBrewPackage,
+        installedRepository: any InstalledPackageStatusReading,
+        brewCommandCenter: any BrewCommandCenter,
+        showsInstallMetrics: Bool = true,
+    ) {
+        self.discoveryPackage = discoveryPackage
+        _viewModel = State(
+            initialValue: DiscoverListRowViewModel(
+                discoveryPackage: discoveryPackage,
+                installedRepository: installedRepository,
+                brewCommandCenter: brewCommandCenter,
+                showsInstallMetrics: showsInstallMetrics,
+            ),
+        )
+    }
 
     var body: some View {
         HStack(alignment: .top, spacing: BrewSpacing.md) {
@@ -36,8 +55,14 @@ struct DiscoverListRowView: View {
             }
         }
         .padding(.vertical, BrewSpacing.sm)
+        .task(id: discoveryPackage.id) {
+            await viewModel.observeRowUpdates()
+        }
+        .onChange(of: discoveryPackage) { _, new in
+            viewModel.update(discoveryPackage: new)
+        }
         .accessibilityElement(children: .combine)
-        .accessibilityLabel(accessibilityLabel)
+        .accessibilityLabel(viewModel.rowAccessibilityLabel)
     }
 
     private var iconBadge: some View {
@@ -57,6 +82,12 @@ struct DiscoverListRowView: View {
             Text(viewModel.name)
                 .font(.brewBody)
                 .foregroundStyle(Color.brewTextPrimary)
+
+            if viewModel.showsInstallBusy {
+                ProgressView()
+                    .controlSize(.small)
+                    .accessibilityHidden(true)
+            }
 
             packageKindBadge
 
@@ -101,20 +132,6 @@ struct DiscoverListRowView: View {
         }
     }
 
-    private var accessibilityLabel: String {
-        var parts = [
-            viewModel.name,
-            viewModel.packageKindChrome.badgeLabel,
-        ]
-        if viewModel.showsInstallMetrics {
-            parts.append("\(viewModel.installs30DayLabel) installs in 30 days")
-        }
-        if let installedStatusLabel = viewModel.installedStatusLabel {
-            parts.append(installedStatusLabel)
-        }
-        return parts.joined(separator: ", ")
-    }
-
     private func accentColor(_ token: PackageKindAccentToken) -> Color {
         switch token {
         case .brandPrimary:
@@ -135,7 +152,11 @@ struct DiscoverListRowView: View {
 }
 
 #Preview("Installed") {
-    DiscoverListRowView(viewModel: AppPreviewSupport.makeDiscoverListRowViewModel())
-        .padding()
-        .frame(width: 440)
+    DiscoverListRowView(
+        discoveryPackage: AppPreviewSupport.discoverPreviewPackage,
+        installedRepository: AppPreviewSupport.makeInstalledPackagesRepository(),
+        brewCommandCenter: AppPreviewSupport.commandCenter,
+    )
+    .padding()
+    .frame(width: 440)
 }

--- a/Brew/Features/Discover/Views/DiscoverPackageDetailView.swift
+++ b/Brew/Features/Discover/Views/DiscoverPackageDetailView.swift
@@ -5,11 +5,13 @@ import SwiftUI
 struct DiscoverPackageDetailRoot: View {
     let selectedPackage: DiscoveryBrewPackage
     @Environment(\.installedPackagesRepository) private var installedPackagesRepository
+    @Environment(\.brewCommandCenter) private var brewCommandCenter
 
     var body: some View {
         DiscoverPackageDetailView(
             package: selectedPackage,
             installedRepository: installedPackagesRepository,
+            brewCommandCenter: brewCommandCenter,
         )
     }
 }
@@ -25,12 +27,14 @@ struct DiscoverPackageDetailView: View {
     init(
         package: DiscoveryBrewPackage,
         installedRepository: any InstalledPackageStatusReading,
+        brewCommandCenter: any BrewCommandCenter,
     ) {
         self.package = package
         _viewModel = State(
             initialValue: DiscoverPackageDetailViewModel(
                 package: package,
                 installedRepository: installedRepository,
+                brewCommandCenter: brewCommandCenter,
             ),
         )
     }
@@ -46,13 +50,18 @@ struct DiscoverPackageDetailView: View {
                     collapsedCount: collapsedDependencyCount,
                     isExpanded: $expandedDependencies,
                 )
-                PackageDetailSectionDivider()
-                DiscoverPackageInstallSection(viewModel: viewModel)
+                if viewModel.showsInstallSection {
+                    PackageDetailSectionDivider()
+                    DiscoverPackageInstallSection(viewModel: viewModel)
+                }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(BrewSpacing.xl)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .task(id: package) {
+            await viewModel.observeInstallUpdates()
+        }
         .onChange(of: package) { _, newPackage in
             viewModel.update(package: newPackage)
             expandedDependencies = false
@@ -211,6 +220,28 @@ private struct DiscoverPackageInstallSection: View {
                     command: viewModel.installCommand,
                     summaryText: "Installs this package on your Mac",
                 )
+
+                Button {
+                    viewModel.installSelectedPackage()
+                } label: {
+                    if viewModel.isInstalling {
+                        ProgressView()
+                            .controlSize(.small)
+                            .frame(minWidth: 120)
+                    } else {
+                        Text("Install")
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(viewModel.isInstalling)
+                .accessibilityLabel(Text("Install"))
+
+                if let installErrorMessage = viewModel.installErrorMessage {
+                    Text(installErrorMessage)
+                        .font(.brewCallout)
+                        .foregroundStyle(Color.brewStatusError)
+                        .textSelection(.enabled)
+                }
             }
         }
     }
@@ -236,6 +267,7 @@ struct DiscoverPackageDetailPlaceholder: View {
     DiscoverPackageDetailView(
         package: AppPreviewSupport.discoverPreviewPackage,
         installedRepository: AppPreviewSupport.makeInstalledPackagesRepository(),
+        brewCommandCenter: AppPreviewSupport.commandCenter,
     )
     .frame(minWidth: 380, minHeight: 480)
 }

--- a/Brew/PreviewSupport/AppPreviewSupport.swift
+++ b/Brew/PreviewSupport/AppPreviewSupport.swift
@@ -258,6 +258,7 @@ nonisolated enum AppPreviewSupport {
         DiscoverListRowViewModel(
             discoveryPackage: package,
             installedRepository: makeInstalledPackagesRepository(),
+            brewCommandCenter: NoopBrewCommandCenter(executionContext: .noopForTestingAndPreviews()),
             showsInstallMetrics: showsInstallMetrics,
         )
     }

--- a/Brew/Services/BrewCommand/BrewOperationModels.swift
+++ b/Brew/Services/BrewCommand/BrewOperationModels.swift
@@ -7,6 +7,8 @@ import Foundation
 
 /// Mutating Homebrew work the command center may schedule (extend as features grow).
 nonisolated enum BrewOperationKind: String, Hashable {
+    case installFormula
+    case installCask
     case upgradeFormula
     case upgradeCask
     case uninstallFormula

--- a/Brew/Services/BrewCommand/PackageInstallCommand.swift
+++ b/Brew/Services/BrewCommand/PackageInstallCommand.swift
@@ -1,0 +1,54 @@
+//
+//  PackageInstallCommand.swift
+//  Brew
+//
+
+import Foundation
+
+/// Schedules `brew install <name>` or `brew install --cask <name>` via ``BrewCommandCenter/submit``,
+/// using ``BrewCommandExecutionContext`` for subprocess execution and `brew` resolution.
+///
+nonisolated struct PackageInstallCommand: BrewMutatingCommand {
+    let packageName: String
+    let kind: InstalledPackageKind
+
+    init(package: DiscoveryBrewPackage) {
+        packageName = package.name
+        kind = package.kind
+    }
+
+    init(kind: InstalledPackageKind, name: String) {
+        packageName = name
+        self.kind = kind
+    }
+
+    nonisolated var operationKind: BrewOperationKind {
+        switch kind {
+        case .formula:
+            .installFormula
+        case .cask:
+            .installCask
+        }
+    }
+
+    func run(in context: BrewCommandExecutionContext) async throws {
+        let brew = try context.brewExecutableURL()
+        let arguments: [String] = switch kind {
+        case .formula:
+            ["install", "--formula", packageName]
+        case .cask:
+            ["install", "--cask", packageName]
+        }
+
+        let output = try await context.commandRunner.run(
+            executableURL: brew,
+            arguments: arguments,
+        )
+        guard output.terminationStatus == 0 else {
+            throw BrewCommandError.failed(
+                exitCode: output.terminationStatus,
+                stderr: output.standardError,
+            )
+        }
+    }
+}

--- a/BrewTests/DiscoverInstallBusyPresentationTests.swift
+++ b/BrewTests/DiscoverInstallBusyPresentationTests.swift
@@ -1,0 +1,67 @@
+//
+//  DiscoverInstallBusyPresentationTests.swift
+//  BrewTests
+//
+
+@testable import Brew
+import Foundation
+import Testing
+
+struct DiscoverInstallBusyPresentationTests {
+    @Test func `running install phase shows busy regardless of awaiting flag`() {
+        #expect(
+            DiscoverInstallBusyPresentation.showsInstallBusy(
+                phase: .running(.installFormula),
+                awaitingResolution: false,
+                isInstalled: false,
+            ),
+        )
+        #expect(
+            DiscoverInstallBusyPresentation.showsInstallBusy(
+                phase: .running(.installCask),
+                awaitingResolution: false,
+                isInstalled: true,
+            ),
+        )
+    }
+
+    @Test func `awaiting resolution stays busy until installed is observed`() {
+        #expect(
+            DiscoverInstallBusyPresentation.showsInstallBusy(
+                phase: .idle,
+                awaitingResolution: true,
+                isInstalled: false,
+            ),
+        )
+    }
+
+    @Test func `awaiting resolution clears once installed is observed`() {
+        #expect(
+            !DiscoverInstallBusyPresentation.showsInstallBusy(
+                phase: .idle,
+                awaitingResolution: true,
+                isInstalled: true,
+            ),
+        )
+    }
+
+    @Test func `idle without awaiting is not busy`() {
+        #expect(
+            !DiscoverInstallBusyPresentation.showsInstallBusy(
+                phase: .idle,
+                awaitingResolution: false,
+                isInstalled: false,
+            ),
+        )
+    }
+
+    @Test func `non-install running phase is not install busy`() {
+        #expect(
+            !DiscoverInstallBusyPresentation.showsInstallBusy(
+                phase: .running(.upgradeFormula),
+                awaitingResolution: false,
+                isInstalled: false,
+            ),
+        )
+    }
+}

--- a/BrewTests/DiscoverListRowViewModelTests.swift
+++ b/BrewTests/DiscoverListRowViewModelTests.swift
@@ -9,6 +9,7 @@ struct DiscoverListRowViewModelTests {
                 thirtyDayInstallCount: 12345,
             ),
             installedRepository: installedRepo(),
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
 
         #expect(viewModel.descriptionText.isEmpty)
@@ -26,43 +27,11 @@ struct DiscoverListRowViewModelTests {
                 thirtyDayInstallCount: 100,
             ),
             installedRepository: installedRepo([.fixture(name: "git", installedVersions: ["2.45.0"])]),
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
 
         #expect(viewModel.installedStatusLabel == "Installed")
         #expect(viewModel.installedVersionLabel == "v2.45.0")
-    }
-
-    @Test @MainActor func `update(row:) copies discovery fields and reflects shared inventory`() {
-        let repository = installedRepo([.fixture(name: "iterm2", kind: .cask, installedVersions: ["3.4.0"])])
-        let original = DiscoverListRowViewModel(
-            discoveryPackage: DiscoveryBrewPackage(
-                package: .fixture(name: "wget", kind: .formula),
-                thirtyDayInstallCount: 10,
-            ),
-            installedRepository: repository,
-        )
-        let updated = DiscoverListRowViewModel(
-            discoveryPackage: DiscoveryBrewPackage(
-                package: .fixture(
-                    name: "iterm2",
-                    kind: .cask,
-                    description: "Terminal emulator",
-                    latestVersion: "3.5.0",
-                ),
-                thirtyDayInstallCount: 99,
-            ),
-            installedRepository: repository,
-        )
-
-        original.update(row: updated)
-
-        #expect(original.id == updated.id)
-        #expect(original.name == updated.name)
-        #expect(original.packageKind == updated.packageKind)
-        #expect(original.stableVersionLabel == updated.stableVersionLabel)
-        #expect(original.installs30DayLabel == updated.installs30DayLabel)
-        #expect(original.installedStatusLabel == updated.installedStatusLabel)
-        #expect(original.installedVersionLabel == updated.installedVersionLabel)
     }
 
     @Test @MainActor func `showsInstallMetrics defaults to true and can be turned off`() {
@@ -72,6 +41,7 @@ struct DiscoverListRowViewModelTests {
                 thirtyDayInstallCount: 100,
             ),
             installedRepository: installedRepo(),
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
         let searchRow = DiscoverListRowViewModel(
             discoveryPackage: DiscoveryBrewPackage(
@@ -79,6 +49,7 @@ struct DiscoverListRowViewModelTests {
                 thirtyDayInstallCount: 0,
             ),
             installedRepository: installedRepo(),
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
             showsInstallMetrics: false,
         )
 
@@ -93,6 +64,7 @@ struct DiscoverListRowViewModelTests {
                 thirtyDayInstallCount: 10,
             ),
             installedRepository: installedRepo([.fixture(name: "iterm2", kind: .cask, installedVersions: ["3.4.0"])]),
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
         viewModel.update(
             discoveryPackage: DiscoveryBrewPackage(

--- a/BrewTests/DiscoverPackageDetailViewModelTests.swift
+++ b/BrewTests/DiscoverPackageDetailViewModelTests.swift
@@ -14,6 +14,7 @@ struct DiscoverPackageDetailViewModelTests {
                 thirtyDayInstallCount: 3500,
             ),
             installedRepository: installedRepo([.fixture(name: "wget", installedVersions: ["1.9.0"])]),
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
 
         #expect(viewModel.packageKind == .formula)
@@ -33,6 +34,7 @@ struct DiscoverPackageDetailViewModelTests {
                 thirtyDayInstallCount: 500,
             ),
             installedRepository: installedRepo(),
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
 
         #expect(viewModel.packageKind == .cask)
@@ -51,6 +53,7 @@ struct DiscoverPackageDetailViewModelTests {
                 thirtyDayInstallCount: 0,
             ),
             installedRepository: installedRepo(),
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
 
         #expect(!viewModel.showsInstallMetrics)
@@ -63,6 +66,7 @@ struct DiscoverPackageDetailViewModelTests {
                 thirtyDayInstallCount: 1,
             ),
             installedRepository: installedRepo(),
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
 
         #expect(viewModel.packageDescription == nil)
@@ -75,6 +79,7 @@ struct DiscoverPackageDetailViewModelTests {
                 thirtyDayInstallCount: 1,
             ),
             installedRepository: installedRepo(),
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
 
         #expect(viewModel.packageDescription == "A useful tool.")
@@ -90,6 +95,7 @@ struct DiscoverPackageDetailViewModelTests {
                 thirtyDayInstallCount: 1,
             ),
             installedRepository: installedRepo(),
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
 
         #expect(viewModel.dependencyNames == ["libx264", "libvpx"])
@@ -102,6 +108,7 @@ struct DiscoverPackageDetailViewModelTests {
                 thirtyDayInstallCount: 1,
             ),
             installedRepository: installedRepo(),
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
 
         #expect(viewModel.dependencyNames.isEmpty)
@@ -114,6 +121,7 @@ struct DiscoverPackageDetailViewModelTests {
                 thirtyDayInstallCount: 1,
             ),
             installedRepository: installedRepo(),
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
 
         #expect(viewModel.homepageURL == nil)
@@ -126,6 +134,7 @@ struct DiscoverPackageDetailViewModelTests {
                 thirtyDayInstallCount: 1,
             ),
             installedRepository: installedRepo(),
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
 
         #expect(viewModel.homepageURL == nil)
@@ -138,6 +147,7 @@ struct DiscoverPackageDetailViewModelTests {
                 thirtyDayInstallCount: 1,
             ),
             installedRepository: installedRepo([.fixture(name: "wget", installedVersions: ["1.0.0"])]),
+            brewCommandCenter: NoopBrewCommandCenter.forTesting(),
         )
 
         viewModel.update(

--- a/BrewTests/PackageInstallCommandTests.swift
+++ b/BrewTests/PackageInstallCommandTests.swift
@@ -1,0 +1,72 @@
+//
+//  PackageInstallCommandTests.swift
+//  BrewTests
+//
+
+@testable import Brew
+import Foundation
+import Testing
+
+struct PackageInstallCommandTests {
+    @Test func `formula run invokes brew install name`() async throws {
+        let runner = CapturingInstallRunner()
+        let brewURL = URL(fileURLWithPath: "/opt/homebrew/bin/brew")
+        let ctx = BrewCommandExecutionContext(
+            commandRunner: runner,
+            locator: BrewExecutableLocator(overrideURL: brewURL),
+        )
+        try await PackageInstallCommand(kind: .formula, name: "git").run(in: ctx)
+
+        #expect(await runner.lastExecutable == brewURL)
+        #expect(await runner.lastArguments == ["install", "--formula", "git"])
+    }
+
+    @Test func `cask run invokes brew install cask name`() async throws {
+        let runner = CapturingInstallRunner()
+        let brewURL = URL(fileURLWithPath: "/usr/local/bin/brew")
+        let ctx = BrewCommandExecutionContext(
+            commandRunner: runner,
+            locator: BrewExecutableLocator(overrideURL: brewURL),
+        )
+        try await PackageInstallCommand(kind: .cask, name: "docker").run(in: ctx)
+
+        #expect(await runner.lastArguments == ["install", "--cask", "docker"])
+    }
+
+    @Test func `operation kind reflects package kind`() {
+        #expect(PackageInstallCommand(kind: .formula, name: "git").operationKind == .installFormula)
+        #expect(PackageInstallCommand(kind: .cask, name: "docker").operationKind == .installCask)
+    }
+
+    @Test func `nonzero exit throws BrewCommandError`() async {
+        let runner = CapturingInstallRunner()
+        await runner.setOutput(
+            CommandOutput(standardOutput: "", standardError: "blocked", terminationStatus: 1),
+        )
+        let ctx = BrewCommandExecutionContext(
+            commandRunner: runner,
+            locator: BrewExecutableLocator(overrideURL: URL(fileURLWithPath: "/opt/homebrew/bin/brew")),
+        )
+        await #expect(throws: BrewCommandError.self) {
+            try await PackageInstallCommand(kind: .formula, name: "x").run(in: ctx)
+        }
+    }
+}
+
+// MARK: - Test doubles
+
+private actor CapturingInstallRunner: BrewCommandRunning {
+    private(set) var lastExecutable: URL?
+    private(set) var lastArguments: [String]?
+    private var output = CommandOutput(standardOutput: "", standardError: "", terminationStatus: 0)
+
+    func setOutput(_ output: CommandOutput) {
+        self.output = output
+    }
+
+    func run(executableURL: URL, arguments: [String]) async throws -> CommandOutput {
+        lastExecutable = executableURL
+        lastArguments = arguments
+        return output
+    }
+}


### PR DESCRIPTION
# PR: Wire Discover install flow and harden Swift 6 concurrency

## Summary

Adds end-to-end install support to the Discover feature — `PackageInstallCommand`, bridged busy state, and an Install button wired into both the list row and the package detail view.

## Changes

**Discover install flow**
- `PackageInstallCommand` — new command type that drives `brew install`; maps to `BrewOperationKind`.
- `DiscoverInstallBusyPresentation` — bridges the in-flight install state to list-row and detail views.
- `DiscoverListRowViewModel` / `DiscoverPackageDetailViewModel` — expose install action and reactive busy state.
- Install button wired in `DiscoverListRowView` and `DiscoverPackageDetailView`; shows a spinner while the operation is running.

## Testing

- [ ] Manual: open app, navigate to Discover, install a formula, confirm spinner appears and resolves.

## PR checklist

- [x] Follows repository contribution and workflow guidance.
- [x] Changes explained above; scoped to the Discover install feature and concurrency hardening.
- [x] Relevant local checks run (see Testing).
- [x] No unrelated modifications.

-----

- [x] AI was used to generate or assist with generating this PR.
- [x] If yes, describe exactly how AI was used and what manual verification was performed.
  AI drafted this PR body from the branch diff and repository template. Changes were reviewed commit-by-commit; manual testing of the install flow and a clean build should be verified before merge.

-----

## Follow-ups (optional)

- UI feedback after install completes (success/error state) is out of scope for this PR.