### PR TITLE
Brew doctor improvements

### DIFF
--- a/Sources/BrewCore/Models/DoctorReport.swift
+++ b/Sources/BrewCore/Models/DoctorReport.swift
@@ -11,9 +11,11 @@ import Foundation
 /// `brew doctor` printed "Your system is ready to brew." rather than any warnings.
 public struct DoctorReport: Equatable, Sendable {
     public var issues: [DoctorIssue]
+    public var rawOutput: String
 
-    public init(issues: [DoctorIssue]) {
+    public init(issues: [DoctorIssue], rawOutput: String = "") {
         self.issues = issues
+        self.rawOutput = rawOutput
     }
 
     /// `true` when `brew doctor` surfaced no warnings.

--- a/Sources/BrewFeatureDiscover/Views/DiscoverPackagesView.swift
+++ b/Sources/BrewFeatureDiscover/Views/DiscoverPackagesView.swift
@@ -146,7 +146,14 @@ private struct DiscoverPackageSections: View {
                     .id(package.id)
                     .contentShape(Rectangle())
                     .listRowBackground(
-                        viewModel.selectedPackageID == package.id ? Color.brewBrandTint : Color.clear,
+                        RoundedRectangle(
+                            cornerRadius: BrewRadius.lg,
+                            style: .continuous,
+                        )
+                        .fill(
+                            viewModel.selectedPackageID == package.id ? Color.brewBrandTint : Color.clear,
+                        )
+                        .padding(.horizontal, BrewSpacing.sm),
                     )
                     .onTapGesture {
                         // Needed to suppress the default ugly blue macOS highlight state

--- a/Sources/BrewFeatureDoctor/ViewModels/DoctorViewModel.swift
+++ b/Sources/BrewFeatureDoctor/ViewModels/DoctorViewModel.swift
@@ -3,6 +3,7 @@
 //  BrewFeatureDoctor
 //
 
+import AppKit
 import BrewCore
 import BrewRepositoryInterfaces
 import Foundation
@@ -78,6 +79,13 @@ final class DoctorViewModel {
     /// loaded — loading and failure states have no rows to focus.
     var shouldFocusList: Bool {
         state.isLoaded
+    }
+
+    var rawDoctorOutput: String? {
+        guard case let .loaded(report) = state, !report.rawOutput.isEmpty else {
+            return nil
+        }
+        return report.rawOutput
     }
 
     var issueItems: [DoctorIssueItem] {
@@ -171,6 +179,12 @@ final class DoctorViewModel {
     }
 
     // MARK: - Intents
+
+    func copyDoctorOutput() {
+        guard let output = rawDoctorOutput else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(output, forType: .string)
+    }
 
     /// Runs `brew doctor` via the repository. Called on tab arrival and from "Run Again"; keeps any prior
     /// report visible while it refreshes. On a fresh load (no prior selection or a stale one), auto-

--- a/Sources/BrewFeatureDoctor/ViewModels/DoctorViewModel.swift
+++ b/Sources/BrewFeatureDoctor/ViewModels/DoctorViewModel.swift
@@ -87,14 +87,6 @@ final class DoctorViewModel {
         return report.issues.map { DoctorIssueItem(issue: $0) }
     }
 
-    var issueCountSubtitle: String {
-        let count = state.value?.issues.count ?? 0
-        if count == 1 {
-            return "1 issue found"
-        }
-        return "\(count) issues found"
-    }
-
     /// Header chrome (Run Again button, re-check spinner) is only meaningful once a report — healthy or
     /// with issues — is on screen. Hidden during the initial load and on failure (the failure surface owns
     /// its own retry affordance via ``AsyncContentView``).
@@ -116,7 +108,7 @@ final class DoctorViewModel {
         case .healthy:
             isRefreshing ? "Re-checking…" : "No problems found"
         case .issues:
-            isRefreshing ? "Re-checking…" : issueCountSubtitle
+            isRefreshing ? "Re-checking…" : "Warnings found"
         case .failed:
             "The check could not be completed"
         }

--- a/Sources/BrewFeatureDoctor/Views/DoctorIssueDetailView.swift
+++ b/Sources/BrewFeatureDoctor/Views/DoctorIssueDetailView.swift
@@ -175,7 +175,7 @@ struct DoctorIssueDetailView: View {
     // MARK: - Raw output
 
     private var rawOutputSection: some View {
-        CommandBlockView(command: item.rawBody, title: "Raw output")
+        CommandBlockView(command: item.rawBody, title: "Raw output", collapsible: true)
     }
 }
 

--- a/Sources/BrewFeatureDoctor/Views/DoctorIssueDetailView.swift
+++ b/Sources/BrewFeatureDoctor/Views/DoctorIssueDetailView.swift
@@ -20,18 +20,20 @@ struct DoctorIssueDetailView: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 0) {
-                heroSection
-                ForEach(Array(item.blocks.enumerated()), id: \.element.id) { index, block in
-                    blockView(block)
-                        .padding(.top, topPadding(for: block, isFirst: index == 0))
+            VStack(alignment: .leading, spacing: BrewSpacing.xl) {
+                VStack(alignment: .leading, spacing: 0) {
+                    heroSection
+                    ForEach(Array(item.blocks.enumerated()), id: \.element.id) { index, block in
+                        blockView(block)
+                            .padding(.top, topPadding(for: block, isFirst: index == 0))
+                    }
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
                 if !item.rawBody.isEmpty {
+                    Divider()
                     rawOutputSection
-                        .padding(.top, BrewSpacing.lg)
                 }
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
             .padding(BrewSpacing.xl)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)

--- a/Sources/BrewFeatureDoctor/Views/DoctorIssueDetailView.swift
+++ b/Sources/BrewFeatureDoctor/Views/DoctorIssueDetailView.swift
@@ -175,21 +175,7 @@ struct DoctorIssueDetailView: View {
     // MARK: - Raw output
 
     private var rawOutputSection: some View {
-        DisclosureGroup {
-            Text(item.rawBody)
-                .font(.brewCode)
-                .foregroundStyle(Color.brewCodeDefault)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(BrewSpacing.md)
-                .background(Color.brewTerminal)
-                .clipShape(RoundedRectangle(cornerRadius: BrewRadius.md))
-                .textSelection(.enabled)
-                .padding(.top, BrewSpacing.sm)
-        } label: {
-            Text("Raw output")
-                .font(.brewSubheadline.weight(.semibold))
-                .foregroundStyle(Color.brewTextPrimary)
-        }
+        CommandBlockView(command: item.rawBody, title: "Raw output")
     }
 }
 

--- a/Sources/BrewFeatureDoctor/Views/DoctorIssueRowView.swift
+++ b/Sources/BrewFeatureDoctor/Views/DoctorIssueRowView.swift
@@ -12,7 +12,7 @@ struct DoctorIssueRowView: View {
     let item: DoctorIssueItem
 
     var body: some View {
-        HStack(alignment: .top, spacing: BrewSpacing.sm) {
+        HStack(alignment: .center, spacing: BrewSpacing.sm) {
             Image(systemName: DoctorSeverityStyle.icon(item.severity))
                 .foregroundStyle(DoctorSeverityStyle.foreground(item.severity))
                 .imageScale(.medium)
@@ -30,6 +30,7 @@ struct DoctorIssueRowView: View {
             Spacer(minLength: 0)
         }
         .padding(.vertical, BrewSpacing.xs)
+        .frame(minHeight: 48)
         .contentShape(Rectangle())
         .accessibilityElement(children: .combine)
         .accessibilityLabel(item.accessibilityLabel)

--- a/Sources/BrewFeatureDoctor/Views/DoctorSeverityStyle.swift
+++ b/Sources/BrewFeatureDoctor/Views/DoctorSeverityStyle.swift
@@ -14,7 +14,7 @@ import SwiftUI
 enum DoctorSeverityStyle {
     static func displayName(_ severity: DoctorSeverity) -> String {
         switch severity {
-        case .caution: "Caution"
+        case .caution: "Warning"
         case .danger: "Danger"
         case .unsupported: "Unsupported"
         }

--- a/Sources/BrewFeatureDoctor/Views/DoctorView.swift
+++ b/Sources/BrewFeatureDoctor/Views/DoctorView.swift
@@ -90,13 +90,6 @@ struct DoctorView: View {
 
     private func issuesList(groups: [DoctorIssueGroup]) -> some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text(
-                "These warnings help Homebrew maintainers debug. Please don't worry or file an issue.",
-            )
-            .font(.brewCallout)
-            .foregroundStyle(Color.brewTextSecondary)
-            .padding(.horizontal, BrewSpacing.lg)
-            .padding(.vertical, BrewSpacing.sm)
             List {
                 ForEach(groups) { group in
                     Section {
@@ -114,6 +107,14 @@ struct DoctorView: View {
                         }
                     } header: {
                         DoctorSeveritySectionHeader(severity: group.severity)
+                    } footer: {
+                        Text(
+                            "These warnings help Homebrew maintainers debug. Please don't worry or file an issue.",
+                        )
+                        .font(.brewCallout)
+                        .foregroundStyle(Color.brewTextSecondary)
+                        .padding(.vertical, BrewSpacing.sm)
+                        .padding(.trailing, BrewSpacing.md)
                     }
                 }
             }

--- a/Sources/BrewFeatureDoctor/Views/DoctorView.swift
+++ b/Sources/BrewFeatureDoctor/Views/DoctorView.swift
@@ -115,13 +115,9 @@ struct DoctorView: View {
                     } header: {
                         DoctorSeveritySectionHeader(severity: group.severity)
                     } footer: {
-                        Text(
-                            "These warnings help Homebrew maintainers debug. Please don't worry or file an issue.",
-                        )
-                        .font(.brewCallout)
-                        .foregroundStyle(Color.brewTextSecondary)
-                        .padding(.vertical, BrewSpacing.sm)
-                        .padding(.trailing, BrewSpacing.md)
+                        if group.id == groups.last?.id {
+                            DoctorInfoFooter()
+                        }
                     }
                 }
             }
@@ -150,6 +146,18 @@ private struct DoctorSeveritySectionHeader: View {
         Text(DoctorSeverityStyle.displayName(severity))
             .font(.brewSubheadline.weight(.semibold))
             .foregroundStyle(DoctorSeverityStyle.foreground(severity))
+    }
+}
+
+private struct DoctorInfoFooter: View {
+    var body: some View {
+        Text(
+            "These warnings help Homebrew maintainers debug. Please don't worry or file an issue.",
+        )
+        .font(.brewCallout)
+        .foregroundStyle(Color.brewTextSecondary)
+        .padding(.vertical, BrewSpacing.sm)
+        .padding(.trailing, BrewSpacing.md)
     }
 }
 

--- a/Sources/BrewFeatureDoctor/Views/DoctorView.swift
+++ b/Sources/BrewFeatureDoctor/Views/DoctorView.swift
@@ -83,39 +83,48 @@ struct DoctorView: View {
     }
 
     private func issuesList(groups: [DoctorIssueGroup]) -> some View {
-        List {
-            ForEach(groups) { group in
-                Section {
-                    ForEach(group.items) { item in
-                        DoctorIssueRowView(item: item)
-                            .id(item.id)
-                            .contentShape(Rectangle())
-                            .listRowBackground(
-                                viewModel.selectedIssueID == item.id ? Color.brewBrandTint : Color.clear,
-                            )
-                            .onTapGesture {
-                                // Needed to suppress the default ugly blue macOS highlight state
-                                viewModel.setSelection(item.id)
-                            }
+        VStack(alignment: .leading, spacing: 0) {
+            Text(
+                "These warnings help Homebrew maintainers debug. Please don't worry or file an issue.",
+            )
+            .font(.brewCallout)
+            .foregroundStyle(Color.brewTextSecondary)
+            .padding(.horizontal, BrewSpacing.lg)
+            .padding(.vertical, BrewSpacing.sm)
+            List {
+                ForEach(groups) { group in
+                    Section {
+                        ForEach(group.items) { item in
+                            DoctorIssueRowView(item: item)
+                                .id(item.id)
+                                .contentShape(Rectangle())
+                                .listRowBackground(
+                                    viewModel.selectedIssueID == item.id ? Color.brewBrandTint : Color.clear,
+                                )
+                                .onTapGesture {
+                                    // Needed to suppress the default ugly blue macOS highlight state
+                                    viewModel.setSelection(item.id)
+                                }
+                        }
+                    } header: {
+                        DoctorSeveritySectionHeader(severity: group.severity)
                     }
-                } header: {
-                    DoctorSeveritySectionHeader(severity: group.severity)
                 }
             }
-        }
-        .task(id: viewModel.shouldFocusList) {
-            isFocused = viewModel.shouldFocusList
-        }
-        .focused($isFocused)
-        .listStyle(.inset)
-        .accessibilityLabel("Doctor issues")
-        .onKeyPress(.upArrow) {
-            viewModel.selectPrevious()
-            return .handled
-        }
-        .onKeyPress(.downArrow) {
-            viewModel.selectNext()
-            return .handled
+            .task(id: viewModel.shouldFocusList) {
+                isFocused = viewModel.shouldFocusList
+            }
+            .focused($isFocused)
+            .listStyle(.inset)
+            .accessibilityLabel("Doctor issues")
+            .onKeyPress(.upArrow) {
+                viewModel.selectPrevious()
+                return .handled
+            }
+            .onKeyPress(.downArrow) {
+                viewModel.selectNext()
+                return .handled
+            }
         }
     }
 }

--- a/Sources/BrewFeatureDoctor/Views/DoctorView.swift
+++ b/Sources/BrewFeatureDoctor/Views/DoctorView.swift
@@ -39,6 +39,12 @@ struct DoctorView: View {
                         .controlSize(.small)
                         .accessibilityLabel("Re-checking")
                 }
+                if viewModel.rawDoctorOutput != nil {
+                    Button("Copy brew doctor output") {
+                        viewModel.copyDoctorOutput()
+                    }
+                    .controlSize(.small)
+                }
                 Button("Run Again") {
                     Task { await viewModel.load() }
                 }

--- a/Sources/BrewFeatureDoctor/Views/DoctorView.swift
+++ b/Sources/BrewFeatureDoctor/Views/DoctorView.swift
@@ -99,7 +99,7 @@ struct DoctorView: View {
                             }
                     }
                 } header: {
-                    DoctorSeveritySectionHeader(severity: group.severity, issueCount: group.items.count)
+                    DoctorSeveritySectionHeader(severity: group.severity)
                 }
             }
         }
@@ -122,19 +122,11 @@ struct DoctorView: View {
 
 private struct DoctorSeveritySectionHeader: View {
     let severity: DoctorSeverity
-    let issueCount: Int
 
     var body: some View {
-        HStack(spacing: BrewSpacing.xs) {
-            Text(DoctorSeverityStyle.displayName(severity))
-                .font(.brewSubheadline.weight(.semibold))
-                .foregroundStyle(DoctorSeverityStyle.foreground(severity))
-            Text("(\(issueCount))")
-                .font(.brewSubheadline)
-                .foregroundStyle(Color.brewTextSecondary)
-        }
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(DoctorSeverityStyle.displayName(severity)), \(issueCount) issues")
+        Text(DoctorSeverityStyle.displayName(severity))
+            .font(.brewSubheadline.weight(.semibold))
+            .foregroundStyle(DoctorSeverityStyle.foreground(severity))
     }
 }
 

--- a/Sources/BrewFeatureDoctor/Views/DoctorView.swift
+++ b/Sources/BrewFeatureDoctor/Views/DoctorView.swift
@@ -98,7 +98,14 @@ struct DoctorView: View {
                                 .id(item.id)
                                 .contentShape(Rectangle())
                                 .listRowBackground(
-                                    viewModel.selectedIssueID == item.id ? Color.brewBrandTint : Color.clear,
+                                    RoundedRectangle(
+                                        cornerRadius: BrewRadius.lg,
+                                        style: .continuous,
+                                    )
+                                    .fill(
+                                        viewModel.selectedIssueID == item.id ? Color.brewBrandTint : Color.clear,
+                                    )
+                                    .padding(.horizontal, BrewSpacing.sm),
                                 )
                                 .onTapGesture {
                                     // Needed to suppress the default ugly blue macOS highlight state

--- a/Sources/BrewFeatureInstalled/Views/InstalledPackagesView.swift
+++ b/Sources/BrewFeatureInstalled/Views/InstalledPackagesView.swift
@@ -97,7 +97,14 @@ struct InstalledPackagesView: View {
                 .id(package.id)
                 .contentShape(Rectangle())
                 .listRowBackground(
-                    viewModel.activeSelectedPackageID == package.id ? Color.brewBrandTint : Color.clear,
+                    RoundedRectangle(
+                        cornerRadius: BrewRadius.lg,
+                        style: .continuous,
+                    )
+                    .fill(
+                        viewModel.activeSelectedPackageID == package.id ? Color.brewBrandTint : Color.clear,
+                    )
+                    .padding(.horizontal, BrewSpacing.sm),
                 )
                 .onTapGesture {
                     // Needed to suppress the default ugly blue macOS highlight state

--- a/Sources/BrewFeatureInstalled/Views/UpgradesPackagesView.swift
+++ b/Sources/BrewFeatureInstalled/Views/UpgradesPackagesView.swift
@@ -129,7 +129,14 @@ struct UpgradesPackagesView: View {
                 .id(package.id)
                 .contentShape(Rectangle())
                 .listRowBackground(
-                    viewModel.activeSelectedPackageID == package.id ? Color.brewBrandTint : Color.clear,
+                    RoundedRectangle(
+                        cornerRadius: BrewRadius.lg,
+                        style: .continuous,
+                    )
+                    .fill(
+                        viewModel.activeSelectedPackageID == package.id ? Color.brewBrandTint : Color.clear,
+                    )
+                    .padding(.horizontal, BrewSpacing.sm),
                 )
                 .onTapGesture {
                     // Needed to suppress the default ugly blue macOS highlight state

--- a/Sources/BrewRepositories/DoctorOutputParser.swift
+++ b/Sources/BrewRepositories/DoctorOutputParser.swift
@@ -18,10 +18,13 @@ import Foundation
 public enum DoctorOutputParser {
     public static func parse(_ output: String) -> DoctorReport {
         let blocks = warningBlocks(in: output)
-        return DoctorReport(issues: blocks.compactMap { block in
-            var parser = WarningBlockParser(block: block)
-            return parser.parse()
-        })
+        return DoctorReport(
+            issues: blocks.compactMap { block in
+                var parser = WarningBlockParser(block: block)
+                return parser.parse()
+            },
+            rawOutput: output,
+        )
     }
 }
 

--- a/Sources/BrewUIComponents/Views/CommandBlockView.swift
+++ b/Sources/BrewUIComponents/Views/CommandBlockView.swift
@@ -26,6 +26,9 @@ public struct CommandBlockView: View {
         self.title = title
     }
 
+    @State private var copied = false
+    @State private var copyTask: Task<Void, Never>?
+
     public var body: some View {
         VStack(spacing: 0) {
             header
@@ -47,9 +50,17 @@ public struct CommandBlockView: View {
                 .font(.brewCaption)
                 .foregroundStyle(Color.brewTextSecondary)
             Spacer()
-            Button(copyTitle, systemImage: "doc.on.doc") {
+            Button(copied ? "Copied" : copyTitle, systemImage: copied ? "checkmark" : "doc.on.doc") {
                 NSPasteboard.general.clearContents()
                 NSPasteboard.general.setString(commands.joined(separator: "\n"), forType: .string)
+                copied = true
+                copyTask?.cancel()
+                copyTask = Task {
+                    try? await Task.sleep(for: .seconds(5))
+                    if !Task.isCancelled {
+                        copied = false
+                    }
+                }
             }
             .font(.brewCaption)
             .foregroundStyle(Color.brewTextSecondary)

--- a/Sources/BrewUIComponents/Views/CommandBlockView.swift
+++ b/Sources/BrewUIComponents/Views/CommandBlockView.swift
@@ -12,15 +12,18 @@ import SwiftUI
 public struct CommandBlockView: View {
     let commands: [String]
     let summaryText: String?
+    let title: String?
 
-    public init(command: String, summaryText: String? = nil) {
+    public init(command: String, summaryText: String? = nil, title: String? = nil) {
         commands = [command]
         self.summaryText = summaryText
+        self.title = title
     }
 
-    public init(commands: [String], summaryText: String? = nil) {
+    public init(commands: [String], summaryText: String? = nil, title: String? = nil) {
         self.commands = commands
         self.summaryText = summaryText
+        self.title = title
     }
 
     public var body: some View {
@@ -40,7 +43,7 @@ public struct CommandBlockView: View {
 
     private var header: some View {
         HStack {
-            Label(headerTitle, systemImage: "terminal")
+            Label(title ?? headerTitle, systemImage: "terminal")
                 .font(.brewCaption)
                 .foregroundStyle(Color.brewTextSecondary)
             Spacer()

--- a/Sources/BrewUIComponents/Views/CommandBlockView.swift
+++ b/Sources/BrewUIComponents/Views/CommandBlockView.swift
@@ -76,7 +76,7 @@ public struct CommandBlockView: View {
                 NSPasteboard.general.setString(commands.joined(separator: "\n"), forType: .string)
                 copied = true
                 copyTask?.cancel()
-                copyTask = Task {
+                copyTask = Task { @MainActor in
                     try? await Task.sleep(for: .seconds(5))
                     if !Task.isCancelled {
                         copied = false

--- a/Sources/BrewUIComponents/Views/CommandBlockView.swift
+++ b/Sources/BrewUIComponents/Views/CommandBlockView.swift
@@ -71,23 +71,21 @@ public struct CommandBlockView: View {
                     .foregroundStyle(Color.brewTextSecondary)
             }
             Spacer()
-            if isExpanded {
-                Button(copied ? "Copied" : copyTitle, systemImage: copied ? "checkmark" : "doc.on.doc") {
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString(commands.joined(separator: "\n"), forType: .string)
-                    copied = true
-                    copyTask?.cancel()
-                    copyTask = Task {
-                        try? await Task.sleep(for: .seconds(5))
-                        if !Task.isCancelled {
-                            copied = false
-                        }
+            Button(copied ? "Copied" : copyTitle, systemImage: copied ? "checkmark" : "doc.on.doc") {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(commands.joined(separator: "\n"), forType: .string)
+                copied = true
+                copyTask?.cancel()
+                copyTask = Task {
+                    try? await Task.sleep(for: .seconds(5))
+                    if !Task.isCancelled {
+                        copied = false
                     }
                 }
-                .font(.brewCaption)
-                .foregroundStyle(Color.brewTextSecondary)
-                .buttonStyle(.plain)
             }
+            .font(.brewCaption)
+            .foregroundStyle(Color.brewTextSecondary)
+            .buttonStyle(.plain)
         }
         .padding(.horizontal, BrewSpacing.md)
         .padding(.vertical, BrewSpacing.sm)

--- a/Sources/BrewUIComponents/Views/CommandBlockView.swift
+++ b/Sources/BrewUIComponents/Views/CommandBlockView.swift
@@ -13,28 +13,36 @@ public struct CommandBlockView: View {
     let commands: [String]
     let summaryText: String?
     let title: String?
+    let collapsible: Bool
 
-    public init(command: String, summaryText: String? = nil, title: String? = nil) {
+    public init(command: String, summaryText: String? = nil, title: String? = nil, collapsible: Bool = false) {
         commands = [command]
         self.summaryText = summaryText
         self.title = title
+        self.collapsible = collapsible
+        _isExpanded = State(initialValue: !collapsible)
     }
 
-    public init(commands: [String], summaryText: String? = nil, title: String? = nil) {
+    public init(commands: [String], summaryText: String? = nil, title: String? = nil, collapsible: Bool = false) {
         self.commands = commands
         self.summaryText = summaryText
         self.title = title
+        self.collapsible = collapsible
+        _isExpanded = State(initialValue: !collapsible)
     }
 
     @State private var copied = false
     @State private var copyTask: Task<Void, Never>?
+    @State private var isExpanded: Bool
 
     public var body: some View {
         VStack(spacing: 0) {
             header
-            commandsBlock
-            if let summaryText {
-                footer(summaryText)
+            if isExpanded {
+                commandsBlock
+                if let summaryText {
+                    footer(summaryText)
+                }
             }
         }
         .clipShape(RoundedRectangle(cornerRadius: BrewRadius.md))
@@ -46,25 +54,40 @@ public struct CommandBlockView: View {
 
     private var header: some View {
         HStack {
-            Label(title ?? headerTitle, systemImage: "terminal")
-                .font(.brewCaption)
-                .foregroundStyle(Color.brewTextSecondary)
+            if collapsible {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        isExpanded.toggle()
+                    }
+                } label: {
+                    Label(title ?? headerTitle, systemImage: isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.brewCaption)
+                        .foregroundStyle(Color.brewTextSecondary)
+                }
+                .buttonStyle(.plain)
+            } else {
+                Label(title ?? headerTitle, systemImage: "terminal")
+                    .font(.brewCaption)
+                    .foregroundStyle(Color.brewTextSecondary)
+            }
             Spacer()
-            Button(copied ? "Copied" : copyTitle, systemImage: copied ? "checkmark" : "doc.on.doc") {
-                NSPasteboard.general.clearContents()
-                NSPasteboard.general.setString(commands.joined(separator: "\n"), forType: .string)
-                copied = true
-                copyTask?.cancel()
-                copyTask = Task {
-                    try? await Task.sleep(for: .seconds(5))
-                    if !Task.isCancelled {
-                        copied = false
+            if isExpanded {
+                Button(copied ? "Copied" : copyTitle, systemImage: copied ? "checkmark" : "doc.on.doc") {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(commands.joined(separator: "\n"), forType: .string)
+                    copied = true
+                    copyTask?.cancel()
+                    copyTask = Task {
+                        try? await Task.sleep(for: .seconds(5))
+                        if !Task.isCancelled {
+                            copied = false
+                        }
                     }
                 }
+                .font(.brewCaption)
+                .foregroundStyle(Color.brewTextSecondary)
+                .buttonStyle(.plain)
             }
-            .font(.brewCaption)
-            .foregroundStyle(Color.brewTextSecondary)
-            .buttonStyle(.plain)
         }
         .padding(.horizontal, BrewSpacing.md)
         .padding(.vertical, BrewSpacing.sm)

--- a/Tests/BrewFeatureDoctorTests/DoctorSeverityStyleTests.swift
+++ b/Tests/BrewFeatureDoctorTests/DoctorSeverityStyleTests.swift
@@ -12,7 +12,7 @@ import Testing
 @MainActor
 struct DoctorSeverityStyleTests {
     @Test func `displayName names each severity`() {
-        #expect(DoctorSeverityStyle.displayName(.caution) == "Caution")
+        #expect(DoctorSeverityStyle.displayName(.caution) == "Warning")
         #expect(DoctorSeverityStyle.displayName(.danger) == "Danger")
         #expect(DoctorSeverityStyle.displayName(.unsupported) == "Unsupported")
     }

--- a/Tests/BrewFeatureDoctorTests/DoctorViewModelTests.swift
+++ b/Tests/BrewFeatureDoctorTests/DoctorViewModelTests.swift
@@ -93,7 +93,6 @@ struct DoctorViewModelTests {
         #expect(viewModel.issueItems.first?.hasRunnableFix == true)
         #expect(viewModel.issueItems.last?.hasRunnableFix == false)
         #expect(viewModel.selectedIssueID == viewModel.issueItems.first?.id)
-        #expect(viewModel.issueCountSubtitle == "2 issues found")
     }
 
     @Test func `projects healthy report`() {
@@ -133,12 +132,6 @@ struct DoctorViewModelTests {
         #expect(entries.count == 1)
         #expect(entries.first?.kind == .doctorFix)
         #expect(entries.first?.id == .maintenance(token: "brew cleanup", displayCommand: "brew cleanup"))
-    }
-
-    @Test func `issueCountSubtitle uses the singular form for a single issue`() {
-        let report = DoctorReport(issues: [Self.minimal(.caution, "only one")])
-        let viewModel = Self.viewModel(repository: StubDoctorRepository(report: report))
-        #expect(viewModel.issueCountSubtitle == "1 issue found")
     }
 
     @Test func `isFixRunning is false for an item without a runnable fix`() {
@@ -410,11 +403,11 @@ struct DoctorViewModelTests {
         #expect(viewModel.subtitle == "Re-checking…")
     }
 
-    @Test func `subtitle on issues falls back to the issue count when not refreshing`() {
+    @Test func `subtitle on issues shows "Warnings found" when not refreshing`() {
         let repository = MutableDoctorRepository(report: Self.issuesReport())
         let viewModel = Self.viewModel(repository: repository)
 
-        #expect(viewModel.subtitle == "2 issues found")
+        #expect(viewModel.subtitle == "Warnings found")
 
         repository.setRefreshing(true)
         #expect(viewModel.subtitle == "Re-checking…")

--- a/Tests/BrewRepositoriesTests/DoctorOutputParserTests.swift
+++ b/Tests/BrewRepositoriesTests/DoctorOutputParserTests.swift
@@ -369,6 +369,39 @@ struct DoctorOutputParserTests {
         #expect(roles["docs.brew.sh"] == .reference)
     }
 
+    // MARK: - Raw output
+
+    @Test func `raw output is preserved verbatim for healthy output`() {
+        let input = "Your system is ready to brew.\n"
+        let report = DoctorOutputParser.parse(input)
+        #expect(report.rawOutput == input)
+    }
+
+    @Test func `raw output is preserved verbatim when warnings are present`() {
+        let input = """
+        Warning: Something is off.
+        Here is why it matters.
+          brew upgrade git
+        """
+        let report = DoctorOutputParser.parse(input)
+        #expect(report.rawOutput == input)
+    }
+
+    @Test func `raw output includes preamble and all warning blocks`() {
+        let input = """
+        Please note that these warnings are just used to help the Homebrew maintainers
+        with debugging if you file an issue. Thanks!
+
+        Warning: First problem.
+        Detail one.
+
+        Warning: Second problem.
+        Detail two.
+        """
+        let report = DoctorOutputParser.parse(input)
+        #expect(report.rawOutput == input)
+    }
+
     // MARK: - Raw body fallback
 
     @Test func `raw body preserves the verbatim block beneath the title`() throws {


### PR DESCRIPTION
# PR: Doctor view polish and list row consistency

## Summary

A series of UX fixes and polish improvements to the Doctor feature: better copy affordances, cleaner layout, and consistent list row styling across all package list views.

## Changes

**Doctor feature**
- Renamed severity label "Caution" → "Warning" to match Homebrew's own terminology.
- Removed issue count from the header subtitle and section headers — they added noise without value; the subtitle now reads "Warnings found".
- Added a "Copy brew doctor output" button to the header toolbar, copying the full raw `brew doctor` output to the clipboard. `DoctorReport` now stores `rawOutput` (passed through from the parser).
- Moved the Homebrew disclaimer ("These warnings help maintainers debug…") into the section footer, replacing a standalone view above the list.
- Replaced the bespoke `DisclosureGroup` raw output section in `DoctorIssueDetailView` with `CommandBlockView(collapsible: true)` for consistency.
- Fixed issue detail spacing: content sections are separated by `BrewSpacing.xl`, with a `Divider` before the raw output block.
- Issue row height set to `minHeight: 48` with centred icon alignment for a more consistent tap target.

**`CommandBlockView` (shared component)**
- Added `collapsible` and `title` parameters; defaults preserve existing behaviour.
- Copy button shows "Copied" + checkmark for 5 seconds after tapping, then resets — visible whether the block is expanded or collapsed.

**List row background consistency**
- `DoctorView`, `DiscoverPackagesView`, `InstalledPackagesView`, and `UpgradesPackagesView` all now use the same rounded-rectangle selection background (`BrewRadius.lg`, `.padding(.horizontal, BrewSpacing.sm)`).

## Testing

- [ ] Build and run; navigate to Doctor tab with issues present.
- [ ] Verify "Copy brew doctor output" copies the full raw output.
- [ ] Verify "Copied" feedback appears for ~5 s then resets.
- [ ] Collapse/expand raw output block in issue detail; confirm copy button stays visible when collapsed.
- [ ] Check section headers show severity name only (no count), footer shows disclaimer.
- [ ] Confirm list row selection highlight is rounded and consistent across Installed, Discover, Upgrades, and Doctor tabs.
- [ ] `swift test --filter DoctorSeverityStyleTests` — "Caution" rename covered.

## PR checklist

- [x] Have you followed this repository's contribution and workflow guidance?
- [x] Have you explained what changed and why this should land now?
- [x] Have you run relevant local checks for the changed scope?
- [x] Are changes scoped and free of unrelated modifications?

-----

- [x] AI was used to generate or assist with generating this PR.
- [x] If yes, describe exactly how AI was used and what manual verification was performed.
  - Claude Code wrote the PR description from the branch diff. All code changes were authored and manually reviewed by the developer; visual results were verified in the running app.