### PR TITLE
UX improvements

### DIFF
--- a/Homebrew/BrewApp.swift
+++ b/Homebrew/BrewApp.swift
@@ -59,6 +59,7 @@ struct BrewApp: App {
         )
         doctorRepository = BrewDoctorRepository(commandCenter: center)
         configRepository = BrewConfigRepository.live()
+        NSWindow.allowsAutomaticWindowTabbing = false
     }
 
     var body: some Scene {
@@ -95,9 +96,9 @@ struct BrewApp: App {
             height: BrewLayout.minWindowHeight,
         )
         .commands {
-            ConsoleCommands()
-            SidebarCommands()
             SearchCommands()
+            SidebarCommands()
+            ConsoleCommands()
         }
         #if DEBUG
         .commands {

--- a/Homebrew/BrewApp.swift
+++ b/Homebrew/BrewApp.swift
@@ -102,7 +102,7 @@ struct BrewApp: App {
             SearchCommands()
             SidebarCommands()
             ConsoleCommands()
-          
+
             // Replace the default "Homebrew Help" item (which points at a
             // non-existent help book) with a link to the online documentation.
             CommandGroup(replacing: .help) {

--- a/Homebrew/BrewApp.swift
+++ b/Homebrew/BrewApp.swift
@@ -23,6 +23,7 @@ struct BrewApp: App {
     private let commandFactory: LiveBrewMutatingCommandFactory
     private let installedInventoryCache: InstalledInventoryCache
     private let catalogueCache: CatalogueCache
+    private let discoverAnalyticsCache: DiscoverAnalyticsCache
     private let installedPackagesRepository: BrewInstalledPackagesRepository
     private let commandJobsRepository: BrewCommandJobsRepository
     private let installedDependentsRepository: BrewInstalledDependentsRepository
@@ -34,12 +35,14 @@ struct BrewApp: App {
     init() {
         let inventoryCache = InstalledInventoryCache()
         let catalogue = CatalogueCache()
+        let discoverAnalytics = DiscoverAnalyticsCache()
         let center = SerialBrewCommandCenter(executionContext: .live())
         let apiClient = URLSessionBrewAPIClient.live()
         let catalogueRepo = BrewCatalogueRepository(apiClient: apiClient, cache: catalogue)
 
         installedInventoryCache = inventoryCache
         catalogueCache = catalogue
+        discoverAnalyticsCache = discoverAnalytics
         commandCenter = center
         commandFactory = LiveBrewMutatingCommandFactory()
         installedPackagesRepository = BrewInstalledPackagesRepository.live(
@@ -52,6 +55,7 @@ struct BrewApp: App {
         discoverPackagesRepository = BrewDiscoverPackagesRepository(
             apiClient: apiClient,
             catalogueRepository: catalogueRepo,
+            cache: discoverAnalytics,
         )
         doctorRepository = BrewDoctorRepository(commandCenter: center)
         configRepository = BrewConfigRepository.live()
@@ -70,6 +74,7 @@ struct BrewApp: App {
                 .environment(\.doctorRepository, doctorRepository)
                 .environment(\.configRepository, configRepository)
                 .task { await catalogueCache.prepare() }
+                .task { await discoverAnalyticsCache.prepare() }
                 .task { await installedPackagesRepository.load() }
                 .onChange(of: scenePhase) { oldPhase, newPhase in
                     // Mark the config + brew.env caches stale on return-to-foreground so the next visit

--- a/Sources/BrewAppEnvironment/UnimplementedRepositories.swift
+++ b/Sources/BrewAppEnvironment/UnimplementedRepositories.swift
@@ -103,7 +103,7 @@ struct UnimplementedMutatingCommandFactory: BrewMutatingCommandFactory {
         unimplemented()
     }
 
-    func bulkUpgradeCommand() -> any BrewMutatingCommand {
+    func bulkUpgradeCommand(selection _: BrewUpgradeSelection) -> any BrewMutatingCommand {
         unimplemented()
     }
 

--- a/Sources/BrewCLI/BulkUpgradeCommand.swift
+++ b/Sources/BrewCLI/BulkUpgradeCommand.swift
@@ -6,13 +6,16 @@
 import BrewCore
 import Foundation
 
-/// Schedules a single `brew upgrade` (no arguments) via ``BrewCommandCenter/submit``. Homebrew upgrades
-/// every outdated formula and cask in one subprocess, matching what a user would type in Terminal and
-/// the user-facing command rendered by the Upgrades tab's command block.
+/// Schedules a batch `brew upgrade` via ``BrewCommandCenter/submit`` for a ``BrewUpgradeSelection`` —
+/// everything outdated, a single kind (`--formula`/`--cask`), or an explicit list of names. Homebrew runs
+/// it in one subprocess, matching what a user would type in Terminal and the command rendered by the
+/// Upgrades tab's command block.
 ///
-/// Keep this argument list in sync with ``BrewOperationID/bulkUpgradeDisplayCommand`` — the latter is the
-/// human-readable rendering and must describe what this command actually runs.
+/// Both the argument list and the human-readable rendering come from the same ``BrewUpgradeSelection``, so
+/// what runs and what's shown can't drift.
 struct BulkUpgradeCommand: BrewMutatingCommand {
+    let selection: BrewUpgradeSelection
+
     var operationKind: BrewOperationKind {
         .upgradeAll
     }
@@ -21,7 +24,7 @@ struct BulkUpgradeCommand: BrewMutatingCommand {
         let brew = try context.brewExecutableURL()
         let output = try await context.commandRunner.run(
             executableURL: brew,
-            arguments: ["upgrade"],
+            arguments: selection.arguments,
         )
         guard output.terminationStatus == 0 else {
             throw BrewCommandError.failed(

--- a/Sources/BrewCLI/LiveBrewMutatingCommandFactory.swift
+++ b/Sources/BrewCLI/LiveBrewMutatingCommandFactory.swift
@@ -22,8 +22,8 @@ public struct LiveBrewMutatingCommandFactory: BrewMutatingCommandFactory {
         PackageUninstallCommand(kind: kind, name: name)
     }
 
-    public func bulkUpgradeCommand() -> any BrewMutatingCommand {
-        BulkUpgradeCommand()
+    public func bulkUpgradeCommand(selection: BrewUpgradeSelection) -> any BrewMutatingCommand {
+        BulkUpgradeCommand(selection: selection)
     }
 
     public func doctorFixCommand(arguments: [String]) -> any BrewMutatingCommand {

--- a/Sources/BrewCore/Operations/BrewMutatingCommandFactory.swift
+++ b/Sources/BrewCore/Operations/BrewMutatingCommandFactory.swift
@@ -14,9 +14,10 @@ public protocol BrewMutatingCommandFactory: Sendable {
     func upgradeCommand(kind: HomebrewPackageKind, name: String) -> any BrewMutatingCommand
     func uninstallCommand(kind: HomebrewPackageKind, name: String) -> any BrewMutatingCommand
 
-    /// Builds the bulk `brew upgrade` command — invoked with no arguments so Homebrew upgrades every
-    /// outdated formula and cask in a single subprocess. Submitted under ``BrewOperationID/bulkUpgrade``.
-    func bulkUpgradeCommand() -> any BrewMutatingCommand
+    /// Builds a batch `brew upgrade` command for the given ``BrewUpgradeSelection`` — either everything
+    /// outdated, a single kind (`--formula`/`--cask`), or an explicit list of names. Submitted under
+    /// ``BrewOperationID/bulkUpgrade(_:)`` carrying the same selection.
+    func bulkUpgradeCommand(selection: BrewUpgradeSelection) -> any BrewMutatingCommand
 
     /// Builds a maintenance command running the given `brew` argument vector (e.g. a `brew doctor` fix
     /// like `["link", "openssl@3"]` or `["cleanup"]`). Not package-scoped — surfaces in the console as

--- a/Sources/BrewCore/Operations/BrewOperationModels.swift
+++ b/Sources/BrewCore/Operations/BrewOperationModels.swift
@@ -28,12 +28,14 @@ public enum BrewOperationKind: String, Hashable, Sendable {
 /// the canonical ``HomebrewPackageID`` *is* the operation key. Maintenance work (e.g. a `brew doctor` fix such as
 /// `brew link a b` or `brew cleanup`) isn't tied to a single package, so it carries its own `token` for identity
 /// plus the user-facing `displayCommand` the console renders (it cannot be reconstructed from a package name).
-/// ``bulkUpgrade`` is a singleton id for `brew upgrade` (no arguments) — the Upgrades tab submits one bulk
-/// operation instead of N per-package upgrades, so a fixed case is enough.
+/// ``bulkUpgrade`` carries the ``BrewUpgradeSelection`` the Upgrades tab submitted — one batch operation
+/// instead of N per-package upgrades. The selection is part of the identity so the console renders the exact
+/// command (`brew upgrade`, `brew upgrade --formula`, `brew upgrade git slack`, …) and distinct selections
+/// don't dedupe against one another.
 public enum BrewOperationID: Hashable, Identifiable, Sendable {
     case package(HomebrewPackageID)
     case maintenance(token: String, displayCommand: String)
-    case bulkUpgrade
+    case bulkUpgrade(BrewUpgradeSelection)
 
     public var id: Self {
         self
@@ -51,10 +53,10 @@ public enum BrewOperationID: Hashable, Identifiable, Sendable {
         self = .package(packageID)
     }
 
-    /// Canonical user-facing rendering of ``bulkUpgrade`` — the literal a person would type. Shared
-    /// across the Upgrades tab's `CommandBlockView`, the console job, and the live `BulkUpgradeCommand`
-    /// so a future rename (e.g. `brew upgrade --greedy`) only needs to land here.
-    public static let bulkUpgradeDisplayCommand = "brew upgrade"
+    /// Canonical user-facing rendering of an unfiltered "Upgrade All" — the literal a person would type.
+    /// Derived from ``BrewUpgradeSelection/all`` so the plain-`brew upgrade` rendering has one home; scoped
+    /// and search-narrowed submissions render their own ``BrewUpgradeSelection/displayCommand``.
+    public static let bulkUpgradeDisplayCommand = BrewUpgradeSelection.all.displayCommand
 }
 
 /// Visibility for UI and tests — mutually exclusive with “absent” represented by ``BrewCommandCenter/phase(for:)``

--- a/Sources/BrewCore/Operations/BrewUpgradeSelection.swift
+++ b/Sources/BrewCore/Operations/BrewUpgradeSelection.swift
@@ -1,0 +1,44 @@
+//
+//  BrewUpgradeSelection.swift
+//  BrewCore
+//
+
+import Foundation
+
+/// What a single "Upgrade All" submission actually upgrades. The Upgrades tab derives this from its
+/// active scope picker and search field so the batch operation matches the visible list:
+///
+/// - ``all`` — `brew upgrade` (every outdated formula and cask).
+/// - ``formulae`` — `brew upgrade --formula` (every outdated formula).
+/// - ``casks`` — `brew upgrade --cask` (every outdated cask).
+/// - ``explicit(_:)`` — `brew upgrade <name>…` for a specific set of packages (used when a search
+///   narrows the list to named rows).
+///
+/// It is the single source of truth for both the argument vector the subprocess runs (``arguments``)
+/// and the user-facing command string rendered in the header and console (``displayCommand``), so the
+/// two can never drift.
+public enum BrewUpgradeSelection: Hashable, Sendable {
+    case all
+    case formulae
+    case casks
+    case explicit([String])
+
+    /// Argument vector passed to the `brew` executable.
+    public var arguments: [String] {
+        switch self {
+        case .all:
+            ["upgrade"]
+        case .formulae:
+            ["upgrade", "--formula"]
+        case .casks:
+            ["upgrade", "--cask"]
+        case let .explicit(names):
+            ["upgrade"] + names
+        }
+    }
+
+    /// The literal a person would type — `"brew "` joined with ``arguments``.
+    public var displayCommand: String {
+        "brew " + arguments.joined(separator: " ")
+    }
+}

--- a/Sources/BrewFeatureConsole/ViewModels/ConsoleViewModel.swift
+++ b/Sources/BrewFeatureConsole/ViewModels/ConsoleViewModel.swift
@@ -40,11 +40,17 @@ final class ConsoleViewModel {
         return nil
     }
 
+    /// Mirrors the app-wide "Expand Console Panel Automatically" preference (bound from
+    /// `@AppStorage` in the view). Owned here so ``shouldAutoExpandConsole`` stays a pure,
+    /// unit-testable decision. Defaults on.
+    var autoExpandEnabled: Bool = true
+
     /// Drives the console panel's auto-expand. True while a command is running (`activeJob` is
-    /// non-terminal). The view watches the rising edge of this and expands the collapsed panel so the
-    /// user sees output stream in without opening it manually; it never force-collapses.
+    /// non-terminal) and the preference is enabled. The view watches the rising edge of this and
+    /// expands the collapsed panel so the user sees output stream in without opening it manually; it
+    /// never force-collapses.
     var shouldAutoExpandConsole: Bool {
-        activeJob != nil
+        autoExpandEnabled && activeJob != nil
     }
 
     /// Currently focused job for the expanded console body — explicit selection, else active, else most recent.

--- a/Sources/BrewFeatureConsole/ViewModels/ConsoleViewModel.swift
+++ b/Sources/BrewFeatureConsole/ViewModels/ConsoleViewModel.swift
@@ -40,6 +40,13 @@ final class ConsoleViewModel {
         return nil
     }
 
+    /// Drives the console panel's auto-expand. True while a command is running (`activeJob` is
+    /// non-terminal). The view watches the rising edge of this and expands the collapsed panel so the
+    /// user sees output stream in without opening it manually; it never force-collapses.
+    var shouldAutoExpandConsole: Bool {
+        activeJob != nil
+    }
+
     /// Currently focused job for the expanded console body — explicit selection, else active, else most recent.
     var selectedJob: CommandJob? {
         if let id = selectedID, let job = repository.jobs[id] {

--- a/Sources/BrewFeatureConsole/Views/ConsoleCommands.swift
+++ b/Sources/BrewFeatureConsole/Views/ConsoleCommands.swift
@@ -11,6 +11,8 @@ import SwiftUI
 /// View menu commands for the command console. Currently a single `⌘\`` toggle matching Xcode / VS Code / Terminal.
 public struct ConsoleCommands: Commands {
     @FocusedBinding(\.consoleExpanded) private var expanded: Bool?
+    /// App-wide preference (not per-window), so it lives here directly rather than as a focused value.
+    @AppStorage("autoExpandConsole") private var autoExpandConsole = true
 
     public init() {}
 
@@ -21,6 +23,8 @@ public struct ConsoleCommands: Commands {
             }
             .keyboardShortcut("`", modifiers: .command)
             .disabled(expanded == nil)
+
+            Toggle("Expand Console Panel Automatically", isOn: $autoExpandConsole)
         }
     }
 }

--- a/Sources/BrewFeatureConsole/Views/ConsolePanel.swift
+++ b/Sources/BrewFeatureConsole/Views/ConsolePanel.swift
@@ -31,5 +31,10 @@ struct ConsolePanel: View {
             }
         }
         .background(Color.brewSurface)
+        .onChange(of: viewModel.shouldAutoExpandConsole) { _, shouldExpand in
+            // Rising edge only: open the collapsed panel when a command starts. We never force-collapse,
+            // so a user who manually collapses mid-run isn't fought — the next command re-raises it.
+            if shouldExpand { expanded = true }
+        }
     }
 }

--- a/Sources/BrewFeatureConsole/Views/ConsolePanel.swift
+++ b/Sources/BrewFeatureConsole/Views/ConsolePanel.swift
@@ -14,6 +14,7 @@ import SwiftUI
 struct ConsolePanel: View {
     @Binding var expanded: Bool
     @State var viewModel: ConsoleViewModel
+    @AppStorage("autoExpandConsole") private var autoExpandConsole = true
 
     init(expanded: Binding<Bool>, commandJobsRepository: any CommandJobsObserving) {
         _expanded = expanded
@@ -31,6 +32,8 @@ struct ConsolePanel: View {
             }
         }
         .background(Color.brewSurface)
+        .onAppear { viewModel.autoExpandEnabled = autoExpandConsole }
+        .onChange(of: autoExpandConsole) { _, enabled in viewModel.autoExpandEnabled = enabled }
         .onChange(of: viewModel.shouldAutoExpandConsole) { _, shouldExpand in
             // Rising edge only: open the collapsed panel when a command starts. We never force-collapse,
             // so a user who manually collapses mid-run isn't fought — the next command re-raises it.

--- a/Sources/BrewFeatureDiscover/Views/DiscoverPackagesView.swift
+++ b/Sources/BrewFeatureDiscover/Views/DiscoverPackagesView.swift
@@ -27,7 +27,7 @@ struct DiscoverPackagesView: View {
             text: $viewModel.query,
             isPresented: $searchPresented,
             placement: .toolbar,
-            prompt: "Search Homebrew's Catalogue",
+            prompt: "Search Homebrew's Packages",
         )
         .focusedSceneValue(\.searchPresented, $searchPresented)
         .task(id: viewModel.query) {

--- a/Sources/BrewFeatureInstalled/ViewModels/InstalledPackageScope.swift
+++ b/Sources/BrewFeatureInstalled/ViewModels/InstalledPackageScope.swift
@@ -1,0 +1,17 @@
+//
+//  InstalledPackageScope.swift
+//  BrewFeatureInstalled
+//
+
+import Foundation
+
+/// Package-kind filter for the Installed and Upgrades list scope pickers. Mirrors the Discover tab's
+/// `DiscoverSearchScope`: it filters the already-loaded inventory client-side and never refetches.
+///
+/// Both `InstalledViewModel` and `UpgradesViewModel` project through this scope on top of the active
+/// search query, so the two lists share one filtering vocabulary.
+enum InstalledPackageScope: CaseIterable, Equatable {
+    case all
+    case formulae
+    case casks
+}

--- a/Sources/BrewFeatureInstalled/ViewModels/InstalledViewModel.swift
+++ b/Sources/BrewFeatureInstalled/ViewModels/InstalledViewModel.swift
@@ -110,10 +110,16 @@ final class InstalledViewModel {
         return false
     }
 
-    /// Drives the list view's `@FocusState`. The list only owns keyboard focus once the inventory has
-    /// loaded — while loading or in an error state focus belongs elsewhere (or to nothing).
+    /// Mirrors the search field's presentation state (bound to `.searchable(isPresented:)`). Owned
+    /// here — rather than as view `@State` — so ``shouldFocusList`` can factor it in and stay a pure,
+    /// unit-testable decision.
+    var isSearchFieldPresented: Bool = false
+
+    /// Drives the list view's `@FocusState`. The list claims keyboard focus once the inventory has
+    /// loaded, but never while the search field is active — auto-focusing the list must not kick the
+    /// cursor out of an in-progress search.
     var shouldFocusList: Bool {
-        state.isLoaded
+        state.isLoaded && !isSearchFieldPresented
     }
 
     var packageCountSubtitle: String {

--- a/Sources/BrewFeatureInstalled/ViewModels/InstalledViewModel.swift
+++ b/Sources/BrewFeatureInstalled/ViewModels/InstalledViewModel.swift
@@ -31,6 +31,19 @@ struct InstalledPackagesContent: Equatable {
     var orderedPackageIDs: [InstalledBrewPackage.ID] {
         formulaPackages.map(\.id) + caskPackages.map(\.id)
     }
+
+    /// Narrows the content to a single package kind for the scope picker. `.all` is the identity —
+    /// returning `self` keeps the original ordering intact.
+    func filtered(by scope: InstalledPackageScope) -> InstalledPackagesContent {
+        switch scope {
+        case .all:
+            self
+        case .formulae:
+            InstalledPackagesContent(packages: formulaPackages)
+        case .casks:
+            InstalledPackagesContent(packages: caskPackages)
+        }
+    }
 }
 
 @Observable
@@ -47,10 +60,21 @@ final class InstalledViewModel {
         }
     }
 
+    /// Package-kind scope picker. Filters the loaded inventory client-side alongside the search query.
+    var scope: InstalledPackageScope = .all {
+        didSet {
+            guard oldValue != scope else {
+                return
+            }
+            updateSelectionForScopeChange()
+        }
+    }
+
     private var selectedPackageID: InstalledBrewPackage.ID?
 
-    /// Projects the shared repository's inventory through the active search query. The repository is the
-    /// single source of truth; this view model owns only screen-local search and selection state.
+    /// Projects the shared repository's inventory through the active scope and search query. The
+    /// repository is the single source of truth; this view model owns only screen-local filter and
+    /// selection state.
     var state: LoadState<InstalledPackagesContent, String> {
         switch repository.state {
         case .loading:
@@ -58,7 +82,11 @@ final class InstalledViewModel {
         case let .failed(error):
             .failed(Self.userMessage(for: error))
         case let .loaded(packages):
-            .loaded(Self.filteredContent(InstalledPackagesContent(packages: packages), query: searchQuery))
+            .loaded(Self.filteredContent(
+                InstalledPackagesContent(packages: packages),
+                scope: scope,
+                query: searchQuery,
+            ))
         }
     }
 
@@ -209,23 +237,35 @@ final class InstalledViewModel {
         }
     }
 
+    /// Re-homes the search preview when a scope change hides the previewed row. Committed selections
+    /// are left untouched: `activeSelectedPackageID` already falls back to the first visible row while a
+    /// selection is scoped out, and restores it if the user widens the scope again.
+    private func updateSelectionForScopeChange() {
+        guard isSearchActive, !didCommitSelectionDuringSearch else {
+            return
+        }
+        searchPreviewSelectedPackageID = firstVisibleRowID()
+    }
+
     private func firstVisibleRowID() -> InstalledBrewPackage.ID? {
         allRows.first?.id
     }
 
     private static func filteredContent(
         _ content: InstalledPackagesContent,
+        scope: InstalledPackageScope,
         query: String,
     ) -> InstalledPackagesContent {
+        let scoped = content.filtered(by: scope)
         let normalizedQuery = normalizedSearchQuery(query)
         guard !normalizedQuery.isEmpty else {
-            return content
+            return scoped
         }
 
-        let filteredFormulaRows = content.formulaPackages.filter {
+        let filteredFormulaRows = scoped.formulaPackages.filter {
             $0.name.localizedCaseInsensitiveContains(normalizedQuery)
         }
-        let filteredCaskRows = content.caskPackages.filter {
+        let filteredCaskRows = scoped.caskPackages.filter {
             $0.name.localizedCaseInsensitiveContains(normalizedQuery)
         }
         return InstalledPackagesContent(

--- a/Sources/BrewFeatureInstalled/ViewModels/UpgradesViewModel.swift
+++ b/Sources/BrewFeatureInstalled/ViewModels/UpgradesViewModel.swift
@@ -90,10 +90,17 @@ final class UpgradesViewModel {
         return false
     }
 
-    /// Drives the list view's `@FocusState`. The list only owns keyboard focus once the outdated
-    /// inventory has loaded — while loading or in an error state focus belongs elsewhere.
+    /// Mirrors the search field's presentation state (bound to `.searchable(isPresented:)`). Owned
+    /// here — rather than as view `@State` — so ``shouldFocusList`` can factor it in and stay a pure,
+    /// unit-testable decision.
+    var isSearchFieldPresented: Bool = false
+
+    /// Drives the list view's `@FocusState`. The list claims keyboard focus once the outdated
+    /// inventory has loaded, but never while the search field is active: a query that filters down to
+    /// zero matches removes the list, and deleting the query re-inserts it — grabbing focus then would
+    /// yank the cursor out of the search box mid-edit.
     var shouldFocusList: Bool {
-        state.isLoaded
+        state.isLoaded && !isSearchFieldPresented
     }
 
     /// Subtitle for the in-page Upgrades header. Reflects the unfiltered

--- a/Sources/BrewFeatureInstalled/ViewModels/UpgradesViewModel.swift
+++ b/Sources/BrewFeatureInstalled/ViewModels/UpgradesViewModel.swift
@@ -25,6 +25,17 @@ final class UpgradesViewModel {
         }
     }
 
+    /// Package-kind scope picker. Filters the outdated inventory client-side alongside the search query
+    /// and, together with the search, decides what "Upgrade All" actually upgrades (see ``upgradeSelection``).
+    var scope: InstalledPackageScope = .all {
+        didSet {
+            guard oldValue != scope else {
+                return
+            }
+            updateSelectionForScopeChange()
+        }
+    }
+
     private var selectedPackageID: InstalledBrewPackage.ID?
 
     private var runningIDs: Set<BrewOperationID> = []
@@ -39,6 +50,7 @@ final class UpgradesViewModel {
             .loaded(
                 Self.filteredContent(
                     InstalledPackagesContent(packages: packages.filter(\.outdated)),
+                    scope: scope,
                     query: searchQuery,
                 ),
             )
@@ -92,8 +104,8 @@ final class UpgradesViewModel {
         if shouldShowInitialLoadingIndicator {
             return String(localized: "Loading packages…", comment: "Upgrades tab subtitle while fetching")
         }
-        if isSearchActive {
-            return searchActiveSubtitle
+        if isFiltering {
+            return filteredSubtitle
         }
         return inventorySubtitle
     }
@@ -118,24 +130,26 @@ final class UpgradesViewModel {
         }
     }
 
-    private var searchActiveSubtitle: String {
+    /// Subtitle while a scope and/or search filter is narrowing the list: "Showing N of M upgrades", or
+    /// "No matches in M outdated packages" when the filters hide every available upgrade.
+    private var filteredSubtitle: String {
         let total = totalOutdatedCount
         let visible = outdatedCount
         if visible > 0 {
             return String(
                 localized: "Showing \(visible) of \(total) upgrades",
-                comment: "Upgrades tab subtitle while searching with at least one match",
+                comment: "Upgrades tab subtitle while filtering with at least one match",
             )
         }
         if total == 1 {
             return String(
                 localized: "No matches in 1 outdated package",
-                comment: "Upgrades tab subtitle when search hides the single available upgrade",
+                comment: "Upgrades tab subtitle when filters hide the single available upgrade",
             )
         }
         return String(
             localized: "No matches in \(total) outdated packages",
-            comment: "Upgrades tab subtitle when search hides every available upgrade",
+            comment: "Upgrades tab subtitle when filters hide every available upgrade",
         )
     }
 
@@ -175,25 +189,13 @@ final class UpgradesViewModel {
         await repository.load(forceRefresh: true)
     }
 
-    /// User-facing command rendered by the Updates header's `CommandBlockView`. Reads the canonical
-    /// literal from ``BrewOperationID/bulkUpgradeDisplayCommand`` so the view, the console job, and
-    /// the live `BulkUpgradeCommand` all share one source of truth.
-    var bulkUpgradeDisplayCommand: String {
-        BrewOperationID.bulkUpgradeDisplayCommand
-    }
-
-    /// Submits a single `brew upgrade` (no arguments) under ``BrewOperationID/bulkUpgrade``. Submit
-    /// dedupes against the in-flight id, so a re-tap while the bulk run is in progress is a no-op.
-    /// The repository's completion observer reconciles inventory on running→idle, so finished rows
-    /// drop from the list when the bulk run finishes.
-    func upgradeAll() {
-        let id = BrewOperationID.bulkUpgrade
-        let command = commandFactory.bulkUpgradeCommand()
-        Task { try? await brewCommandCenter.submit(id: id, command: command) }
-    }
-
     private var isSearchActive: Bool {
         !Self.normalizedSearchQuery(searchQuery).isEmpty
+    }
+
+    /// True when either the scope picker or the search field is narrowing the outdated inventory.
+    var isFiltering: Bool {
+        isSearchActive || scope != .all
     }
 
     /// Rows in the order the list renders them (formulae section, then casks).
@@ -238,6 +240,16 @@ final class UpgradesViewModel {
         }
     }
 
+    /// Re-homes the search preview when a scope change hides the previewed row. Committed selections are
+    /// left intact — `activeSelectedPackageID` falls back to the first visible row while a selection is
+    /// scoped out and restores it if the scope widens again. Mirrors `InstalledViewModel`.
+    private func updateSelectionForScopeChange() {
+        guard isSearchActive, !didCommitSelectionDuringSearch else {
+            return
+        }
+        searchPreviewSelectedPackageID = firstVisibleRowID()
+    }
+
     private func firstVisibleRowID() -> InstalledBrewPackage.ID? {
         allRows.first?.id
     }
@@ -249,7 +261,12 @@ final class UpgradesViewModel {
     /// don't disable the *Upgrade All* button.
     private func observePhaseChanges() async {
         let stream = await brewCommandCenter.allPhaseChanges()
-        for await (id, phase) in stream where id == .bulkUpgrade {
+        for await (id, phase) in stream {
+            // Any bulk-upgrade selection (all / --formula / --cask / explicit names) counts; unrelated
+            // installs, uninstalls, and doctor fixes on the shared stream are ignored.
+            guard case .bulkUpgrade = id else {
+                continue
+            }
             switch phase {
             case .running:
                 runningIDs.insert(id)
@@ -261,17 +278,19 @@ final class UpgradesViewModel {
 
     private static func filteredContent(
         _ content: InstalledPackagesContent,
+        scope: InstalledPackageScope,
         query: String,
     ) -> InstalledPackagesContent {
+        let scoped = content.filtered(by: scope)
         let normalizedQuery = normalizedSearchQuery(query)
         guard !normalizedQuery.isEmpty else {
-            return content
+            return scoped
         }
 
-        let filteredFormulaRows = content.formulaPackages.filter {
+        let filteredFormulaRows = scoped.formulaPackages.filter {
             $0.name.localizedCaseInsensitiveContains(normalizedQuery)
         }
-        let filteredCaskRows = content.caskPackages.filter {
+        let filteredCaskRows = scoped.caskPackages.filter {
             $0.name.localizedCaseInsensitiveContains(normalizedQuery)
         }
         return InstalledPackagesContent(
@@ -302,6 +321,54 @@ final class UpgradesViewModel {
         default:
             return String(localized: "Something went wrong loading packages.", comment: "Upgrades tab generic error")
         }
+    }
+}
+
+// MARK: - Upgrade action
+
+extension UpgradesViewModel {
+    /// User-facing command rendered by the Updates header's `CommandBlockView`. Derived from the same
+    /// ``BrewUpgradeSelection`` that ``upgradeAll()`` submits, so the shown command always matches what runs.
+    var bulkUpgradeDisplayCommand: String {
+        upgradeSelection.displayCommand
+    }
+
+    /// What "Upgrade All" upgrades, given the active filters:
+    /// - A search narrows the batch to the visible rows by name (`brew upgrade git slack`).
+    /// - Otherwise the scope picker maps to everything / `--formula` / `--cask`.
+    ///
+    /// The button is gated on `outdatedCount > 0`, so ``BrewUpgradeSelection/explicit(_:)`` is never
+    /// submitted with an empty name list.
+    var upgradeSelection: BrewUpgradeSelection {
+        if isSearchActive {
+            return .explicit(allRows.map(\.name))
+        }
+        switch scope {
+        case .all:
+            return .all
+        case .formulae:
+            return .formulae
+        case .casks:
+            return .casks
+        }
+    }
+
+    /// Submits one batch `brew upgrade` for ``upgradeSelection`` under ``BrewOperationID/bulkUpgrade(_:)``
+    /// carrying that selection. Submit dedupes against the in-flight id, so a re-tap with the same
+    /// selection is a no-op. The repository's completion observer reconciles inventory on running→idle,
+    /// so finished rows drop from the list when the run completes.
+    func upgradeAll() {
+        let selection = upgradeSelection
+        let id = BrewOperationID.bulkUpgrade(selection)
+        let command = commandFactory.bulkUpgradeCommand(selection: selection)
+        Task { try? await brewCommandCenter.submit(id: id, command: command) }
+    }
+
+    /// Clears both filters, restoring the full outdated list. Wired to the "Show all upgrades" affordance
+    /// on the no-matches empty state.
+    func resetFilters() {
+        searchQuery = ""
+        scope = .all
     }
 }
 

--- a/Sources/BrewFeatureInstalled/Views/InstalledPackagesView.swift
+++ b/Sources/BrewFeatureInstalled/Views/InstalledPackagesView.swift
@@ -11,7 +11,6 @@ import SwiftUI
 /// Middle column of the main window: “Installed” chrome and the package list.
 struct InstalledPackagesView: View {
     @Bindable var viewModel: InstalledViewModel
-    @State private var searchPresented = false
     @FocusState private var isFocused: Bool
 
     var body: some View {
@@ -43,11 +42,11 @@ struct InstalledPackagesView: View {
         }
         .searchable(
             text: $viewModel.searchQuery,
-            isPresented: $searchPresented,
+            isPresented: $viewModel.isSearchFieldPresented,
             placement: .toolbar,
             prompt: "Search Installed Packages",
         )
-        .focusedSceneValue(\.searchPresented, $searchPresented)
+        .focusedSceneValue(\.searchPresented, $viewModel.isSearchFieldPresented)
     }
 
     /// Persistent kind filter, always visible. Filters the loaded inventory client-side; never refetches.
@@ -84,9 +83,6 @@ struct InstalledPackagesView: View {
                 scrollToSelection(viewModel.activeSelectedPackageID, in: content, with: proxy)
             }
             .task(id: viewModel.shouldFocusList) {
-                // Never grab focus while the search field is active — auto-focusing the list for
-                // keyboard nav must not kick the cursor out of an in-progress search.
-                guard !searchPresented else { return }
                 isFocused = viewModel.shouldFocusList
             }
             .focused($isFocused)

--- a/Sources/BrewFeatureInstalled/Views/InstalledPackagesView.swift
+++ b/Sources/BrewFeatureInstalled/Views/InstalledPackagesView.swift
@@ -84,6 +84,9 @@ struct InstalledPackagesView: View {
                 scrollToSelection(viewModel.activeSelectedPackageID, in: content, with: proxy)
             }
             .task(id: viewModel.shouldFocusList) {
+                // Never grab focus while the search field is active — auto-focusing the list for
+                // keyboard nav must not kick the cursor out of an in-progress search.
+                guard !searchPresented else { return }
                 isFocused = viewModel.shouldFocusList
             }
             .focused($isFocused)

--- a/Sources/BrewFeatureInstalled/Views/InstalledPackagesView.swift
+++ b/Sources/BrewFeatureInstalled/Views/InstalledPackagesView.swift
@@ -29,6 +29,9 @@ struct InstalledPackagesView: View {
             .accessibilityElement(children: .combine)
             .accessibilityHeading(.h1)
 
+            scopePicker
+            Divider()
+
             AsyncContentView(
                 state: viewModel.state,
                 onRetry: { Task { await viewModel.refresh() } },
@@ -45,6 +48,19 @@ struct InstalledPackagesView: View {
             prompt: "Search Installed Packages",
         )
         .focusedSceneValue(\.searchPresented, $searchPresented)
+    }
+
+    /// Persistent kind filter, always visible. Filters the loaded inventory client-side; never refetches.
+    private var scopePicker: some View {
+        Picker("Scope", selection: $viewModel.scope) {
+            Text("All").tag(InstalledPackageScope.all)
+            Text("Formulae").tag(InstalledPackageScope.formulae)
+            Text("Casks").tag(InstalledPackageScope.casks)
+        }
+        .pickerStyle(.segmented)
+        .labelsHidden()
+        .padding(.horizontal, BrewSpacing.lg)
+        .padding(.bottom, BrewSpacing.md)
     }
 
     private func installedList(_ content: InstalledPackagesContent) -> some View {

--- a/Sources/BrewFeatureInstalled/Views/UpgradesPackagesView.swift
+++ b/Sources/BrewFeatureInstalled/Views/UpgradesPackagesView.swift
@@ -18,6 +18,11 @@ struct UpgradesPackagesView: View {
         VStack(alignment: .leading, spacing: 0) {
             header
 
+            if viewModel.totalOutdatedCount > 0 {
+                scopePicker
+                Divider()
+            }
+
             AsyncContentView(
                 state: viewModel.state,
                 onRetry: { Task { await viewModel.refresh() } },
@@ -77,6 +82,19 @@ struct UpgradesPackagesView: View {
             }
         }
         .padding(BrewSpacing.lg)
+    }
+
+    /// Kind filter shown whenever there is outdated inventory to narrow. Filters client-side; never refetches.
+    private var scopePicker: some View {
+        Picker("Scope", selection: $viewModel.scope) {
+            Text("All").tag(InstalledPackageScope.all)
+            Text("Formulae").tag(InstalledPackageScope.formulae)
+            Text("Casks").tag(InstalledPackageScope.casks)
+        }
+        .pickerStyle(.segmented)
+        .labelsHidden()
+        .padding(.horizontal, BrewSpacing.lg)
+        .padding(.vertical, BrewSpacing.md)
     }
 
     private func upgradesList(_ content: InstalledPackagesContent) -> some View {
@@ -173,7 +191,7 @@ struct UpgradesPackagesView: View {
         }
     }
 
-    /// Shown when the search filter hides every outdated package but upgrades
+    /// Shown when the active filters (scope and/or search) hide every outdated package but upgrades
     /// still exist in the inventory — distinct from the "all caught up" state.
     private var noSearchMatchesState: some View {
         centeredEmptyState(
@@ -182,7 +200,7 @@ struct UpgradesPackagesView: View {
             actionTitle: "Show all upgrades",
             accessibilityLabel: noSearchMatchesSubtitle,
         ) {
-            viewModel.searchQuery = ""
+            viewModel.resetFilters()
         }
     }
 
@@ -238,13 +256,13 @@ struct UpgradesPackagesView: View {
         let hidden = viewModel.totalOutdatedCount
         if hidden == 1 {
             return String(
-                localized: "1 outdated package is hidden by the current search.",
-                comment: "Upgrades search-empty state with a single hidden outdated package",
+                localized: "1 outdated package is hidden by the current filters.",
+                comment: "Upgrades filter-empty state with a single hidden outdated package",
             )
         }
         return String(
-            localized: "\(hidden) outdated packages are hidden by the current search.",
-            comment: "Upgrades search-empty state with multiple hidden outdated packages",
+            localized: "\(hidden) outdated packages are hidden by the current filters.",
+            comment: "Upgrades filter-empty state with multiple hidden outdated packages",
         )
     }
 }

--- a/Sources/BrewFeatureInstalled/Views/UpgradesPackagesView.swift
+++ b/Sources/BrewFeatureInstalled/Views/UpgradesPackagesView.swift
@@ -11,7 +11,6 @@ import SwiftUI
 /// and a friendly empty state when nothing is outdated.
 struct UpgradesPackagesView: View {
     @Bindable var viewModel: UpgradesViewModel
-    @State private var searchPresented = false
     @FocusState private var isFocused: Bool
 
     var body: some View {
@@ -42,11 +41,11 @@ struct UpgradesPackagesView: View {
         }
         .searchable(
             text: $viewModel.searchQuery,
-            isPresented: $searchPresented,
+            isPresented: $viewModel.isSearchFieldPresented,
             placement: .toolbar,
             prompt: "Search Upgrades",
         )
-        .focusedSceneValue(\.searchPresented, $searchPresented)
+        .focusedSceneValue(\.searchPresented, $viewModel.isSearchFieldPresented)
     }
 
     private var header: some View {
@@ -118,11 +117,6 @@ struct UpgradesPackagesView: View {
                 scrollToSelection(viewModel.activeSelectedPackageID, in: content, with: proxy)
             }
             .task(id: viewModel.shouldFocusList) {
-                // Don't yank focus out of an active search field: a query that filters down to
-                // zero matches removes this List from the hierarchy, and deleting the query
-                // re-inserts it — re-running this .task on appear. Grabbing focus then would kick
-                // the cursor out of the search box mid-edit.
-                guard !searchPresented else { return }
                 isFocused = viewModel.shouldFocusList
             }
             .focused($isFocused)

--- a/Sources/BrewFeatureInstalled/Views/UpgradesPackagesView.swift
+++ b/Sources/BrewFeatureInstalled/Views/UpgradesPackagesView.swift
@@ -118,6 +118,11 @@ struct UpgradesPackagesView: View {
                 scrollToSelection(viewModel.activeSelectedPackageID, in: content, with: proxy)
             }
             .task(id: viewModel.shouldFocusList) {
+                // Don't yank focus out of an active search field: a query that filters down to
+                // zero matches removes this List from the hierarchy, and deleting the query
+                // re-inserts it — re-running this .task on appear. Grabbing focus then would kick
+                // the cursor out of the search box mid-edit.
+                guard !searchPresented else { return }
                 isFocused = viewModel.shouldFocusList
             }
             .focused($isFocused)

--- a/Sources/BrewNetworking/BrewAPIClient.swift
+++ b/Sources/BrewNetworking/BrewAPIClient.swift
@@ -7,8 +7,17 @@ import BrewCore
 import Foundation
 
 public protocol BrewAPIClient: Sendable {
-    func fetchFormulaInstallOnRequestAnalytics(window: BrewAnalyticsWindow) async throws -> BrewAnalyticsJSON
-    func fetchCaskInstallAnalytics(window: BrewAnalyticsWindow) async throws -> BrewAnalyticsJSON
+    /// Returns the raw analytics JSON body so callers can persist it verbatim (the `BrewAnalyticsJSON`
+    /// DTO is lossy/`Decodable`-only and cannot be round-tripped). Supports conditional requests via
+    /// `etag`, mirroring the catalogue endpoints.
+    func fetchFormulaInstallOnRequestAnalytics(
+        window: BrewAnalyticsWindow,
+        etag: String?,
+    ) async throws -> CatalogueResponse<Data>
+    func fetchCaskInstallAnalytics(
+        window: BrewAnalyticsWindow,
+        etag: String?,
+    ) async throws -> CatalogueResponse<Data>
     func fetchFormulaCatalogue(etag: String?) async throws -> CatalogueResponse<FormulaCatalogueJSON>
     func fetchCaskCatalogue(etag: String?) async throws -> CatalogueResponse<CaskCatalogueJSON>
 }
@@ -31,12 +40,18 @@ public struct URLSessionBrewAPIClient: BrewAPIClient {
         URLSessionBrewAPIClient(session: .shared)
     }
 
-    public func fetchFormulaInstallOnRequestAnalytics(window: BrewAnalyticsWindow) async throws -> BrewAnalyticsJSON {
-        try await fetchAnalytics(for: .formulaInstallOnRequest(window: window))
+    public func fetchFormulaInstallOnRequestAnalytics(
+        window: BrewAnalyticsWindow,
+        etag: String?,
+    ) async throws -> CatalogueResponse<Data> {
+        try await fetchConditionalAnalytics(for: .formulaInstallOnRequest(window: window), etag: etag)
     }
 
-    public func fetchCaskInstallAnalytics(window: BrewAnalyticsWindow) async throws -> BrewAnalyticsJSON {
-        try await fetchAnalytics(for: .caskInstall(window: window))
+    public func fetchCaskInstallAnalytics(
+        window: BrewAnalyticsWindow,
+        etag: String?,
+    ) async throws -> CatalogueResponse<Data> {
+        try await fetchConditionalAnalytics(for: .caskInstall(window: window), etag: etag)
     }
 
     public func fetchFormulaCatalogue(etag: String?) async throws -> CatalogueResponse<FormulaCatalogueJSON> {
@@ -47,8 +62,15 @@ public struct URLSessionBrewAPIClient: BrewAPIClient {
         try await fetchConditionalCatalogue(for: .caskCatalogue, etag: etag, as: CaskCatalogueJSON.self)
     }
 
-    private func fetchAnalytics(for endpoint: Endpoint) async throws -> BrewAnalyticsJSON {
-        let request = try makeRequest(for: endpoint)
+    private func fetchConditionalAnalytics(
+        for endpoint: Endpoint,
+        etag: String?,
+    ) async throws -> CatalogueResponse<Data> {
+        var headers: [String: String] = [:]
+        if let etag {
+            headers["If-None-Match"] = etag
+        }
+        let request = try makeRequest(for: endpoint, headers: headers)
 
         let data: Data
         let response: URLResponse
@@ -62,16 +84,16 @@ public struct URLSessionBrewAPIClient: BrewAPIClient {
             throw BrewAPIClientError.invalidResponse
         }
 
-        guard (200 ... 299).contains(httpResponse.statusCode) else {
+        switch httpResponse.statusCode {
+        case 304:
+            return .notModified
+        case 200 ... 299:
+            let responseETag = httpResponse.value(forHTTPHeaderField: "ETag")
+            return .updated(data: data, etag: responseETag)
+        default:
             let bodyData = Data(data.prefix(250))
             let bodySnippet = String(bytes: bodyData, encoding: .utf8) ?? ""
             throw BrewAPIClientError.httpStatus(code: httpResponse.statusCode, bodySnippet: bodySnippet)
-        }
-
-        do {
-            return try JSONDecoder().decode(BrewAnalyticsJSON.self, from: data)
-        } catch {
-            throw BrewAPIClientError.decoding(underlying: String(describing: error))
         }
     }
 

--- a/Sources/BrewNetworking/DiscoverAnalyticsCache.swift
+++ b/Sources/BrewNetworking/DiscoverAnalyticsCache.swift
@@ -1,0 +1,134 @@
+//
+//  DiscoverAnalyticsCache.swift
+//  BrewNetworking
+//
+
+import BrewCore
+import Foundation
+
+/// Persistent store for the raw Homebrew analytics JSON responses that back the Discover trending
+/// list. Mirrors ``CatalogueCache``: the network bytes are written verbatim to disk (the
+/// `BrewAnalyticsJSON` DTO is lossy/`Decodable`-only, so it cannot be re-encoded), keyed by kind and
+/// analytics window, with ETags stored alongside in `UserDefaults`.
+public actor DiscoverAnalyticsCache: DiscoverAnalyticsCaching {
+    public enum AnalyticsKind: String, Sendable, CaseIterable {
+        case formula
+        case cask
+    }
+
+    private struct CacheKey: Hashable {
+        let kind: AnalyticsKind
+        let window: BrewAnalyticsWindow
+    }
+
+    private let cacheDirectoryURL: URL
+    private let defaultsKeyPrefix: String
+
+    private var inMemoryData: [CacheKey: Data] = [:]
+    private var hasPrepared = false
+    private var prepareTask: Task<[CacheKey: Data], Never>?
+
+    /// `cacheDirectoryURL` and `defaultsKeyPrefix` are the only test seams; the actor reaches for
+    /// `FileManager.default` / `UserDefaults.standard` itself so it doesn't have to store
+    /// non-Sendable singletons. Tests pass a unique tmp directory + unique key prefix to isolate.
+    public init(
+        cacheDirectoryURL: URL? = nil,
+        defaultsKeyPrefix: String = "DiscoverAnalyticsCache",
+    ) {
+        self.cacheDirectoryURL = cacheDirectoryURL ?? Self.defaultCacheDirectoryURL()
+        self.defaultsKeyPrefix = defaultsKeyPrefix
+    }
+
+    public func prepare() async {
+        if hasPrepared {
+            return
+        }
+
+        if let inFlightTask = prepareTask {
+            await applyPreparedData(inFlightTask.value)
+            hasPrepared = true
+            return
+        }
+
+        let directoryURL = cacheDirectoryURL
+        let task = Task(priority: .utility) {
+            var loaded: [CacheKey: Data] = [:]
+            for window in BrewAnalyticsWindow.allCases {
+                for kind in AnalyticsKind.allCases {
+                    let url = Self.cacheURL(in: directoryURL, kind: kind, window: window)
+                    if let data = try? Data(contentsOf: url) {
+                        loaded[CacheKey(kind: kind, window: window)] = data
+                    }
+                }
+            }
+            return loaded
+        }
+        prepareTask = task
+        let loaded = await task.value
+        prepareTask = nil
+        applyPreparedData(loaded)
+        hasPrepared = true
+    }
+
+    public func formulaAnalyticsData(window: BrewAnalyticsWindow) async -> Data? {
+        inMemoryData[CacheKey(kind: .formula, window: window)]
+    }
+
+    public func caskAnalyticsData(window: BrewAnalyticsWindow) async -> Data? {
+        inMemoryData[CacheKey(kind: .cask, window: window)]
+    }
+
+    public func etag(for kind: AnalyticsKind, window: BrewAnalyticsWindow) async -> String? {
+        UserDefaults.standard.string(forKey: etagKey(for: kind, window: window))
+    }
+
+    public func updateFormulaAnalytics(window: BrewAnalyticsWindow, with rawData: Data, etag: String?) async throws {
+        try store(kind: .formula, window: window, rawData: rawData, etag: etag)
+    }
+
+    public func updateCaskAnalytics(window: BrewAnalyticsWindow, with rawData: Data, etag: String?) async throws {
+        try store(kind: .cask, window: window, rawData: rawData, etag: etag)
+    }
+
+    private func store(kind: AnalyticsKind, window: BrewAnalyticsWindow, rawData: Data, etag: String?) throws {
+        let url = Self.cacheURL(in: cacheDirectoryURL, kind: kind, window: window)
+        try FileManager.default.createDirectory(at: cacheDirectoryURL, withIntermediateDirectories: true)
+        try rawData.write(to: url, options: .atomic)
+        inMemoryData[CacheKey(kind: kind, window: window)] = rawData
+        persistETag(etag, for: kind, window: window)
+    }
+
+    private func persistETag(_ etag: String?, for kind: AnalyticsKind, window: BrewAnalyticsWindow) {
+        let key = etagKey(for: kind, window: window)
+        if let etag {
+            UserDefaults.standard.set(etag, forKey: key)
+        } else {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+    }
+
+    private func etagKey(for kind: AnalyticsKind, window: BrewAnalyticsWindow) -> String {
+        "\(defaultsKeyPrefix).\(kind.rawValue).\(window.rawValue).etag"
+    }
+
+    private func applyPreparedData(_ loaded: [CacheKey: Data]) {
+        // Never clobber in-memory writes that landed while the disk read was in flight.
+        for (key, value) in loaded where inMemoryData[key] == nil {
+            inMemoryData[key] = value
+        }
+    }
+}
+
+private extension DiscoverAnalyticsCache {
+    static func defaultCacheDirectoryURL() -> URL {
+        let fileManager = FileManager.default
+        if let appSupportURL = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
+            return appSupportURL.appendingPathComponent("Brew", isDirectory: true)
+        }
+        return fileManager.temporaryDirectory.appendingPathComponent("Brew", isDirectory: true)
+    }
+
+    static func cacheURL(in directoryURL: URL, kind: AnalyticsKind, window: BrewAnalyticsWindow) -> URL {
+        directoryURL.appendingPathComponent("\(kind.rawValue)-analytics-\(window.rawValue).json")
+    }
+}

--- a/Sources/BrewNetworking/DiscoverAnalyticsCaching.swift
+++ b/Sources/BrewNetworking/DiscoverAnalyticsCaching.swift
@@ -1,0 +1,15 @@
+//
+//  DiscoverAnalyticsCaching.swift
+//  BrewNetworking
+//
+
+import BrewCore
+import Foundation
+
+public protocol DiscoverAnalyticsCaching: Sendable {
+    func formulaAnalyticsData(window: BrewAnalyticsWindow) async -> Data?
+    func caskAnalyticsData(window: BrewAnalyticsWindow) async -> Data?
+    func etag(for kind: DiscoverAnalyticsCache.AnalyticsKind, window: BrewAnalyticsWindow) async -> String?
+    func updateFormulaAnalytics(window: BrewAnalyticsWindow, with rawData: Data, etag: String?) async throws
+    func updateCaskAnalytics(window: BrewAnalyticsWindow, with rawData: Data, etag: String?) async throws
+}

--- a/Sources/BrewRepositories/BrewDiscoverPackagesRepository.swift
+++ b/Sources/BrewRepositories/BrewDiscoverPackagesRepository.swift
@@ -8,47 +8,139 @@ import BrewNetworking
 import BrewRepositoryInterfaces
 import Foundation
 
-public struct BrewDiscoverPackagesRepository: DiscoverPackagesRepository {
+enum DiscoverPackagesRepositoryError: Error, Equatable {
+    case cacheMissingAfterRefresh(window: BrewAnalyticsWindow)
+}
+
+/// Discover top-package repository with a 24-hour analytics cache.
+///
+/// Homebrew publishes install analytics once per day, so the raw analytics responses are cached to
+/// disk (via ``DiscoverAnalyticsCaching``) and only refetched when older than `ttl`. Staleness is
+/// tracked with a per-window `lastRefresh` timestamp in `UserDefaults`, mirroring
+/// `BrewCatalogueRepository`. Catalogue enrichment (name/description/version lookups) is re-run on
+/// every call from the cached analytics — that path is already cached by the catalogue repository.
+public actor BrewDiscoverPackagesRepository: DiscoverPackagesRepository {
+    public static let defaultTTL: TimeInterval = 86400
+
     private let apiClient: any BrewAPIClient
     private let catalogueRepository: any CatalogueRepository
+    private let cache: any DiscoverAnalyticsCaching
+    private let defaultsKeyPrefix: String
+    private let now: @Sendable () -> Date
+    private let ttl: TimeInterval
 
+    private var refreshTasks: [BrewAnalyticsWindow: Task<(Data, Data), Error>] = [:]
+
+    /// `defaultsKeyPrefix` is the test seam for `UserDefaults.standard`; tests pass a unique prefix
+    /// to isolate their lastRefresh timestamps from each other and from production data.
     public init(
         apiClient: any BrewAPIClient,
         catalogueRepository: any CatalogueRepository,
+        cache: any DiscoverAnalyticsCaching,
+        defaultsKeyPrefix: String = "DiscoverAnalytics",
+        now: @escaping @Sendable () -> Date = Date.init,
+        ttl: TimeInterval = BrewDiscoverPackagesRepository.defaultTTL,
     ) {
         self.apiClient = apiClient
         self.catalogueRepository = catalogueRepository
+        self.cache = cache
+        self.defaultsKeyPrefix = defaultsKeyPrefix
+        self.now = now
+        self.ttl = ttl
+    }
+
+    nonisolated func lastRefreshKey(for window: BrewAnalyticsWindow) -> String {
+        "\(defaultsKeyPrefix).analytics.\(window.rawValue).lastRefresh"
     }
 
     public func loadTopPackages(
         limit: Int = 10,
         window: BrewAnalyticsWindow = .days30,
     ) async throws -> DiscoverTopPackagesSnapshot {
-        async let formulaAnalyticsTask = apiClient.fetchFormulaInstallOnRequestAnalytics(window: window)
-        async let caskAnalyticsTask = apiClient.fetchCaskInstallAnalytics(window: window)
-        let formulaAnalytics = try await formulaAnalyticsTask
-        let caskAnalytics = try await caskAnalyticsTask
+        let (formulaData, caskData) = try await freshAnalyticsData(window: window)
+        return try await enrichedSnapshot(formulaData: formulaData, caskData: caskData, limit: limit)
+    }
 
-        async let formulae = topPackages(
-            from: formulaAnalytics,
-            catalogueRepository: catalogueRepository,
-            limit: limit,
-        )
-        async let casks = topPackages(
-            from: caskAnalytics,
-            catalogueRepository: catalogueRepository,
-            limit: limit,
-        )
+    /// Returns the cached analytics bytes for `window`, refetching over the network only when the
+    /// cache is stale or the bytes are unexpectedly absent.
+    private func freshAnalyticsData(window: BrewAnalyticsWindow) async throws -> (Data, Data) {
+        if !isStale(window: window),
+           let formulaData = await cache.formulaAnalyticsData(window: window),
+           let caskData = await cache.caskAnalyticsData(window: window)
+        {
+            return (formulaData, caskData)
+        }
+        return try await refreshAwaitingSharedTask(for: window)
+    }
 
-        return try await DiscoverTopPackagesSnapshot(
-            topFormulae: formulae,
-            topCasks: casks,
+    /// Coalesces concurrent refreshes for the same window so simultaneous view appearances trigger a
+    /// single network round-trip (mirrors `BrewCatalogueRepository.refreshAwaitingSharedTask`).
+    private func refreshAwaitingSharedTask(for window: BrewAnalyticsWindow) async throws -> (Data, Data) {
+        if let existing = refreshTasks[window] {
+            return try await existing.value
+        }
+        let task = Task { try await self.performRefresh(for: window) }
+        refreshTasks[window] = task
+        do {
+            let value = try await task.value
+            refreshTasks[window] = nil
+            return value
+        } catch {
+            refreshTasks[window] = nil
+            throw error
+        }
+    }
+
+    private func performRefresh(for window: BrewAnalyticsWindow) async throws -> (Data, Data) {
+        let formulaETag = await cache.etag(for: .formula, window: window)
+        let formulaResponse = try await apiClient.fetchFormulaInstallOnRequestAnalytics(
+            window: window,
+            etag: formulaETag,
         )
+        switch formulaResponse {
+        case .notModified:
+            break
+        case let .updated(data: data, etag: nextETag):
+            try await cache.updateFormulaAnalytics(window: window, with: data, etag: nextETag)
+        }
+
+        let caskETag = await cache.etag(for: .cask, window: window)
+        let caskResponse = try await apiClient.fetchCaskInstallAnalytics(window: window, etag: caskETag)
+        switch caskResponse {
+        case .notModified:
+            break
+        case let .updated(data: data, etag: nextETag):
+            try await cache.updateCaskAnalytics(window: window, with: data, etag: nextETag)
+        }
+
+        guard let formulaData = await cache.formulaAnalyticsData(window: window),
+              let caskData = await cache.caskAnalyticsData(window: window)
+        else {
+            throw DiscoverPackagesRepositoryError.cacheMissingAfterRefresh(window: window)
+        }
+
+        // Only stamp the cache fresh once both fetches (and stores) succeeded, so a mid-refresh
+        // failure leaves the window stale and the next call retries.
+        updateLastRefresh(window: window)
+        return (formulaData, caskData)
+    }
+
+    private func enrichedSnapshot(
+        formulaData: Data,
+        caskData: Data,
+        limit: Int,
+    ) async throws -> DiscoverTopPackagesSnapshot {
+        let formulaAnalytics = try Self.decodeAnalytics(formulaData)
+        let caskAnalytics = try Self.decodeAnalytics(caskData)
+
+        let formulae = try await topPackages(from: formulaAnalytics, limit: limit)
+        let casks = try await topPackages(from: caskAnalytics, limit: limit)
+
+        return DiscoverTopPackagesSnapshot(topFormulae: formulae, topCasks: casks)
     }
 
     private func topPackages(
         from analytics: BrewAnalyticsJSON,
-        catalogueRepository: any CatalogueRepository,
         limit: Int,
     ) async throws -> [DiscoveryBrewPackage] {
         let validatedLimit = max(0, limit)
@@ -85,5 +177,20 @@ public struct BrewDiscoverPackagesRepository: DiscoverPackagesRepository {
             return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
         }
         return lhs.count > rhs.count
+    }
+
+    private func updateLastRefresh(window: BrewAnalyticsWindow) {
+        UserDefaults.standard.set(now(), forKey: lastRefreshKey(for: window))
+    }
+
+    private func isStale(window: BrewAnalyticsWindow) -> Bool {
+        guard let refreshedAt = UserDefaults.standard.object(forKey: lastRefreshKey(for: window)) as? Date else {
+            return true
+        }
+        return now().timeIntervalSince(refreshedAt) >= ttl
+    }
+
+    private static func decodeAnalytics(_ data: Data) throws -> BrewAnalyticsJSON {
+        try JSONDecoder().decode(BrewAnalyticsJSON.self, from: data)
     }
 }

--- a/Sources/BrewRepositories/BrewDiscoverPackagesRepository.swift
+++ b/Sources/BrewRepositories/BrewDiscoverPackagesRepository.swift
@@ -93,20 +93,25 @@ public actor BrewDiscoverPackagesRepository: DiscoverPackagesRepository {
 
     private func performRefresh(for window: BrewAnalyticsWindow) async throws -> (Data, Data) {
         let formulaETag = await cache.etag(for: .formula, window: window)
-        let formulaResponse = try await apiClient.fetchFormulaInstallOnRequestAnalytics(
+        let caskETag = await cache.etag(for: .cask, window: window)
+
+        async let formulaResponse = apiClient.fetchFormulaInstallOnRequestAnalytics(
             window: window,
             etag: formulaETag,
         )
-        switch formulaResponse {
+        async let caskResponse = apiClient.fetchCaskInstallAnalytics(
+            window: window,
+            etag: caskETag,
+        )
+
+        switch try await formulaResponse {
         case .notModified:
             break
         case let .updated(data: data, etag: nextETag):
             try await cache.updateFormulaAnalytics(window: window, with: data, etag: nextETag)
         }
 
-        let caskETag = await cache.etag(for: .cask, window: window)
-        let caskResponse = try await apiClient.fetchCaskInstallAnalytics(window: window, etag: caskETag)
-        switch caskResponse {
+        switch try await caskResponse {
         case .notModified:
             break
         case let .updated(data: data, etag: nextETag):

--- a/Sources/BrewRepositoryInterfaces/CommandJob.swift
+++ b/Sources/BrewRepositoryInterfaces/CommandJob.swift
@@ -96,8 +96,8 @@ public extension CommandJob {
             userFacingCommand(kind: kind, name: packageID.name)
         case let .maintenance(_, displayCommand):
             displayCommand
-        case .bulkUpgrade:
-            BrewOperationID.bulkUpgradeDisplayCommand
+        case let .bulkUpgrade(selection):
+            selection.displayCommand
         }
         return CommandJob(
             id: id,

--- a/Sources/BrewRepositoryInterfaces/Fakes/Stubs.swift
+++ b/Sources/BrewRepositoryInterfaces/Fakes/Stubs.swift
@@ -200,7 +200,7 @@ public struct StubMutatingCommandFactory: BrewMutatingCommandFactory {
         NoopMutatingCommand(operationKind: kind == .formula ? .uninstallFormula : .uninstallCask)
     }
 
-    public func bulkUpgradeCommand() -> any BrewMutatingCommand {
+    public func bulkUpgradeCommand(selection _: BrewUpgradeSelection) -> any BrewMutatingCommand {
         NoopMutatingCommand(operationKind: .upgradeAll)
     }
 

--- a/Sources/BrewServicesTestSupport/DiscoverAnalyticsCacheDoubles.swift
+++ b/Sources/BrewServicesTestSupport/DiscoverAnalyticsCacheDoubles.swift
@@ -1,0 +1,57 @@
+//
+//  DiscoverAnalyticsCacheDoubles.swift
+//  BrewServicesTestSupport
+//
+
+import BrewCore
+import BrewNetworking
+import Foundation
+
+/// In-memory ``DiscoverAnalyticsCaching`` for tests: no disk, no `UserDefaults`. Seed it to simulate
+/// an already-populated cache, or leave it empty to force the repository to fetch.
+public actor InMemoryDiscoverAnalyticsCache: DiscoverAnalyticsCaching {
+    private struct Key: Hashable {
+        let kind: DiscoverAnalyticsCache.AnalyticsKind
+        let window: BrewAnalyticsWindow
+    }
+
+    private var data: [Key: Data] = [:]
+    private var etags: [Key: String] = [:]
+
+    public init() {}
+
+    public func seed(
+        window: BrewAnalyticsWindow,
+        formula: Data,
+        cask: Data,
+        formulaETag: String? = nil,
+        caskETag: String? = nil,
+    ) {
+        data[Key(kind: .formula, window: window)] = formula
+        data[Key(kind: .cask, window: window)] = cask
+        etags[Key(kind: .formula, window: window)] = formulaETag
+        etags[Key(kind: .cask, window: window)] = caskETag
+    }
+
+    public func formulaAnalyticsData(window: BrewAnalyticsWindow) async -> Data? {
+        data[Key(kind: .formula, window: window)]
+    }
+
+    public func caskAnalyticsData(window: BrewAnalyticsWindow) async -> Data? {
+        data[Key(kind: .cask, window: window)]
+    }
+
+    public func etag(for kind: DiscoverAnalyticsCache.AnalyticsKind, window: BrewAnalyticsWindow) async -> String? {
+        etags[Key(kind: kind, window: window)]
+    }
+
+    public func updateFormulaAnalytics(window: BrewAnalyticsWindow, with rawData: Data, etag: String?) async throws {
+        data[Key(kind: .formula, window: window)] = rawData
+        etags[Key(kind: .formula, window: window)] = etag
+    }
+
+    public func updateCaskAnalytics(window: BrewAnalyticsWindow, with rawData: Data, etag: String?) async throws {
+        data[Key(kind: .cask, window: window)] = rawData
+        etags[Key(kind: .cask, window: window)] = etag
+    }
+}

--- a/Tests/BrewCLITests/BulkUpgradeCommandTests.swift
+++ b/Tests/BrewCLITests/BulkUpgradeCommandTests.swift
@@ -10,7 +10,7 @@ import Foundation
 import Testing
 
 struct BulkUpgradeCommandTests {
-    @Test func `run invokes brew upgrade with no arguments`() async throws {
+    @Test func `run invokes brew upgrade with the selection's arguments`() async throws {
         let runner = CapturingCommandRunner()
         let brewURL = URL(fileURLWithPath: "/opt/homebrew/bin/brew")
         let ctx = BrewCommandExecutionContext(
@@ -18,10 +18,24 @@ struct BulkUpgradeCommandTests {
             locator: BrewExecutableLocator(overrideURL: brewURL),
         )
 
-        try await BulkUpgradeCommand().run(in: ctx)
+        try await BulkUpgradeCommand(selection: .all).run(in: ctx)
 
         #expect(await runner.lastExecutable == brewURL)
         #expect(await runner.lastArguments == ["upgrade"])
+    }
+
+    @Test func `run forwards a scoped selection's flags`() async throws {
+        let runner = CapturingCommandRunner()
+        let ctx = BrewCommandExecutionContext(
+            commandRunner: runner,
+            locator: BrewExecutableLocator(overrideURL: URL(fileURLWithPath: "/opt/homebrew/bin/brew")),
+        )
+
+        try await BulkUpgradeCommand(selection: .formulae).run(in: ctx)
+        #expect(await runner.lastArguments == ["upgrade", "--formula"])
+
+        try await BulkUpgradeCommand(selection: .explicit(["git", "slack"])).run(in: ctx)
+        #expect(await runner.lastArguments == ["upgrade", "git", "slack"])
     }
 
     @Test func `nonzero exit throws BrewCommandError with stderr`() async {
@@ -35,12 +49,12 @@ struct BulkUpgradeCommandTests {
         )
 
         await #expect(throws: BrewCommandError.self) {
-            try await BulkUpgradeCommand().run(in: ctx)
+            try await BulkUpgradeCommand(selection: .all).run(in: ctx)
         }
     }
 
     @Test func `operationKind is upgradeAll`() {
-        #expect(BulkUpgradeCommand().operationKind == .upgradeAll)
+        #expect(BulkUpgradeCommand(selection: .all).operationKind == .upgradeAll)
     }
 }
 

--- a/Tests/BrewCoreTests/BrewAnalyticsJSONTests.swift
+++ b/Tests/BrewCoreTests/BrewAnalyticsJSONTests.swift
@@ -1,0 +1,139 @@
+//
+//  BrewAnalyticsJSONTests.swift
+//  BrewTests
+//
+
+import BrewCore
+import Foundation
+import Testing
+
+/// Decoding coverage for the analytics DTO. The API client now returns the raw response bytes and the
+/// repository decodes them through this type, so these fixtures exercise the flatten/validation logic
+/// directly rather than through a URLSession stub.
+struct BrewAnalyticsJSONTests {
+    @Test func `decodes formula ranking and flattens buckets`() throws {
+        let json = Data(
+            """
+            {
+              "category": "formula_install_on_request",
+              "total_items": 2,
+              "total_count": 1200,
+              "start_date": "2026-04-17",
+              "end_date": "2026-05-17",
+              "formulae": {
+                "wget": [{ "formula": "wget", "count": "1,000" }],
+                "bat": [{ "formula": "bat", "count": "200" }]
+              }
+            }
+            """.utf8,
+        )
+
+        let decoded = try JSONDecoder().decode(BrewAnalyticsJSON.self, from: json)
+
+        #expect(decoded.category == "formula_install_on_request")
+        #expect(decoded.totalCount == 1200)
+        let countsByName = Dictionary(uniqueKeysWithValues: decoded.packageCounts.map { ($0.name, $0.count) })
+        #expect(countsByName["wget"] == 1000)
+        #expect(countsByName["bat"] == 200)
+    }
+
+    @Test func `decodes cask ranking into cask references`() throws {
+        let json = Data(
+            """
+            {
+              "category": "cask_install",
+              "total_items": 1,
+              "total_count": 50,
+              "start_date": "2026-02-17",
+              "end_date": "2026-05-17",
+              "formulae": {
+                "iterm2": [{ "cask": "iterm2", "count": "50" }]
+              }
+            }
+            """.utf8,
+        )
+
+        let decoded = try JSONDecoder().decode(BrewAnalyticsJSON.self, from: json)
+        #expect(decoded.packageCounts.first?.reference == .cask(token: "iterm2"))
+    }
+
+    @Test func `throws when required fields are missing`() throws {
+        let json = Data(
+            """
+            {
+              "category": "formula_install_on_request",
+              "total_items": 2,
+              "start_date": "2026-04-17",
+              "end_date": "2026-05-17",
+              "formulae": {
+                "wget": [{ "formula": "wget", "count": "1000" }]
+              }
+            }
+            """.utf8,
+        )
+
+        #expect(throws: DecodingError.self) {
+            _ = try JSONDecoder().decode(BrewAnalyticsJSON.self, from: json)
+        }
+    }
+
+    @Test func `throws when entry count is malformed`() throws {
+        let json = Data(
+            """
+            {
+              "category": "formula_install_on_request",
+              "total_items": 2,
+              "total_count": 1200,
+              "start_date": "2026-04-17",
+              "end_date": "2026-05-17",
+              "formulae": {
+                "wget": [{ "formula": "wget", "count": "not-a-number" }]
+              }
+            }
+            """.utf8,
+        )
+
+        #expect(throws: DecodingError.self) {
+            _ = try JSONDecoder().decode(BrewAnalyticsJSON.self, from: json)
+        }
+    }
+
+    @Test func `throws when entry package identity is missing`() throws {
+        let json = Data(
+            """
+            {
+              "category": "formula_install_on_request",
+              "total_items": 2,
+              "total_count": 1200,
+              "start_date": "2026-04-17",
+              "end_date": "2026-05-17",
+              "formulae": {
+                "wget": [{ "count": "1000" }]
+              }
+            }
+            """.utf8,
+        )
+
+        #expect(throws: DecodingError.self) {
+            _ = try JSONDecoder().decode(BrewAnalyticsJSON.self, from: json)
+        }
+    }
+
+    @Test func `throws when neither formulae nor casks bucket is present`() throws {
+        let json = Data(
+            """
+            {
+              "category": "formula_install_on_request",
+              "total_items": 0,
+              "total_count": 0,
+              "start_date": "2026-04-17",
+              "end_date": "2026-05-17"
+            }
+            """.utf8,
+        )
+
+        #expect(throws: DecodingError.self) {
+            _ = try JSONDecoder().decode(BrewAnalyticsJSON.self, from: json)
+        }
+    }
+}

--- a/Tests/BrewCoreTests/BrewUpgradeSelectionTests.swift
+++ b/Tests/BrewCoreTests/BrewUpgradeSelectionTests.swift
@@ -1,0 +1,51 @@
+//
+//  BrewUpgradeSelectionTests.swift
+//  BrewTests
+//
+
+import BrewCore
+import Foundation
+import Testing
+
+struct BrewUpgradeSelectionTests {
+    @Test func `all upgrades everything`() {
+        #expect(BrewUpgradeSelection.all.arguments == ["upgrade"])
+        #expect(BrewUpgradeSelection.all.displayCommand == "brew upgrade")
+    }
+
+    @Test func `formulae restricts to the formula flag`() {
+        #expect(BrewUpgradeSelection.formulae.arguments == ["upgrade", "--formula"])
+        #expect(BrewUpgradeSelection.formulae.displayCommand == "brew upgrade --formula")
+    }
+
+    @Test func `casks restricts to the cask flag`() {
+        #expect(BrewUpgradeSelection.casks.arguments == ["upgrade", "--cask"])
+        #expect(BrewUpgradeSelection.casks.displayCommand == "brew upgrade --cask")
+    }
+
+    @Test func `explicit lists the given names after upgrade`() {
+        let selection = BrewUpgradeSelection.explicit(["git", "slack"])
+        #expect(selection.arguments == ["upgrade", "git", "slack"])
+        #expect(selection.displayCommand == "brew upgrade git slack")
+    }
+
+    @Test func `explicit with no names is just upgrade`() {
+        // Defensive: the Upgrades tab never submits an empty explicit selection (the button is gated on a
+        // non-zero visible count), but the value type should still be well-defined.
+        let selection = BrewUpgradeSelection.explicit([])
+        #expect(selection.arguments == ["upgrade"])
+        #expect(selection.displayCommand == "brew upgrade")
+    }
+
+    @Test func `bulkUpgradeDisplayCommand mirrors the all selection`() {
+        #expect(BrewOperationID.bulkUpgradeDisplayCommand == BrewUpgradeSelection.all.displayCommand)
+    }
+
+    @Test func `distinct selections produce distinct bulk upgrade ids`() {
+        // Selection is part of the operation identity so the console can render each variant and distinct
+        // batches don't dedupe against one another.
+        #expect(BrewOperationID.bulkUpgrade(.all) != BrewOperationID.bulkUpgrade(.formulae))
+        #expect(BrewOperationID.bulkUpgrade(.explicit(["git"])) != BrewOperationID.bulkUpgrade(.explicit(["wget"])))
+        #expect(BrewOperationID.bulkUpgrade(.formulae) == BrewOperationID.bulkUpgrade(.formulae))
+    }
+}

--- a/Tests/BrewFeatureConsoleTests/CommandJobTests.swift
+++ b/Tests/BrewFeatureConsoleTests/CommandJobTests.swift
@@ -71,13 +71,36 @@ struct CommandJobTests {
 
     @Test func `materialize for bulk upgrade id renders the shared display command`() {
         let job = CommandJob.materialize(
-            id: .bulkUpgrade,
+            id: .bulkUpgrade(.all),
             kind: .upgradeAll,
             phase: .running(.upgradeAll),
         )
 
         #expect(job.command == BrewOperationID.bulkUpgradeDisplayCommand)
         #expect(job.command == "brew upgrade")
+    }
+
+    @Test func `materialize for a scoped bulk upgrade renders the selection's command`() {
+        let formulae = CommandJob.materialize(
+            id: .bulkUpgrade(.formulae),
+            kind: .upgradeAll,
+            phase: .running(.upgradeAll),
+        )
+        #expect(formulae.command == "brew upgrade --formula")
+
+        let casks = CommandJob.materialize(
+            id: .bulkUpgrade(.casks),
+            kind: .upgradeAll,
+            phase: .running(.upgradeAll),
+        )
+        #expect(casks.command == "brew upgrade --cask")
+
+        let explicit = CommandJob.materialize(
+            id: .bulkUpgrade(.explicit(["git", "slack"])),
+            kind: .upgradeAll,
+            phase: .running(.upgradeAll),
+        )
+        #expect(explicit.command == "brew upgrade git slack")
     }
 
     @Test func `updatePhase from running to idle sets exit code zero`() {

--- a/Tests/BrewFeatureConsoleTests/ConsoleViewModelTests.swift
+++ b/Tests/BrewFeatureConsoleTests/ConsoleViewModelTests.swift
@@ -157,4 +157,35 @@ struct ConsoleViewModelTests {
         await harness.emit(id: second, phase: .idle)
         #expect(!harness.viewModel.shouldAutoExpandConsole)
     }
+
+    @Test func `autoExpandEnabled defaults to true`() async {
+        let harness = ConsoleJobsHarness()
+        await harness.awaitReady()
+
+        #expect(harness.viewModel.autoExpandEnabled)
+    }
+
+    @Test func `shouldAutoExpandConsole is false while a command runs but auto-expand is disabled`() async {
+        let harness = ConsoleJobsHarness()
+        await harness.awaitReady()
+        let id = BrewOperationID(kind: .formula, name: "gh")
+        await harness.emit(id: id, phase: .running(.installFormula))
+
+        harness.viewModel.autoExpandEnabled = false
+
+        #expect(!harness.viewModel.shouldAutoExpandConsole)
+    }
+
+    @Test func `shouldAutoExpandConsole returns to true when auto-expand is re-enabled while a command runs`() async {
+        let harness = ConsoleJobsHarness()
+        await harness.awaitReady()
+        let id = BrewOperationID(kind: .formula, name: "gh")
+        await harness.emit(id: id, phase: .running(.installFormula))
+
+        harness.viewModel.autoExpandEnabled = false
+        #expect(!harness.viewModel.shouldAutoExpandConsole)
+
+        harness.viewModel.autoExpandEnabled = true
+        #expect(harness.viewModel.shouldAutoExpandConsole)
+    }
 }

--- a/Tests/BrewFeatureConsoleTests/ConsoleViewModelTests.swift
+++ b/Tests/BrewFeatureConsoleTests/ConsoleViewModelTests.swift
@@ -108,4 +108,53 @@ struct ConsoleViewModelTests {
 
         #expect(harness.viewModel.selectedID == running)
     }
+
+    // MARK: - shouldAutoExpandConsole
+
+    @Test func `shouldAutoExpandConsole is false with no jobs`() async {
+        let harness = ConsoleJobsHarness()
+        await harness.awaitReady()
+
+        #expect(!harness.viewModel.shouldAutoExpandConsole)
+    }
+
+    @Test func `shouldAutoExpandConsole becomes true once a command starts running`() async {
+        let harness = ConsoleJobsHarness()
+        await harness.awaitReady()
+        let id = BrewOperationID(kind: .formula, name: "gh")
+
+        await harness.emit(id: id, phase: .running(.installFormula))
+
+        #expect(harness.viewModel.shouldAutoExpandConsole)
+    }
+
+    @Test func `shouldAutoExpandConsole returns to false once the running command reaches terminal`() async {
+        let harness = ConsoleJobsHarness()
+        await harness.awaitReady()
+        let id = BrewOperationID(kind: .formula, name: "gh")
+
+        await harness.emit(id: id, phase: .running(.installFormula))
+        #expect(harness.viewModel.shouldAutoExpandConsole)
+
+        await harness.emit(id: id, phase: .idle)
+        #expect(!harness.viewModel.shouldAutoExpandConsole)
+    }
+
+    @Test func `shouldAutoExpandConsole stays true while any command is still running`() async {
+        let harness = ConsoleJobsHarness()
+        await harness.awaitReady()
+        let first = BrewOperationID(kind: .formula, name: "gh")
+        let second = BrewOperationID(kind: .formula, name: "ripgrep")
+
+        await harness.emit(id: first, phase: .running(.installFormula))
+        await harness.emit(id: second, phase: .running(.installFormula))
+
+        // One finishes — the other is still running, so the panel should stay open.
+        await harness.emit(id: first, phase: .idle)
+        #expect(harness.viewModel.shouldAutoExpandConsole)
+
+        // Both finished — nothing running.
+        await harness.emit(id: second, phase: .idle)
+        #expect(!harness.viewModel.shouldAutoExpandConsole)
+    }
 }

--- a/Tests/BrewFeatureInstalledTests/InstalledViewModelScopeTests.swift
+++ b/Tests/BrewFeatureInstalledTests/InstalledViewModelScopeTests.swift
@@ -1,0 +1,137 @@
+//
+//  InstalledViewModelScopeTests.swift
+//  BrewTests
+//
+
+import BrewCLI
+import BrewCore
+import BrewCoreTestSupport
+@testable import BrewFeatureInstalled
+import BrewRepositories
+import BrewRepositoryInterfaces
+import BrewServicesTestSupport
+import Foundation
+import Testing
+
+struct InstalledViewModelScopeTests {
+    @Test @MainActor func `scope defaults to all and shows both kinds`() async {
+        let vm = await InstalledFeatureTestSupport.loadedViewModel(
+            formulae: [.fixture(name: "git", kind: .formula)],
+            casks: [.fixture(name: "slack", kind: .cask)],
+        )
+
+        #expect(vm.scope == .all)
+        #expect(vm.loadedFormulaPackages.map(\.name) == ["git"])
+        #expect(vm.loadedCaskPackages.map(\.name) == ["slack"])
+        #expect(vm.totalPackageCount == 2)
+    }
+
+    @Test @MainActor func `scope formulae hides casks`() async {
+        let vm = await InstalledFeatureTestSupport.loadedViewModel(
+            formulae: [
+                .fixture(name: "git", kind: .formula),
+                .fixture(name: "wget", kind: .formula),
+            ],
+            casks: [.fixture(name: "slack", kind: .cask)],
+        )
+
+        vm.scope = .formulae
+
+        #expect(vm.loadedFormulaPackages.map(\.name) == ["git", "wget"])
+        #expect(vm.loadedCaskPackages.isEmpty)
+        #expect(vm.totalPackageCount == 2)
+    }
+
+    @Test @MainActor func `scope casks hides formulae`() async {
+        let vm = await InstalledFeatureTestSupport.loadedViewModel(
+            formulae: [.fixture(name: "git", kind: .formula)],
+            casks: [
+                .fixture(name: "slack", kind: .cask),
+                .fixture(name: "docker", kind: .cask),
+            ],
+        )
+
+        vm.scope = .casks
+
+        #expect(vm.loadedFormulaPackages.isEmpty)
+        #expect(vm.loadedCaskPackages.map(\.name) == ["slack", "docker"])
+        #expect(vm.totalPackageCount == 2)
+    }
+
+    @Test @MainActor func `scope composes with the search query`() async {
+        let vm = await InstalledFeatureTestSupport.loadedViewModel(
+            formulae: [
+                .fixture(name: "git", kind: .formula),
+                .fixture(name: "wget", kind: .formula),
+            ],
+            casks: [.fixture(name: "github", kind: .cask)],
+        )
+
+        vm.scope = .formulae
+        vm.searchQuery = "git"
+
+        // The cask "github" matches the query but is excluded by the formulae scope.
+        #expect(vm.loadedFormulaPackages.map(\.name) == ["git"])
+        #expect(vm.loadedCaskPackages.isEmpty)
+    }
+
+    @Test @MainActor func `packageCountSubtitle reflects the scoped count`() async {
+        let vm = await InstalledFeatureTestSupport.loadedViewModel(
+            formulae: [.fixture(name: "git", kind: .formula)],
+            casks: [
+                .fixture(name: "slack", kind: .cask),
+                .fixture(name: "docker", kind: .cask),
+            ],
+        )
+
+        vm.scope = .formulae
+        #expect(vm.packageCountSubtitle == "1 package")
+
+        vm.scope = .casks
+        #expect(vm.packageCountSubtitle == "2 packages")
+    }
+
+    @Test @MainActor func `selection falls back to first visible row when scope hides it`() async {
+        let vm = await InstalledFeatureTestSupport.loadedViewModel(
+            formulae: [.fixture(name: "git", kind: .formula)],
+            casks: [.fixture(name: "slack", kind: .cask)],
+        )
+        vm.setSelection(.cask(token: "slack"))
+        #expect(vm.activeSelectedPackageID == .cask(token: "slack"))
+
+        // Scoping to formulae hides the selected cask; the always-on selection falls back to the
+        // first visible formula.
+        vm.scope = .formulae
+        #expect(vm.activeSelectedPackageID == .formula(name: "git"))
+    }
+
+    @Test @MainActor func `widening scope restores the previously scoped-out selection`() async {
+        let vm = await InstalledFeatureTestSupport.loadedViewModel(
+            formulae: [.fixture(name: "git", kind: .formula)],
+            casks: [.fixture(name: "slack", kind: .cask)],
+        )
+        vm.setSelection(.cask(token: "slack"))
+
+        vm.scope = .formulae
+        #expect(vm.activeSelectedPackageID == .formula(name: "git"))
+
+        // The committed cask selection was never mutated, so widening the scope brings it back.
+        vm.scope = .all
+        #expect(vm.activeSelectedPackageID == .cask(token: "slack"))
+    }
+
+    @Test @MainActor func `scope change re-homes the search preview to the first visible row`() async {
+        let vm = await InstalledFeatureTestSupport.loadedViewModel(
+            formulae: [.fixture(name: "gitui", kind: .formula)],
+            casks: [.fixture(name: "github", kind: .cask)],
+        )
+
+        vm.searchQuery = "git"
+        // Preview lands on the first visible row across both kinds (formula first).
+        #expect(vm.activeSelectedPackageID == .formula(name: "gitui"))
+
+        vm.scope = .casks
+        // With formulae scoped out, the preview re-homes to the first visible cask.
+        #expect(vm.activeSelectedPackageID == .cask(token: "github"))
+    }
+}

--- a/Tests/BrewFeatureInstalledTests/InstalledViewModelTests.swift
+++ b/Tests/BrewFeatureInstalledTests/InstalledViewModelTests.swift
@@ -297,4 +297,26 @@ struct InstalledViewModelTests {
 
         #expect(!vm.shouldFocusList)
     }
+
+    @Test @MainActor func `shouldFocusList is false while the search field is presented`() async {
+        let vm = await InstalledFeatureTestSupport.loadedViewModel(
+            formulae: [.fixture(name: "git", kind: .formula)],
+        )
+
+        vm.isSearchFieldPresented = true
+
+        #expect(!vm.shouldFocusList)
+    }
+
+    @Test @MainActor func `shouldFocusList returns to true once the search field is dismissed`() async {
+        let vm = await InstalledFeatureTestSupport.loadedViewModel(
+            formulae: [.fixture(name: "git", kind: .formula)],
+        )
+
+        vm.isSearchFieldPresented = true
+        #expect(!vm.shouldFocusList)
+
+        vm.isSearchFieldPresented = false
+        #expect(vm.shouldFocusList)
+    }
 }

--- a/Tests/BrewFeatureInstalledTests/UpgradesViewModelScopeTests.swift
+++ b/Tests/BrewFeatureInstalledTests/UpgradesViewModelScopeTests.swift
@@ -1,0 +1,333 @@
+//
+//  UpgradesViewModelScopeTests.swift
+//  BrewTests
+//
+
+import BrewCore
+import BrewCoreTestSupport
+@testable import BrewFeatureInstalled
+import BrewRepositoryInterfaces
+import Foundation
+import Testing
+
+struct UpgradesViewModelScopeTests {
+    // MARK: - Filtering
+
+    @Test @MainActor func `scope defaults to all and shows both outdated kinds`() {
+        let vm = Self.makeViewModel(packages: Self.mixedOutdated)
+
+        #expect(vm.scope == .all)
+        guard case let .loaded(content) = vm.state else {
+            Issue.record("expected loaded state")
+            return
+        }
+        #expect(content.formulaPackages.map(\.name) == ["git"])
+        #expect(content.caskPackages.map(\.name) == ["slack"])
+        #expect(vm.outdatedCount == 2)
+    }
+
+    @Test @MainActor func `scope formulae hides outdated casks`() {
+        let vm = Self.makeViewModel(packages: Self.mixedOutdated)
+
+        vm.scope = .formulae
+
+        guard case let .loaded(content) = vm.state else {
+            Issue.record("expected loaded state")
+            return
+        }
+        #expect(content.formulaPackages.map(\.name) == ["git"])
+        #expect(content.caskPackages.isEmpty)
+        #expect(vm.outdatedCount == 1)
+        // The unfiltered total is unaffected by the scope filter.
+        #expect(vm.totalOutdatedCount == 2)
+    }
+
+    @Test @MainActor func `scope casks hides outdated formulae`() {
+        let vm = Self.makeViewModel(packages: Self.mixedOutdated)
+
+        vm.scope = .casks
+
+        guard case let .loaded(content) = vm.state else {
+            Issue.record("expected loaded state")
+            return
+        }
+        #expect(content.formulaPackages.isEmpty)
+        #expect(content.caskPackages.map(\.name) == ["slack"])
+        #expect(vm.outdatedCount == 1)
+    }
+
+    @Test @MainActor func `scope composes with the search query`() {
+        let vm = Self.makeViewModel(packages: [
+            .fixture(name: "git", kind: .formula, outdated: true),
+            .fixture(name: "wget", kind: .formula, outdated: true),
+            .fixture(name: "github", kind: .cask, outdated: true),
+        ])
+
+        vm.scope = .formulae
+        vm.searchQuery = "git"
+
+        // "github" matches the query but is excluded by the formulae scope.
+        guard case let .loaded(content) = vm.state else {
+            Issue.record("expected loaded state")
+            return
+        }
+        #expect(content.packages.map(\.name) == ["git"])
+        #expect(vm.outdatedCount == 1)
+    }
+
+    // MARK: - Subtitle
+
+    @Test @MainActor func `outdatedSubtitle switches to Showing N of M when scoped`() {
+        let vm = Self.makeViewModel(packages: Self.mixedOutdated)
+
+        vm.scope = .formulae
+
+        #expect(vm.outdatedSubtitle == "Showing 1 of 2 upgrades")
+    }
+
+    @Test @MainActor func `outdatedSubtitle reports no matches when the scope hides everything`() {
+        let vm = Self.makeViewModel(packages: [
+            .fixture(name: "git", kind: .formula, outdated: true),
+            .fixture(name: "wget", kind: .formula, outdated: true),
+        ])
+
+        vm.scope = .casks
+
+        #expect(vm.outdatedSubtitle == "No matches in 2 outdated packages")
+    }
+
+    // MARK: - isFiltering / resetFilters
+
+    @Test @MainActor func `isFiltering reflects scope and search`() {
+        let vm = Self.makeViewModel(packages: Self.mixedOutdated)
+        #expect(!vm.isFiltering)
+
+        vm.scope = .casks
+        #expect(vm.isFiltering)
+
+        vm.scope = .all
+        vm.searchQuery = "git"
+        #expect(vm.isFiltering)
+    }
+
+    @Test @MainActor func `resetFilters clears both the scope and the search`() {
+        let vm = Self.makeViewModel(packages: Self.mixedOutdated)
+        vm.scope = .casks
+        vm.searchQuery = "slack"
+
+        vm.resetFilters()
+
+        #expect(vm.scope == .all)
+        #expect(vm.searchQuery.isEmpty)
+        #expect(!vm.isFiltering)
+    }
+
+    // MARK: - Selection
+
+    @Test @MainActor func `selection falls back to first visible row when scope hides it`() {
+        let vm = Self.makeViewModel(packages: Self.mixedOutdated)
+        vm.setSelection(.cask(token: "slack"))
+        #expect(vm.activeSelectedPackageID == .cask(token: "slack"))
+
+        vm.scope = .formulae
+        #expect(vm.activeSelectedPackageID == .formula(name: "git"))
+
+        // Committed selection is untouched, so widening the scope restores it.
+        vm.scope = .all
+        #expect(vm.activeSelectedPackageID == .cask(token: "slack"))
+    }
+
+    // MARK: - upgradeSelection
+
+    @Test @MainActor func `upgradeSelection is all when unfiltered`() {
+        let vm = Self.makeViewModel(packages: Self.mixedOutdated)
+        #expect(vm.upgradeSelection == .all)
+        #expect(vm.bulkUpgradeDisplayCommand == "brew upgrade")
+    }
+
+    @Test @MainActor func `upgradeSelection maps the scope picker to a kind flag`() {
+        let vm = Self.makeViewModel(packages: Self.mixedOutdated)
+
+        vm.scope = .formulae
+        #expect(vm.upgradeSelection == .formulae)
+        #expect(vm.bulkUpgradeDisplayCommand == "brew upgrade --formula")
+
+        vm.scope = .casks
+        #expect(vm.upgradeSelection == .casks)
+        #expect(vm.bulkUpgradeDisplayCommand == "brew upgrade --cask")
+    }
+
+    @Test @MainActor func `upgradeSelection lists visible names when searching`() {
+        let vm = Self.makeViewModel(packages: [
+            .fixture(name: "git", kind: .formula, outdated: true),
+            .fixture(name: "wget", kind: .formula, outdated: true),
+            .fixture(name: "github", kind: .cask, outdated: true),
+        ])
+
+        vm.searchQuery = "git"
+
+        // Visible rows in display order (formulae then casks): git, github.
+        #expect(vm.upgradeSelection == .explicit(["git", "github"]))
+        #expect(vm.bulkUpgradeDisplayCommand == "brew upgrade git github")
+    }
+
+    @Test @MainActor func `upgradeSelection prefers names when both a scope and a search are active`() {
+        let vm = Self.makeViewModel(packages: [
+            .fixture(name: "git", kind: .formula, outdated: true),
+            .fixture(name: "wget", kind: .formula, outdated: true),
+            .fixture(name: "github", kind: .cask, outdated: true),
+        ])
+
+        vm.scope = .formulae
+        vm.searchQuery = "git"
+
+        // Search takes precedence: only the visible (scoped + searched) formula name.
+        #expect(vm.upgradeSelection == .explicit(["git"]))
+    }
+
+    // MARK: - upgradeAll submission
+
+    @Test @MainActor func `upgradeAll submits the scoped selection as both id and command`() async {
+        let recorder = SubmitRecordingCommandCenter()
+        let vm = UpgradesViewModel(
+            repository: StubInstalledPackagesRepository(packages: Self.mixedOutdated),
+            brewCommandCenter: recorder,
+            commandFactory: StubMutatingCommandFactory(),
+        )
+        vm.scope = .formulae
+
+        vm.upgradeAll()
+        // `upgradeAll` submits from a detached Task; yield so it runs before polling the recorder.
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+        await recorder.waitForSubmitCallCount(1)
+
+        let entries = await recorder.recordedSubmitEntries
+        #expect(entries.count == 1)
+        #expect(entries.first?.id == .bulkUpgrade(.formulae))
+        #expect(entries.first?.kind == .upgradeAll)
+    }
+
+    @Test @MainActor func `upgradeAll submits explicit names when searching`() async {
+        let recorder = SubmitRecordingCommandCenter()
+        let vm = UpgradesViewModel(
+            repository: StubInstalledPackagesRepository(packages: [
+                .fixture(name: "git", kind: .formula, outdated: true),
+                .fixture(name: "github", kind: .cask, outdated: true),
+            ]),
+            brewCommandCenter: recorder,
+            commandFactory: StubMutatingCommandFactory(),
+        )
+        vm.searchQuery = "git"
+
+        vm.upgradeAll()
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+        await recorder.waitForSubmitCallCount(1)
+
+        let entries = await recorder.recordedSubmitEntries
+        #expect(entries.first?.id == .bulkUpgrade(.explicit(["git", "github"])))
+    }
+
+    @Test @MainActor func `isUpgradingAny tracks a scoped bulk upgrade id`() async {
+        let center = PhaseStreamingScopeCommandCenter()
+        let vm = UpgradesViewModel(
+            repository: StubInstalledPackagesRepository(packages: Self.mixedOutdated),
+            brewCommandCenter: center,
+            commandFactory: StubMutatingCommandFactory(),
+        )
+        await center.waitForSubscriber()
+
+        await center.emit(id: .bulkUpgrade(.formulae), phase: .running(.upgradeAll))
+        await Self.waitUntil { vm.isUpgradingAny }
+        #expect(vm.isUpgradingAny)
+
+        await center.emit(id: .bulkUpgrade(.formulae), phase: .idle)
+        await Self.waitUntil { !vm.isUpgradingAny }
+        #expect(!vm.isUpgradingAny)
+    }
+
+    // MARK: - Helpers
+
+    private static var mixedOutdated: [InstalledBrewPackage] {
+        [
+            .fixture(name: "git", kind: .formula, outdated: true),
+            .fixture(name: "wget", kind: .formula, outdated: false),
+            .fixture(name: "slack", kind: .cask, outdated: true),
+            .fixture(name: "docker", kind: .cask, outdated: false),
+        ]
+    }
+
+    @MainActor
+    private static func makeViewModel(packages: [InstalledBrewPackage]) -> UpgradesViewModel {
+        UpgradesViewModel(
+            repository: StubInstalledPackagesRepository(packages: packages),
+            brewCommandCenter: StubBrewCommandCenter(),
+            commandFactory: StubMutatingCommandFactory(),
+        )
+    }
+
+    @MainActor
+    private static func waitUntil(_ condition: () -> Bool) async {
+        for _ in 0 ..< 200 {
+            if condition() { return }
+            await Task.yield()
+        }
+    }
+}
+
+/// Live phase stream the scope tests drive by hand — mirrors the one in `UpgradesViewModelTests` but is
+/// kept private to this file to avoid cross-file coupling.
+private actor PhaseStreamingScopeCommandCenter: BrewCommandCenter {
+    typealias PhaseEvent = (BrewOperationID, BrewOperationPhase)
+
+    private let phaseStream: AsyncStream<PhaseEvent>
+    private let phaseContinuation: AsyncStream<PhaseEvent>.Continuation
+    private var subscribed = false
+    private var subscriberWaiters: [CheckedContinuation<Void, Never>] = []
+
+    init() {
+        let (stream, continuation) = AsyncStream<PhaseEvent>.makeStream()
+        phaseStream = stream
+        phaseContinuation = continuation
+    }
+
+    func phase(for _: BrewOperationID) async -> BrewOperationPhase { .idle }
+    func phaseByID() async -> [BrewOperationID: BrewOperationPhase] { [:] }
+    func isActive(id _: BrewOperationID) async -> Bool { false }
+    func submit(id _: BrewOperationID, command _: any BrewMutatingCommand) async throws {}
+
+    func phaseChanges(for _: BrewOperationID) async -> AsyncStream<BrewOperationPhase> {
+        AsyncStream { $0.finish() }
+    }
+
+    func allPhaseChanges() async -> AsyncStream<PhaseEvent> {
+        subscribed = true
+        for waiter in subscriberWaiters {
+            waiter.resume()
+        }
+        subscriberWaiters.removeAll()
+        return phaseStream
+    }
+
+    func outputChanges(for _: BrewOperationID) async -> AsyncStream<BrewCommandOutputLine> {
+        AsyncStream { $0.finish() }
+    }
+
+    func allOutputChanges() async -> AsyncStream<(BrewOperationID, BrewCommandOutputLine)> {
+        AsyncStream { $0.finish() }
+    }
+
+    func emit(id: BrewOperationID, phase: BrewOperationPhase) {
+        phaseContinuation.yield((id, phase))
+    }
+
+    func waitForSubscriber() async {
+        if subscribed { return }
+        await withCheckedContinuation { continuation in
+            subscriberWaiters.append(continuation)
+        }
+    }
+}

--- a/Tests/BrewFeatureInstalledTests/UpgradesViewModelScopeTests.swift
+++ b/Tests/BrewFeatureInstalledTests/UpgradesViewModelScopeTests.swift
@@ -294,9 +294,18 @@ private actor PhaseStreamingScopeCommandCenter: BrewCommandCenter {
         phaseContinuation = continuation
     }
 
-    func phase(for _: BrewOperationID) async -> BrewOperationPhase { .idle }
-    func phaseByID() async -> [BrewOperationID: BrewOperationPhase] { [:] }
-    func isActive(id _: BrewOperationID) async -> Bool { false }
+    func phase(for _: BrewOperationID) async -> BrewOperationPhase {
+        .idle
+    }
+
+    func phaseByID() async -> [BrewOperationID: BrewOperationPhase] {
+        [:]
+    }
+
+    func isActive(id _: BrewOperationID) async -> Bool {
+        false
+    }
+
     func submit(id _: BrewOperationID, command _: any BrewMutatingCommand) async throws {}
 
     func phaseChanges(for _: BrewOperationID) async -> AsyncStream<BrewOperationPhase> {

--- a/Tests/BrewFeatureInstalledTests/UpgradesViewModelTests.swift
+++ b/Tests/BrewFeatureInstalledTests/UpgradesViewModelTests.swift
@@ -144,7 +144,7 @@ struct UpgradesViewModelTests {
 
         let entries = await recorder.recordedSubmitEntries
         #expect(entries.count == 1)
-        #expect(entries.first?.id == .bulkUpgrade)
+        #expect(entries.first?.id == .bulkUpgrade(.all))
         #expect(entries.first?.kind == .upgradeAll)
     }
 
@@ -233,11 +233,11 @@ struct UpgradesViewModelTests {
         // Wait for the observer to subscribe to allPhaseChanges before emitting.
         await center.waitForSubscriber()
 
-        await center.emit(id: .bulkUpgrade, phase: .running(.upgradeAll))
+        await center.emit(id: .bulkUpgrade(.all), phase: .running(.upgradeAll))
         await Self.waitUntil { vm.isUpgradingAny }
         #expect(vm.isUpgradingAny)
 
-        await center.emit(id: .bulkUpgrade, phase: .idle)
+        await center.emit(id: .bulkUpgrade(.all), phase: .idle)
         await Self.waitUntil { !vm.isUpgradingAny }
         #expect(!vm.isUpgradingAny)
     }

--- a/Tests/BrewFeatureInstalledTests/UpgradesViewModelTests.swift
+++ b/Tests/BrewFeatureInstalledTests/UpgradesViewModelTests.swift
@@ -361,6 +361,38 @@ struct UpgradesViewModelTests {
         #expect(!vm.shouldFocusList)
     }
 
+    @Test @MainActor func `shouldFocusList is false while the search field is presented`() {
+        let vm = Self.makeViewModel(packages: Self.mixedPackages)
+
+        vm.isSearchFieldPresented = true
+
+        // The list would otherwise steal focus when it re-appears after a query that filtered every
+        // row is deleted; gating on search presentation keeps the cursor in the search box.
+        #expect(!vm.shouldFocusList)
+    }
+
+    @Test @MainActor func `shouldFocusList returns to true once the search field is dismissed`() {
+        let vm = Self.makeViewModel(packages: Self.mixedPackages)
+
+        vm.isSearchFieldPresented = true
+        #expect(!vm.shouldFocusList)
+
+        vm.isSearchFieldPresented = false
+        #expect(vm.shouldFocusList)
+    }
+
+    @Test @MainActor func `shouldFocusList stays false when the search field is presented but not loaded`() {
+        let vm = UpgradesViewModel(
+            repository: StubInstalledPackagesRepository(state: .loading),
+            brewCommandCenter: StubBrewCommandCenter(),
+            commandFactory: StubMutatingCommandFactory(),
+        )
+
+        vm.isSearchFieldPresented = true
+
+        #expect(!vm.shouldFocusList)
+    }
+
     // MARK: - Helpers
 
     private static var mixedPackages: [InstalledBrewPackage] {

--- a/Tests/BrewNetworkingTests/BrewAPIClientURLSessionIntegrationTests.swift
+++ b/Tests/BrewNetworkingTests/BrewAPIClientURLSessionIntegrationTests.swift
@@ -10,49 +10,70 @@ import Foundation
 import Testing
 
 struct BrewAPIClientURLSessionIntegrationTests {
-    @Test @MainActor func `fetch formula analytics decodes payload`() async throws {
+    @Test @MainActor func `fetch formula analytics returns raw body`() async throws {
         let baseURL = makeStubBaseURL()
         let expectedURL = URL(
             string: "/api/analytics/install-on-request/homebrew-core/30d.json",
             relativeTo: baseURL,
         )?.absoluteURL
+        let body = Data(
+            """
+            {
+              "category": "formula_install_on_request",
+              "total_items": 2,
+              "total_count": 1200,
+              "start_date": "2026-04-17",
+              "end_date": "2026-05-17",
+              "formulae": {
+                "wget": [{ "formula": "wget", "count": "1,000" }],
+                "bat": [{ "formula": "bat", "count": "200" }]
+              }
+            }
+            """.utf8,
+        )
         try StubURLProtocol.register(
-            [
-                .successWithStatus(
-                    data: Data(
-                        """
-                        {
-                          "category": "formula_install_on_request",
-                          "total_items": 2,
-                          "total_count": 1200,
-                          "start_date": "2026-04-17",
-                          "end_date": "2026-05-17",
-                          "formulae": {
-                            "wget": [{ "formula": "wget", "count": "1,000" }],
-                            "bat": [{ "formula": "bat", "count": "200" }]
-                          }
-                        }
-                        """.utf8,
-                    ),
-                    statusCode: 200,
-                ),
-            ],
+            [.successWithStatus(data: body, statusCode: 200)],
             forHost: #require(baseURL.host),
         )
         let session = makeStubbedSession()
         let client = URLSessionBrewAPIClient(session: session, baseURL: baseURL)
 
-        let result = try await client.fetchFormulaInstallOnRequestAnalytics(window: .days30)
+        let response = try await client.fetchFormulaInstallOnRequestAnalytics(window: .days30, etag: nil)
         let requests = try StubURLProtocol.requests(forHost: #require(baseURL.host))
         #expect(requests.count == 1)
         #expect(requests.first?.url == expectedURL)
         #expect(requests.first?.httpMethod == "GET")
-        #expect(result.category == "formula_install_on_request")
-        #expect(result.totalCount == 1200)
 
-        let countsByName = Dictionary(uniqueKeysWithValues: result.packageCounts.map { ($0.name, $0.count) })
-        #expect(countsByName["wget"] == 1000)
-        #expect(countsByName["bat"] == 200)
+        guard case let .updated(data: data, etag: _) = response else {
+            Issue.record("Expected updated analytics payload")
+            return
+        }
+        // The client hands back the response verbatim so callers can persist it byte-for-byte.
+        #expect(data == body)
+        let decoded = try JSONDecoder().decode(BrewAnalyticsJSON.self, from: data)
+        #expect(decoded.category == "formula_install_on_request")
+        #expect(decoded.totalCount == 1200)
+    }
+
+    @Test @MainActor func `fetch analytics forwards etag as conditional request header`() async throws {
+        let baseURL = makeStubBaseURL()
+        try StubURLProtocol.register(
+            [.successWithStatus(data: Data(), statusCode: 304)],
+            forHost: #require(baseURL.host),
+        )
+        let session = makeStubbedSession()
+        let client = URLSessionBrewAPIClient(session: session, baseURL: baseURL)
+
+        let response = try await client.fetchFormulaInstallOnRequestAnalytics(
+            window: .days30,
+            etag: #""cached-etag""#,
+        )
+        let requests = try StubURLProtocol.requests(forHost: #require(baseURL.host))
+        #expect(requests.first?.value(forHTTPHeaderField: "If-None-Match") == #""cached-etag""#)
+        guard case .notModified = response else {
+            Issue.record("Expected notModified for a 304 response")
+            return
+        }
     }
 
     @Test @MainActor func `fetch cask analytics hits cask endpoint`() async throws {
@@ -86,7 +107,7 @@ struct BrewAPIClientURLSessionIntegrationTests {
         let session = makeStubbedSession()
         let client = URLSessionBrewAPIClient(session: session, baseURL: baseURL)
 
-        _ = try await client.fetchCaskInstallAnalytics(window: .days90)
+        _ = try await client.fetchCaskInstallAnalytics(window: .days90, etag: nil)
         let requests = try StubURLProtocol.requests(forHost: #require(baseURL.host))
         #expect(requests.first?.url == expectedURL)
     }
@@ -96,54 +117,28 @@ struct BrewAPIClientURLSessionIntegrationTests {
         let host = try #require(baseURL.host)
         StubURLProtocol.registerByPath(
             [
-                "/api/analytics/install-on-request/homebrew-core/30d.json": .successWithStatus(
-                    data: Data(
-                        """
-                        {
-                          "category": "formula_install_on_request",
-                          "total_items": 1,
-                          "total_count": 100,
-                          "start_date": "2026-04-17",
-                          "end_date": "2026-05-17",
-                          "formulae": {
-                            "wget": [{ "formula": "wget", "count": "100" }]
-                          }
-                        }
-                        """.utf8,
-                    ),
-                    statusCode: 200,
-                ),
-                "/api/analytics/cask-install/homebrew-cask/30d.json": .successWithStatus(
-                    data: Data(
-                        """
-                        {
-                          "category": "cask_install",
-                          "total_items": 1,
-                          "total_count": 50,
-                          "start_date": "2026-04-17",
-                          "end_date": "2026-05-17",
-                          "formulae": {
-                            "iterm2": [{ "cask": "iterm2", "count": "50" }]
-                          }
-                        }
-                        """.utf8,
-                    ),
-                    statusCode: 200,
-                ),
+                "/api/analytics/install-on-request/homebrew-core/30d.json": Self.formulaAnalyticsStub(name: "wget"),
+                "/api/analytics/cask-install/homebrew-cask/30d.json": Self.caskAnalyticsStub(name: "iterm2"),
             ],
             forHost: host,
         )
         let session = makeStubbedSession()
         let client = URLSessionBrewAPIClient(session: session, baseURL: baseURL)
 
-        async let formulaAnalytics = client.fetchFormulaInstallOnRequestAnalytics(window: .days30)
-        async let caskAnalytics = client.fetchCaskInstallAnalytics(window: .days30)
+        async let formulaAnalytics = client.fetchFormulaInstallOnRequestAnalytics(window: .days30, etag: nil)
+        async let caskAnalytics = client.fetchCaskInstallAnalytics(window: .days30, etag: nil)
 
-        let formulaResult = try await formulaAnalytics
-        let caskResult = try await caskAnalytics
+        guard case let .updated(data: formulaData, etag: _) = try await formulaAnalytics,
+              case let .updated(data: caskData, etag: _) = try await caskAnalytics
+        else {
+            Issue.record("Expected updated analytics payloads")
+            return
+        }
 
-        #expect(formulaResult.packageCounts.first?.name == "wget")
-        #expect(caskResult.packageCounts.first?.name == "iterm2")
+        let formula = try JSONDecoder().decode(BrewAnalyticsJSON.self, from: formulaData)
+        let cask = try JSONDecoder().decode(BrewAnalyticsJSON.self, from: caskData)
+        #expect(formula.packageCounts.first?.name == "wget")
+        #expect(cask.packageCounts.first?.name == "iterm2")
         #expect(StubURLProtocol.requests(forHost: host).count == 2)
     }
 
@@ -157,116 +152,7 @@ struct BrewAPIClientURLSessionIntegrationTests {
         let client = URLSessionBrewAPIClient(session: session, baseURL: baseURL)
 
         await #expect(throws: BrewAPIClientError.self) {
-            _ = try await client.fetchFormulaInstallOnRequestAnalytics(window: .days30)
-        }
-    }
-
-    @Test @MainActor func `fetch throws decoding error for invalid JSON`() async throws {
-        let baseURL = makeStubBaseURL()
-        try StubURLProtocol.register(
-            [.successWithStatus(data: Data("{ this-is-not-json }".utf8), statusCode: 200)],
-            forHost: #require(baseURL.host),
-        )
-        let session = makeStubbedSession()
-        let client = URLSessionBrewAPIClient(session: session, baseURL: baseURL)
-
-        await #expect(throws: BrewAPIClientError.self) {
-            _ = try await client.fetchFormulaInstallOnRequestAnalytics(window: .days30)
-        }
-    }
-
-    @Test @MainActor func `fetch throws decoding error when required fields are missing`() async throws {
-        let baseURL = makeStubBaseURL()
-        try StubURLProtocol.register(
-            [
-                .successWithStatus(
-                    data: Data(
-                        """
-                        {
-                          "category": "formula_install_on_request",
-                          "total_items": 2,
-                          "start_date": "2026-04-17",
-                          "end_date": "2026-05-17",
-                          "formulae": {
-                            "wget": [{ "formula": "wget", "count": "1000" }]
-                          }
-                        }
-                        """.utf8,
-                    ),
-                    statusCode: 200,
-                ),
-            ],
-            forHost: #require(baseURL.host),
-        )
-        let session = makeStubbedSession()
-        let client = URLSessionBrewAPIClient(session: session, baseURL: baseURL)
-
-        await #expect(throws: BrewAPIClientError.self) {
-            _ = try await client.fetchFormulaInstallOnRequestAnalytics(window: .days30)
-        }
-    }
-
-    @Test @MainActor func `fetch throws decoding error when entry count is malformed`() async throws {
-        let baseURL = makeStubBaseURL()
-        try StubURLProtocol.register(
-            [
-                .successWithStatus(
-                    data: Data(
-                        """
-                        {
-                          "category": "formula_install_on_request",
-                          "total_items": 2,
-                          "total_count": 1200,
-                          "start_date": "2026-04-17",
-                          "end_date": "2026-05-17",
-                          "formulae": {
-                            "wget": [{ "formula": "wget", "count": "not-a-number" }]
-                          }
-                        }
-                        """.utf8,
-                    ),
-                    statusCode: 200,
-                ),
-            ],
-            forHost: #require(baseURL.host),
-        )
-        let session = makeStubbedSession()
-        let client = URLSessionBrewAPIClient(session: session, baseURL: baseURL)
-
-        await #expect(throws: BrewAPIClientError.self) {
-            _ = try await client.fetchFormulaInstallOnRequestAnalytics(window: .days30)
-        }
-    }
-
-    @Test @MainActor func `fetch throws decoding error when entry package identity is missing`() async throws {
-        let baseURL = makeStubBaseURL()
-        try StubURLProtocol.register(
-            [
-                .successWithStatus(
-                    data: Data(
-                        """
-                        {
-                          "category": "formula_install_on_request",
-                          "total_items": 2,
-                          "total_count": 1200,
-                          "start_date": "2026-04-17",
-                          "end_date": "2026-05-17",
-                          "formulae": {
-                            "wget": [{ "count": "1000" }]
-                          }
-                        }
-                        """.utf8,
-                    ),
-                    statusCode: 200,
-                ),
-            ],
-            forHost: #require(baseURL.host),
-        )
-        let session = makeStubbedSession()
-        let client = URLSessionBrewAPIClient(session: session, baseURL: baseURL)
-
-        await #expect(throws: BrewAPIClientError.self) {
-            _ = try await client.fetchFormulaInstallOnRequestAnalytics(window: .days30)
+            _ = try await client.fetchFormulaInstallOnRequestAnalytics(window: .days30, etag: nil)
         }
     }
 
@@ -280,7 +166,7 @@ struct BrewAPIClientURLSessionIntegrationTests {
         let client = URLSessionBrewAPIClient(session: session, baseURL: baseURL)
 
         await #expect(throws: BrewAPIClientError.self) {
-            _ = try await client.fetchFormulaInstallOnRequestAnalytics(window: .days30)
+            _ = try await client.fetchFormulaInstallOnRequestAnalytics(window: .days30, etag: nil)
         }
     }
 
@@ -305,7 +191,47 @@ struct BrewAPIClientURLSessionIntegrationTests {
         let client = URLSessionBrewAPIClient(session: session, baseURL: baseURL)
 
         await #expect(throws: BrewAPIClientError.self) {
-            _ = try await client.fetchFormulaInstallOnRequestAnalytics(window: .days30)
+            _ = try await client.fetchFormulaInstallOnRequestAnalytics(window: .days30, etag: nil)
         }
+    }
+
+    private static func formulaAnalyticsStub(name: String) -> StubURLProtocol.StubbedResult {
+        .successWithStatus(
+            data: Data(
+                """
+                {
+                  "category": "formula_install_on_request",
+                  "total_items": 1,
+                  "total_count": 100,
+                  "start_date": "2026-04-17",
+                  "end_date": "2026-05-17",
+                  "formulae": {
+                    "\(name)": [{ "formula": "\(name)", "count": "100" }]
+                  }
+                }
+                """.utf8,
+            ),
+            statusCode: 200,
+        )
+    }
+
+    private static func caskAnalyticsStub(name: String) -> StubURLProtocol.StubbedResult {
+        .successWithStatus(
+            data: Data(
+                """
+                {
+                  "category": "cask_install",
+                  "total_items": 1,
+                  "total_count": 50,
+                  "start_date": "2026-04-17",
+                  "end_date": "2026-05-17",
+                  "formulae": {
+                    "\(name)": [{ "cask": "\(name)", "count": "50" }]
+                  }
+                }
+                """.utf8,
+            ),
+            statusCode: 200,
+        )
     }
 }

--- a/Tests/BrewNetworkingTests/DiscoverAnalyticsCacheTests.swift
+++ b/Tests/BrewNetworkingTests/DiscoverAnalyticsCacheTests.swift
@@ -1,0 +1,158 @@
+//
+//  DiscoverAnalyticsCacheTests.swift
+//  BrewTests
+//
+
+import BrewCore
+import BrewCoreTestSupport
+@testable import BrewNetworking
+import Foundation
+import Testing
+
+struct DiscoverAnalyticsCacheTests {
+    @Test @MainActor func `analytics data is nil before any write`() async {
+        let fixture = TestFixture()
+        defer { fixture.cleanup() }
+        let cache = fixture.makeCache()
+
+        #expect(await cache.formulaAnalyticsData(window: .days30) == nil)
+        #expect(await cache.caskAnalyticsData(window: .days30) == nil)
+        #expect(await cache.etag(for: .formula, window: .days30) == nil)
+    }
+
+    @Test @MainActor func `update persists raw body and etag`() async throws {
+        let fixture = TestFixture()
+        defer { fixture.cleanup() }
+        let cache = fixture.makeCache()
+        let formulaBody = fixture.analyticsJSON(name: "wget", kind: .formula)
+        let caskBody = fixture.analyticsJSON(name: "iterm2", kind: .cask)
+
+        try await cache.updateFormulaAnalytics(window: .days30, with: formulaBody, etag: #""formula-etag""#)
+        try await cache.updateCaskAnalytics(window: .days30, with: caskBody, etag: #""cask-etag""#)
+
+        #expect(await cache.formulaAnalyticsData(window: .days30) == formulaBody)
+        #expect(await cache.caskAnalyticsData(window: .days30) == caskBody)
+        #expect(await cache.etag(for: .formula, window: .days30) == #""formula-etag""#)
+        #expect(await cache.etag(for: .cask, window: .days30) == #""cask-etag""#)
+
+        let persisted = try Data(contentsOf: fixture.cacheURL(kind: .formula, window: .days30))
+        #expect(persisted == formulaBody)
+    }
+
+    @Test @MainActor func `update overwrites previous bytes and etag`() async throws {
+        let fixture = TestFixture()
+        defer { fixture.cleanup() }
+        let cache = fixture.makeCache()
+
+        try await cache.updateFormulaAnalytics(
+            window: .days30,
+            with: fixture.analyticsJSON(name: "stale", kind: .formula),
+            etag: #""stale""#,
+        )
+        let fresh = fixture.analyticsJSON(name: "fresh", kind: .formula)
+        try await cache.updateFormulaAnalytics(window: .days30, with: fresh, etag: #""fresh""#)
+
+        #expect(await cache.formulaAnalyticsData(window: .days30) == fresh)
+        #expect(await cache.etag(for: .formula, window: .days30) == #""fresh""#)
+    }
+
+    @Test @MainActor func `analytics are keyed by window`() async throws {
+        let fixture = TestFixture()
+        defer { fixture.cleanup() }
+        let cache = fixture.makeCache()
+        let body = fixture.analyticsJSON(name: "wget", kind: .formula)
+
+        try await cache.updateFormulaAnalytics(window: .days30, with: body, etag: nil)
+
+        #expect(await cache.formulaAnalyticsData(window: .days30) == body)
+        #expect(await cache.formulaAnalyticsData(window: .days90) == nil)
+    }
+
+    @Test @MainActor func `prepare reads analytics persisted by a previous instance`() async throws {
+        let fixture = TestFixture()
+        defer { fixture.cleanup() }
+
+        // First "launch" writes to disk.
+        let writer = fixture.makeCache()
+        let formulaBody = fixture.analyticsJSON(name: "wget", kind: .formula)
+        try await writer.updateFormulaAnalytics(window: .days30, with: formulaBody, etag: #""formula-etag""#)
+
+        // Second "launch": a fresh instance warms itself from the persisted files.
+        let reader = fixture.makeCache()
+        await reader.prepare()
+
+        #expect(await reader.formulaAnalyticsData(window: .days30) == formulaBody)
+        #expect(await reader.etag(for: .formula, window: .days30) == #""formula-etag""#)
+    }
+
+    @Test @MainActor func `prepare does not overwrite in memory updates`() async throws {
+        let fixture = TestFixture()
+        defer { fixture.cleanup() }
+
+        try fixture.writeToDisk(
+            fixture.analyticsJSON(name: "stale", kind: .formula),
+            kind: .formula,
+            window: .days30,
+        )
+        let cache = fixture.makeCache()
+        let fresh = fixture.analyticsJSON(name: "fresh", kind: .formula)
+        try await cache.updateFormulaAnalytics(window: .days30, with: fresh, etag: nil)
+
+        await cache.prepare()
+
+        #expect(await cache.formulaAnalyticsData(window: .days30) == fresh)
+    }
+}
+
+@MainActor
+private struct TestFixture {
+    let cacheDirectoryURL: URL
+    let defaultsKeyPrefix: String
+
+    init() {
+        let id = UUID().uuidString
+        cacheDirectoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DiscoverAnalyticsCacheTests-\(id)", isDirectory: true)
+        defaultsKeyPrefix = "DiscoverAnalyticsCacheTests.\(id)"
+    }
+
+    func makeCache() -> DiscoverAnalyticsCache {
+        DiscoverAnalyticsCache(cacheDirectoryURL: cacheDirectoryURL, defaultsKeyPrefix: defaultsKeyPrefix)
+    }
+
+    func cacheURL(kind: DiscoverAnalyticsCache.AnalyticsKind, window: BrewAnalyticsWindow) -> URL {
+        cacheDirectoryURL.appendingPathComponent("\(kind.rawValue)-analytics-\(window.rawValue).json")
+    }
+
+    func writeToDisk(
+        _ data: Data,
+        kind: DiscoverAnalyticsCache.AnalyticsKind,
+        window: BrewAnalyticsWindow,
+    ) throws {
+        try FileManager.default.createDirectory(at: cacheDirectoryURL, withIntermediateDirectories: true)
+        try data.write(to: cacheURL(kind: kind, window: window), options: .atomic)
+    }
+
+    func analyticsJSON(name: String, kind: DiscoverAnalyticsCache.AnalyticsKind) -> Data {
+        let key = kind == .formula ? "formula" : "cask"
+        return Data(
+            """
+            {
+              "category": "\(kind.rawValue)_install",
+              "total_items": 1,
+              "total_count": 100,
+              "start_date": "2026-04-17",
+              "end_date": "2026-05-17",
+              "formulae": {
+                "\(name)": [{ "\(key)": "\(name)", "count": "100" }]
+              }
+            }
+            """.utf8,
+        )
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: cacheDirectoryURL)
+        UserDefaults.standard.removePersistedKeys(withPrefix: defaultsKeyPrefix)
+    }
+}

--- a/Tests/BrewRepositoriesTests/BrewAPIClientConcurrentIntegrationTests.swift
+++ b/Tests/BrewRepositoriesTests/BrewAPIClientConcurrentIntegrationTests.swift
@@ -76,8 +76,8 @@ struct BrewAPIClientConcurrentIntegrationTests {
         StubURLProtocol.registerByPath(Self.discoverEndpointStubs, forHost: host)
         let client = makeSharedClient(baseURL: baseURL)
 
-        async let formulaAnalytics = client.fetchFormulaInstallOnRequestAnalytics(window: .days30)
-        async let caskAnalytics = client.fetchCaskInstallAnalytics(window: .days30)
+        async let formulaAnalytics = client.fetchFormulaInstallOnRequestAnalytics(window: .days30, etag: nil)
+        async let caskAnalytics = client.fetchCaskInstallAnalytics(window: .days30, etag: nil)
         async let formulaCatalogue = client.fetchFormulaCatalogue(etag: nil)
         async let caskCatalogue = client.fetchCaskCatalogue(etag: nil)
 
@@ -102,6 +102,8 @@ struct BrewAPIClientConcurrentIntegrationTests {
         let discoverRepository = BrewDiscoverPackagesRepository(
             apiClient: client,
             catalogueRepository: catalogueRepository,
+            cache: InMemoryDiscoverAnalyticsCache(),
+            defaultsKeyPrefix: "DiscoverAnalyticsConcurrent.\(UUID().uuidString)",
         )
 
         async let topPackagesTask = discoverRepository.loadTopPackages(limit: 1, window: .days30)
@@ -126,8 +128,8 @@ struct BrewAPIClientConcurrentIntegrationTests {
         try await withThrowingTaskGroup(of: Void.self) { group in
             for _ in 0 ..< 24 {
                 group.addTask {
-                    async let formulaAnalytics = client.fetchFormulaInstallOnRequestAnalytics(window: .days30)
-                    async let caskAnalytics = client.fetchCaskInstallAnalytics(window: .days30)
+                    async let formulaAnalytics = client.fetchFormulaInstallOnRequestAnalytics(window: .days30, etag: nil)
+                    async let caskAnalytics = client.fetchCaskInstallAnalytics(window: .days30, etag: nil)
                     async let formulaCatalogue = client.fetchFormulaCatalogue(etag: nil)
                     async let caskCatalogue = client.fetchCaskCatalogue(etag: nil)
                     _ = try await formulaAnalytics
@@ -161,6 +163,8 @@ private func makeDiscoverRepository(
             formulaNames: formulaCatalogueNames,
             caskNames: caskCatalogueNames,
         ),
+        cache: InMemoryDiscoverAnalyticsCache(),
+        defaultsKeyPrefix: "DiscoverAnalyticsConcurrent.\(UUID().uuidString)",
     )
 }
 

--- a/Tests/BrewRepositoriesTests/BrewCatalogueRepositoryTests.swift
+++ b/Tests/BrewRepositoriesTests/BrewCatalogueRepositoryTests.swift
@@ -322,11 +322,17 @@ private actor StubCatalogueAPIClient: BrewAPIClient {
         self.caskHandler = caskHandler
     }
 
-    func fetchFormulaInstallOnRequestAnalytics(window _: BrewAnalyticsWindow) async throws -> BrewAnalyticsJSON {
+    func fetchFormulaInstallOnRequestAnalytics(
+        window _: BrewAnalyticsWindow,
+        etag _: String?,
+    ) async throws -> CatalogueResponse<Data> {
         throw BrewAPIClientError.invalidResponse
     }
 
-    func fetchCaskInstallAnalytics(window _: BrewAnalyticsWindow) async throws -> BrewAnalyticsJSON {
+    func fetchCaskInstallAnalytics(
+        window _: BrewAnalyticsWindow,
+        etag _: String?,
+    ) async throws -> CatalogueResponse<Data> {
         throw BrewAPIClientError.invalidResponse
     }
 
@@ -352,11 +358,17 @@ private actor DeferredFormulaStubCatalogueAPIClient: BrewAPIClient {
     private var formulaETags: [String?] = []
     private var continuation: CheckedContinuation<CatalogueResponse<FormulaCatalogueJSON>, Error>?
 
-    func fetchFormulaInstallOnRequestAnalytics(window _: BrewAnalyticsWindow) async throws -> BrewAnalyticsJSON {
+    func fetchFormulaInstallOnRequestAnalytics(
+        window _: BrewAnalyticsWindow,
+        etag _: String?,
+    ) async throws -> CatalogueResponse<Data> {
         throw BrewAPIClientError.invalidResponse
     }
 
-    func fetchCaskInstallAnalytics(window _: BrewAnalyticsWindow) async throws -> BrewAnalyticsJSON {
+    func fetchCaskInstallAnalytics(
+        window _: BrewAnalyticsWindow,
+        etag _: String?,
+    ) async throws -> CatalogueResponse<Data> {
         throw BrewAPIClientError.invalidResponse
     }
 

--- a/Tests/BrewRepositoriesTests/BrewDiscoverPackagesRepositoryTests.swift
+++ b/Tests/BrewRepositoriesTests/BrewDiscoverPackagesRepositoryTests.swift
@@ -14,12 +14,17 @@ import Foundation
 import Testing
 
 struct BrewDiscoverPackagesRepositoryTests {
+    // MARK: - Enrichment behaviour
+
     @Test @MainActor func `loadTopPackages sorts descending and applies limit`() async throws {
-        let repository = try makeRepository(
+        let prefix = uniquePrefix()
+        defer { cleanup(prefix) }
+        let (repository, _) = makeRepository(
             formulaAnalytics: DiscoverAnalyticsFixtures.threeFormulaRanking(),
             caskAnalytics: DiscoverAnalyticsFixtures.threeCaskRanking(),
             formulaCatalogueNames: ["wget", "bat", "fd"],
             caskCatalogueNames: ["iterm2", "raycast", "docker-desktop"],
+            defaultsKeyPrefix: prefix,
         )
 
         let snapshot = try await repository.loadTopPackages(limit: 2, window: .days30)
@@ -44,8 +49,10 @@ struct BrewDiscoverPackagesRepositoryTests {
     }
 
     @Test @MainActor func `loadTopPackages supports string counts and tie break sorting`() async throws {
-        let formulaAnalytics = try analytics(
-            from: """
+        let prefix = uniquePrefix()
+        defer { cleanup(prefix) }
+        let formulaAnalytics = analyticsData(
+            """
             {
               "category": "formula_install_on_request",
               "total_items": "2",
@@ -59,8 +66,8 @@ struct BrewDiscoverPackagesRepositoryTests {
             }
             """,
         )
-        let caskAnalytics = try analytics(
-            from: """
+        let caskAnalytics = analyticsData(
+            """
             {
               "category": "cask_install",
               "total_items": 1,
@@ -73,11 +80,12 @@ struct BrewDiscoverPackagesRepositoryTests {
             }
             """,
         )
-        let repository = makeRepository(
+        let (repository, _) = makeRepository(
             formulaAnalytics: formulaAnalytics,
             caskAnalytics: caskAnalytics,
             formulaCatalogueNames: ["alpha", "beta"],
             caskCatalogueNames: ["gamma"],
+            defaultsKeyPrefix: prefix,
         )
 
         let snapshot = try await repository.loadTopPackages(limit: 10, window: .days30)
@@ -88,11 +96,14 @@ struct BrewDiscoverPackagesRepositoryTests {
     }
 
     @Test @MainActor func `loadTopPackages excludes analytics entries missing from catalogue`() async throws {
-        let repository = try makeRepository(
+        let prefix = uniquePrefix()
+        defer { cleanup(prefix) }
+        let (repository, _) = makeRepository(
             formulaAnalytics: DiscoverAnalyticsFixtures.threeFormulaRanking(),
             caskAnalytics: DiscoverAnalyticsFixtures.emptyCask(),
             formulaCatalogueNames: ["bat", "wget"],
             caskCatalogueNames: [],
+            defaultsKeyPrefix: prefix,
         )
 
         let snapshot = try await repository.loadTopPackages(limit: 10, window: .days30)
@@ -104,11 +115,14 @@ struct BrewDiscoverPackagesRepositoryTests {
     }
 
     @Test @MainActor func `loadTopPackages advances past unmatched analytics to fill limit`() async throws {
-        let repository = try makeRepository(
+        let prefix = uniquePrefix()
+        defer { cleanup(prefix) }
+        let (repository, _) = makeRepository(
             formulaAnalytics: DiscoverAnalyticsFixtures.formulaRankingWithMissingTopEntry(),
             caskAnalytics: DiscoverAnalyticsFixtures.emptyCask(),
             formulaCatalogueNames: ["bat", "wget"],
             caskCatalogueNames: [],
+            defaultsKeyPrefix: prefix,
         )
 
         let snapshot = try await repository.loadTopPackages(limit: 2, window: .days30)
@@ -119,8 +133,10 @@ struct BrewDiscoverPackagesRepositoryTests {
     }
 
     @Test @MainActor func `loadTopPackages returns empty lists when limit is zero`() async throws {
-        let analyticsPayload = try analytics(
-            from: """
+        let prefix = uniquePrefix()
+        defer { cleanup(prefix) }
+        let analyticsPayload = analyticsData(
+            """
             {
               "category": "formula_install_on_request",
               "total_items": 1,
@@ -133,11 +149,12 @@ struct BrewDiscoverPackagesRepositoryTests {
             }
             """,
         )
-        let repository = makeRepository(
+        let (repository, _) = makeRepository(
             formulaAnalytics: analyticsPayload,
             caskAnalytics: analyticsPayload,
             formulaCatalogueNames: ["wget"],
             caskCatalogueNames: ["wget"],
+            defaultsKeyPrefix: prefix,
         )
 
         let snapshot = try await repository.loadTopPackages(limit: 0, window: .days30)
@@ -146,27 +163,290 @@ struct BrewDiscoverPackagesRepositoryTests {
     }
 
     @Test @MainActor func `loadTopPackages forwards client errors`() async throws {
+        let prefix = uniquePrefix()
+        defer { cleanup(prefix) }
         let repository = BrewDiscoverPackagesRepository(
             apiClient: ThrowingBrewAPIClient(),
             catalogueRepository: MockCatalogueRepository(formulaCatalogue: [], caskCatalogue: []),
+            cache: InMemoryDiscoverAnalyticsCache(),
+            defaultsKeyPrefix: prefix,
         )
         await #expect(throws: BrewAPIClientError.self) {
             _ = try await repository.loadTopPackages(limit: 10, window: .days30)
         }
     }
-}
 
-@MainActor
-private struct MockBrewAPIClient: BrewAPIClient {
-    let formulaAnalytics: BrewAnalyticsJSON
-    let caskAnalytics: BrewAnalyticsJSON
+    // MARK: - 24-hour caching
 
-    func fetchFormulaInstallOnRequestAnalytics(window _: BrewAnalyticsWindow) async throws -> BrewAnalyticsJSON {
-        formulaAnalytics
+    @Test @MainActor func `second load within ttl serves cache without refetching`() async throws {
+        let prefix = uniquePrefix()
+        defer { cleanup(prefix) }
+        let (repository, spy) = makeRepository(
+            formulaAnalytics: DiscoverAnalyticsFixtures.threeFormulaRanking(),
+            caskAnalytics: DiscoverAnalyticsFixtures.threeCaskRanking(),
+            formulaCatalogueNames: ["bat", "wget", "fd"],
+            caskCatalogueNames: ["iterm2", "raycast", "docker-desktop"],
+            defaultsKeyPrefix: prefix,
+        )
+
+        let first = try await repository.loadTopPackages(limit: 2, window: .days30)
+        let second = try await repository.loadTopPackages(limit: 2, window: .days30)
+
+        #expect(first == second)
+        // One formula + one cask fetch on the cold load; the warm load hits neither endpoint.
+        #expect(await spy.analyticsCallCount == 2)
     }
 
-    func fetchCaskInstallAnalytics(window _: BrewAnalyticsWindow) async throws -> BrewAnalyticsJSON {
-        caskAnalytics
+    @Test @MainActor func `pre-seeded fresh cache serves without any network fetch`() async throws {
+        let prefix = uniquePrefix()
+        defer { cleanup(prefix) }
+        let cache = InMemoryDiscoverAnalyticsCache()
+        await cache.seed(
+            window: .days30,
+            formula: DiscoverAnalyticsFixtures.threeFormulaRanking(),
+            cask: DiscoverAnalyticsFixtures.emptyCask(),
+        )
+        let (repository, spy) = makeRepository(
+            formulaAnalytics: analyticsData("{}"),
+            caskAnalytics: analyticsData("{}"),
+            formulaCatalogueNames: ["bat", "wget"],
+            caskCatalogueNames: [],
+            cache: cache,
+            defaultsKeyPrefix: prefix,
+        )
+        markFresh(repository, window: .days30)
+
+        let snapshot = try await repository.loadTopPackages(limit: 2, window: .days30)
+
+        #expect(snapshot.topFormulae == [
+            discoveryPackage(name: "bat", thirtyDayInstallCount: 1500, latestVersion: "1.0.0"),
+            discoveryPackage(name: "wget", thirtyDayInstallCount: 500, latestVersion: "1.0.0"),
+        ])
+        #expect(await spy.analyticsCallCount == 0)
+    }
+
+    @Test @MainActor func `stale cache refetches and returns fresh analytics`() async throws {
+        let prefix = uniquePrefix()
+        defer { cleanup(prefix) }
+        let cache = InMemoryDiscoverAnalyticsCache()
+        // Seed obsolete data and mark the cache stale so the load must refetch.
+        await cache.seed(
+            window: .days30,
+            formula: DiscoverAnalyticsFixtures.formulaRankingWithMissingTopEntry(),
+            cask: DiscoverAnalyticsFixtures.emptyCask(),
+        )
+        let (repository, spy) = makeRepository(
+            formulaAnalytics: DiscoverAnalyticsFixtures.threeFormulaRanking(),
+            caskAnalytics: DiscoverAnalyticsFixtures.emptyCask(),
+            formulaCatalogueNames: ["bat", "wget"],
+            caskCatalogueNames: [],
+            cache: cache,
+            defaultsKeyPrefix: prefix,
+        )
+        markStale(repository, window: .days30)
+
+        let snapshot = try await repository.loadTopPackages(limit: 2, window: .days30)
+
+        #expect(snapshot.topFormulae == [
+            discoveryPackage(name: "bat", thirtyDayInstallCount: 1500, latestVersion: "1.0.0"),
+            discoveryPackage(name: "wget", thirtyDayInstallCount: 500, latestVersion: "1.0.0"),
+        ])
+        #expect(await spy.analyticsCallCount == 2)
+    }
+
+    @Test @MainActor func `load refetches once the ttl has elapsed`() async throws {
+        let prefix = uniquePrefix()
+        defer { cleanup(prefix) }
+        let (repository, spy) = makeRepository(
+            formulaAnalytics: DiscoverAnalyticsFixtures.threeFormulaRanking(),
+            caskAnalytics: DiscoverAnalyticsFixtures.emptyCask(),
+            formulaCatalogueNames: ["bat", "wget"],
+            caskCatalogueNames: [],
+            defaultsKeyPrefix: prefix,
+        )
+
+        _ = try await repository.loadTopPackages(limit: 2, window: .days30)
+        #expect(await spy.analyticsCallCount == 2)
+
+        // Simulate more than 24h passing since the last refresh.
+        markStale(repository, window: .days30)
+        _ = try await repository.loadTopPackages(limit: 2, window: .days30)
+
+        #expect(await spy.analyticsCallCount == 4)
+    }
+
+    @Test @MainActor func `not modified response reuses cached bytes and refreshes timestamp`() async throws {
+        let prefix = uniquePrefix()
+        defer { cleanup(prefix) }
+        let cache = InMemoryDiscoverAnalyticsCache()
+        await cache.seed(
+            window: .days30,
+            formula: DiscoverAnalyticsFixtures.threeFormulaRanking(),
+            cask: DiscoverAnalyticsFixtures.emptyCask(),
+            formulaETag: #""formula-e1""#,
+            caskETag: #""cask-e1""#,
+        )
+        let spy = SpyBrewAPIClient(formula: .notModified, cask: .notModified)
+        let repository = BrewDiscoverPackagesRepository(
+            apiClient: spy,
+            catalogueRepository: MockCatalogueRepository(
+                formulaCatalogue: formulaPackages(names: ["bat", "wget"]),
+                caskCatalogue: [],
+            ),
+            cache: cache,
+            defaultsKeyPrefix: prefix,
+        )
+        markStale(repository, window: .days30)
+
+        let snapshot = try await repository.loadTopPackages(limit: 2, window: .days30)
+
+        #expect(snapshot.topFormulae == [
+            discoveryPackage(name: "bat", thirtyDayInstallCount: 1500, latestVersion: "1.0.0"),
+            discoveryPackage(name: "wget", thirtyDayInstallCount: 500, latestVersion: "1.0.0"),
+        ])
+        // Both endpoints were queried conditionally, forwarding the cached ETag...
+        #expect(await spy.analyticsCallCount == 2)
+        #expect(await spy.receivedFormulaETags == [#""formula-e1""#])
+        // ...and the refreshed timestamp means the next load serves from cache with no fetch.
+        _ = try await repository.loadTopPackages(limit: 2, window: .days30)
+        #expect(await spy.analyticsCallCount == 2)
+    }
+
+    @Test @MainActor func `analytics error is not cached and next load retries`() async throws {
+        let prefix = uniquePrefix()
+        defer { cleanup(prefix) }
+        let (repository, spy) = makeRepository(
+            formulaAnalytics: DiscoverAnalyticsFixtures.threeFormulaRanking(),
+            caskAnalytics: DiscoverAnalyticsFixtures.emptyCask(),
+            formulaCatalogueNames: ["bat", "wget"],
+            caskCatalogueNames: [],
+            defaultsKeyPrefix: prefix,
+            pendingError: BrewAPIClientError.transport(underlying: "offline"),
+        )
+
+        await #expect(throws: BrewAPIClientError.self) {
+            _ = try await repository.loadTopPackages(limit: 2, window: .days30)
+        }
+
+        // The failed attempt left the window stale, so a second load retries and succeeds.
+        let snapshot = try await repository.loadTopPackages(limit: 2, window: .days30)
+        #expect(snapshot.topFormulae == [
+            discoveryPackage(name: "bat", thirtyDayInstallCount: 1500, latestVersion: "1.0.0"),
+            discoveryPackage(name: "wget", thirtyDayInstallCount: 500, latestVersion: "1.0.0"),
+        ])
+        #expect(await spy.formulaCallCount == 2)
+    }
+
+    @Test @MainActor func `concurrent loads coalesce into a single refresh`() async throws {
+        let prefix = uniquePrefix()
+        defer { cleanup(prefix) }
+        let (repository, spy) = makeRepository(
+            formulaAnalytics: DiscoverAnalyticsFixtures.threeFormulaRanking(),
+            caskAnalytics: DiscoverAnalyticsFixtures.threeCaskRanking(),
+            formulaCatalogueNames: ["bat", "wget", "fd"],
+            caskCatalogueNames: ["iterm2", "raycast", "docker-desktop"],
+            defaultsKeyPrefix: prefix,
+        )
+
+        async let first = repository.loadTopPackages(limit: 2, window: .days30)
+        async let second = repository.loadTopPackages(limit: 2, window: .days30)
+        let firstSnapshot = try await first
+        let secondSnapshot = try await second
+
+        #expect(firstSnapshot == secondSnapshot)
+        #expect(await spy.analyticsCallCount == 2)
+    }
+
+    // MARK: - Cross-launch persistence (integration)
+
+    @Test @MainActor func `analytics persist across relaunch and refetch after ttl`() async throws {
+        let fixture = DiscoverAnalyticsDiskFixture()
+        defer { fixture.cleanup() }
+
+        // First launch: cold cache, fetch and persist to disk.
+        let firstCache = DiscoverAnalyticsCache(
+            cacheDirectoryURL: fixture.cacheDirectoryURL,
+            defaultsKeyPrefix: fixture.cacheDefaultsPrefix,
+        )
+        let (firstRepository, firstSpy) = makeRepository(
+            formulaAnalytics: DiscoverAnalyticsFixtures.threeFormulaRanking(),
+            caskAnalytics: DiscoverAnalyticsFixtures.emptyCask(),
+            formulaCatalogueNames: ["bat", "wget"],
+            caskCatalogueNames: [],
+            cache: firstCache,
+            defaultsKeyPrefix: fixture.repositoryDefaultsPrefix,
+        )
+        let firstSnapshot = try await firstRepository.loadTopPackages(limit: 2, window: .days30)
+        #expect(await firstSpy.analyticsCallCount == 2)
+
+        // Second launch: a brand-new cache instance reads the persisted bytes from disk.
+        let secondCache = DiscoverAnalyticsCache(
+            cacheDirectoryURL: fixture.cacheDirectoryURL,
+            defaultsKeyPrefix: fixture.cacheDefaultsPrefix,
+        )
+        await secondCache.prepare()
+        let (secondRepository, secondSpy) = makeRepository(
+            formulaAnalytics: DiscoverAnalyticsFixtures.threeFormulaRanking(),
+            caskAnalytics: DiscoverAnalyticsFixtures.emptyCask(),
+            formulaCatalogueNames: ["bat", "wget"],
+            caskCatalogueNames: [],
+            cache: secondCache,
+            defaultsKeyPrefix: fixture.repositoryDefaultsPrefix,
+        )
+        let relaunchSnapshot = try await secondRepository.loadTopPackages(limit: 2, window: .days30)
+        #expect(relaunchSnapshot == firstSnapshot)
+        #expect(await secondSpy.analyticsCallCount == 0)
+
+        // Once 24h has elapsed, the relaunched repository refetches.
+        markStale(secondRepository, window: .days30)
+        _ = try await secondRepository.loadTopPackages(limit: 2, window: .days30)
+        #expect(await secondSpy.analyticsCallCount == 2)
+    }
+}
+
+// MARK: - Test doubles
+
+private actor SpyBrewAPIClient: BrewAPIClient {
+    private var formulaResponse: CatalogueResponse<Data>
+    private var caskResponse: CatalogueResponse<Data>
+    private var pendingError: (any Error)?
+    private(set) var formulaCallCount = 0
+    private(set) var caskCallCount = 0
+    private(set) var receivedFormulaETags: [String?] = []
+
+    init(
+        formula: CatalogueResponse<Data>,
+        cask: CatalogueResponse<Data>,
+        pendingError: (any Error)? = nil,
+    ) {
+        formulaResponse = formula
+        caskResponse = cask
+        self.pendingError = pendingError
+    }
+
+    var analyticsCallCount: Int {
+        formulaCallCount + caskCallCount
+    }
+
+    func fetchFormulaInstallOnRequestAnalytics(
+        window _: BrewAnalyticsWindow,
+        etag: String?,
+    ) async throws -> CatalogueResponse<Data> {
+        formulaCallCount += 1
+        receivedFormulaETags.append(etag)
+        if let pendingError {
+            self.pendingError = nil
+            throw pendingError
+        }
+        return formulaResponse
+    }
+
+    func fetchCaskInstallAnalytics(
+        window _: BrewAnalyticsWindow,
+        etag _: String?,
+    ) async throws -> CatalogueResponse<Data> {
+        caskCallCount += 1
+        return caskResponse
     }
 
     func fetchFormulaCatalogue(etag _: String?) async throws -> CatalogueResponse<FormulaCatalogueJSON> {
@@ -212,11 +492,17 @@ private struct MockCatalogueRepository: CatalogueRepository {
 
 @MainActor
 private struct ThrowingBrewAPIClient: BrewAPIClient {
-    func fetchFormulaInstallOnRequestAnalytics(window _: BrewAnalyticsWindow) async throws -> BrewAnalyticsJSON {
+    func fetchFormulaInstallOnRequestAnalytics(
+        window _: BrewAnalyticsWindow,
+        etag _: String?,
+    ) async throws -> CatalogueResponse<Data> {
         throw BrewAPIClientError.transport(underlying: "offline")
     }
 
-    func fetchCaskInstallAnalytics(window _: BrewAnalyticsWindow) async throws -> BrewAnalyticsJSON {
+    func fetchCaskInstallAnalytics(
+        window _: BrewAnalyticsWindow,
+        etag _: String?,
+    ) async throws -> CatalogueResponse<Data> {
         throw BrewAPIClientError.transport(underlying: "offline")
     }
 
@@ -229,10 +515,12 @@ private struct ThrowingBrewAPIClient: BrewAPIClient {
     }
 }
 
+// MARK: - Fixtures & helpers
+
 private enum DiscoverAnalyticsFixtures {
-    static func threeFormulaRanking() throws -> BrewAnalyticsJSON {
-        try analytics(
-            from: """
+    static func threeFormulaRanking() -> Data {
+        analyticsData(
+            """
             {
               "category": "formula_install_on_request",
               "total_items": 3,
@@ -249,9 +537,9 @@ private enum DiscoverAnalyticsFixtures {
         )
     }
 
-    static func threeCaskRanking() throws -> BrewAnalyticsJSON {
-        try analytics(
-            from: """
+    static func threeCaskRanking() -> Data {
+        analyticsData(
+            """
             {
               "category": "cask_install",
               "total_items": 3,
@@ -268,9 +556,9 @@ private enum DiscoverAnalyticsFixtures {
         )
     }
 
-    static func emptyCask() throws -> BrewAnalyticsJSON {
-        try analytics(
-            from: """
+    static func emptyCask() -> Data {
+        analyticsData(
+            """
             {
               "category": "cask_install",
               "total_items": 0,
@@ -283,9 +571,9 @@ private enum DiscoverAnalyticsFixtures {
         )
     }
 
-    static func formulaRankingWithMissingTopEntry() throws -> BrewAnalyticsJSON {
-        try analytics(
-            from: """
+    static func formulaRankingWithMissingTopEntry() -> Data {
+        analyticsData(
+            """
             {
               "category": "formula_install_on_request",
               "total_items": 3,
@@ -303,27 +591,56 @@ private enum DiscoverAnalyticsFixtures {
     }
 }
 
+private func analyticsData(_ json: String) -> Data {
+    Data(json.utf8)
+}
+
 @MainActor
 private func makeRepository(
-    formulaAnalytics: BrewAnalyticsJSON,
-    caskAnalytics: BrewAnalyticsJSON,
+    formulaAnalytics: Data,
+    caskAnalytics: Data,
     formulaCatalogueNames: [String],
     caskCatalogueNames: [String],
-) -> BrewDiscoverPackagesRepository {
-    BrewDiscoverPackagesRepository(
-        apiClient: MockBrewAPIClient(
-            formulaAnalytics: formulaAnalytics,
-            caskAnalytics: caskAnalytics,
-        ),
+    cache: any DiscoverAnalyticsCaching = InMemoryDiscoverAnalyticsCache(),
+    defaultsKeyPrefix: String,
+    pendingError: (any Error)? = nil,
+) -> (BrewDiscoverPackagesRepository, SpyBrewAPIClient) {
+    let spy = SpyBrewAPIClient(
+        formula: .updated(data: formulaAnalytics, etag: nil),
+        cask: .updated(data: caskAnalytics, etag: nil),
+        pendingError: pendingError,
+    )
+    let repository = BrewDiscoverPackagesRepository(
+        apiClient: spy,
         catalogueRepository: MockCatalogueRepository(
             formulaCatalogue: formulaPackages(names: formulaCatalogueNames),
             caskCatalogue: caskPackages(names: caskCatalogueNames),
         ),
+        cache: cache,
+        defaultsKeyPrefix: defaultsKeyPrefix,
     )
+    return (repository, spy)
 }
 
-private func analytics(from json: String) throws -> BrewAnalyticsJSON {
-    try JSONDecoder().decode(BrewAnalyticsJSON.self, from: Data(json.utf8))
+private func uniquePrefix() -> String {
+    "DiscoverAnalyticsTests.\(UUID().uuidString)"
+}
+
+private func cleanup(_ prefix: String) {
+    UserDefaults.standard.removePersistedKeys(withPrefix: prefix)
+}
+
+/// Marks a window fresh by stamping its lastRefresh timestamp to now.
+private func markFresh(_ repository: BrewDiscoverPackagesRepository, window: BrewAnalyticsWindow) {
+    UserDefaults.standard.set(Date(), forKey: repository.lastRefreshKey(for: window))
+}
+
+/// Marks a window stale by backdating its lastRefresh timestamp well beyond the 24h TTL.
+private func markStale(_ repository: BrewDiscoverPackagesRepository, window: BrewAnalyticsWindow) {
+    UserDefaults.standard.set(
+        Date(timeIntervalSinceNow: -(BrewDiscoverPackagesRepository.defaultTTL + 3600)),
+        forKey: repository.lastRefreshKey(for: window),
+    )
 }
 
 private func formulaPackages(names: [String]) -> [BrewPackage] {
@@ -373,4 +690,25 @@ private func discoveryPackage(
         ),
         thirtyDayInstallCount: thirtyDayInstallCount,
     )
+}
+
+@MainActor
+private struct DiscoverAnalyticsDiskFixture {
+    let cacheDirectoryURL: URL
+    let cacheDefaultsPrefix: String
+    let repositoryDefaultsPrefix: String
+
+    init() {
+        let id = UUID().uuidString
+        cacheDirectoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DiscoverAnalyticsCacheFixture-\(id)", isDirectory: true)
+        cacheDefaultsPrefix = "DiscoverAnalyticsCacheFixture.\(id)"
+        repositoryDefaultsPrefix = "DiscoverAnalyticsRepositoryFixture.\(id)"
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: cacheDirectoryURL)
+        UserDefaults.standard.removePersistedKeys(withPrefix: cacheDefaultsPrefix)
+        UserDefaults.standard.removePersistedKeys(withPrefix: repositoryDefaultsPrefix)
+    }
 }


### PR DESCRIPTION
# PR: Package list filtering, console auto-expand, and Discovery analytics caching

## Summary

Rounds out the Installed and Upgrades tabs with package-kind filtering and a smarter batch upgrade, makes the console open itself when work starts, and stops the Discovery screen refetching Homebrew analytics it already has. A grab-bag of UX and efficiency improvements plus one focus bug fix.

## Changes

**Package lists**
- Add a scope picker (All / Formulae / Casks) to both the Installed and Upgrades tabs, driven by a new `InstalledPackageScope` and composed on top of the existing search query — all client-side over the already-loaded inventory.
- Make "Upgrade All" respect the active filters via a new `BrewUpgradeSelection` value type that is the single source of truth for both the subprocess argument vector and the command string shown in the header/console, so what runs and what's displayed can't drift.
- Fix a regression where re-inserting the list (after a search filtered to zero matches) stole keyboard focus from the search field; the focus decision now lives on the view model as `shouldFocusList` and is unit-tested.

**Console**
- Auto-expand the console panel the moment a command starts running, with a checkmarked "Expand Console Panel Automatically" toggle in the View menu (default on) to disable it.

**Discovery**
- Cache the two Homebrew analytics endpoints for 24 hours, persisting the raw ETag-conditional responses to Application Support so a same-day relaunch serves trending from disk with no network hit. The Discover repository becomes a cache-first actor mirroring the catalogue repository.

**General**
- Removes automatic window tabbing as this was never intentional in the first place. It adds no value; it's just a default that AppKit throws in.

## Testing

- [x] `swift build`
- [x] `./scripts/test` (full suite + BrewUILint, all green)
- [x] `swiftformat --lint .` and `swiftlint --strict` (0 issues)
- [x] Manual smoke: filters, Upgrade All command, console auto-expand/toggle, cross-launch Discovery caching

## PR checklist

- [x] Have you followed this repository's contribution and workflow guidance?
- [x] Have you explained what changed and why this should land now?
- [x] Have you run relevant local checks for the changed scope?
- [x] Are changes scoped and free of unrelated modifications?

-----

- [x] AI was used to generate or assist with generating this PR.
- [x] If yes, describe exactly how AI was used and what manual verification was performed: AI implemented the changes and tests; verified locally via build, the full test suite, format/lint, and manual UI smoke-testing.