### PR TITLE
Set default window size sensibly

### DIFF
--- a/Homebrew/BrewApp.swift
+++ b/Homebrew/BrewApp.swift
@@ -95,8 +95,8 @@ struct BrewApp: App {
                 )
         }
         .defaultSize(
-            width: BrewLayout.minWindowWidth,
-            height: BrewLayout.minWindowHeight,
+            width: BrewLayout.defaultWindowWidth,
+            height: BrewLayout.defaultWindowHeight,
         )
         .commands {
             SearchCommands()

--- a/Sources/BrewUIComponents/Theme/BrewSpacing.swift
+++ b/Sources/BrewUIComponents/Theme/BrewSpacing.swift
@@ -48,6 +48,12 @@ public enum BrewLayout {
     public static let installedDetailColumnMaxWidth: CGFloat = 1200
     public static let installedThreePaneMinWindowWidth: CGFloat = 960
 
+    /// Default window width.
+    public static let defaultWindowWidth: CGFloat = 1000
+
+    /// Default window height.
+    public static let defaultWindowHeight: CGFloat = 650
+
     /// Minimum supported window width.
     public static let minWindowWidth: CGFloat = 820
 


### PR DESCRIPTION
# PR: Set default window size to 1000×650

## Summary

The default window size was previously set to the minimum (820px wide), making the app feel cramped on first launch. This sets a more comfortable default of 1000×650.

## Changes

- `BrewSpacing.swift`: Added `defaultWindowWidth` (1000) and `defaultWindowHeight` (650) constants to `BrewLayout`
- `BrewApp.swift`: Use new default constants instead of minimum constants for `.defaultSize`

## Testing

- [x] Built and launched the app — window opens at the new default size

## PR checklist

- [x] Have you followed this repository's contribution and workflow guidance?
- [x] Have you explained what changed and why this should land now?
- [x] Have you run relevant local checks for the changed scope?
- [x] Are changes scoped and free of unrelated modifications?

-----

- [x] AI was used to generate or assist with generating this PR.
- [x] Claude drafted the PR description; changes were written and verified manually.