### PR TITLE
workflows: pin Homebrew/actions to 2026.07.10.1

### DIFF
--- a/.ai/memory.md
+++ b/.ai/memory.md
@@ -72,8 +72,8 @@
 
 - GitHub workflow linting should avoid `uses: docker://...` because org allowlist policy can reject it.
 - Preferred pattern for this repo is Homebrew-influenced and allowlist-friendly:
-  - use `Homebrew/actions/setup-homebrew@main`
-  - use `Homebrew/actions/cache-homebrew-prefix@main` to install `actionlint`/`shellcheck`
+  - use `Homebrew/actions/setup-homebrew@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1`
+  - use `Homebrew/actions/cache-homebrew-prefix@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1` to install `actionlint`/`shellcheck`
   - run `actionlint` via a `run:` step
 - Actionlint remains path-scoped to workflow changes for low CI overhead.
 

--- a/.github/workflows/swift_quality.yml
+++ b/.github/workflows/swift_quality.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Cache Homebrew prefix
-        uses: Homebrew/actions/cache-homebrew-prefix@main
+        uses: Homebrew/actions/cache-homebrew-prefix@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1
         with:
           brewfile: true
           uninstall: true


### PR DESCRIPTION
Pin `Homebrew/actions` references to the immutable `2026.07.10.1` release using its full commit SHA and version comment.

This removes mutable `@main` dependencies while allowing Dependabot to track future releases.