### PR TITLE
Crash handling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -336,6 +336,18 @@ jobs:
           ditto -c -k --keepParent "$RUNNER_TEMP/export/Homebrew.app" "$APP_ZIP"
           echo "APP_ZIP=$APP_ZIP" >> "$GITHUB_ENV"
 
+      - name: Zip dSYMs
+        if: env.NOTARIZE == 'true'
+        run: |
+          DSYM_ZIP="$RUNNER_TEMP/Homebrew-${VERSION}.dSYMs.zip"
+          DSYM_DIR="$RUNNER_TEMP/Homebrew.xcarchive/dSYMs"
+          if [ -z "$(ls -A "$DSYM_DIR" 2>/dev/null)" ]; then
+            echo "No dSYMs in archive — a release build must produce debug symbols."
+            exit 1
+          fi
+          ditto -c -k --keepParent "$DSYM_DIR" "$DSYM_ZIP"
+          echo "DSYM_ZIP=$DSYM_ZIP" >> "$GITHUB_ENV"
+
       - name: Upload package artifact
         if: env.NOTARIZE == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -350,6 +362,14 @@ jobs:
         with:
           name: Homebrew-app
           path: ${{ env.APP_ZIP }}
+          retention-days: 90
+
+      - name: Upload dSYMs artifact
+        if: env.NOTARIZE == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: Homebrew-dsyms
+          path: ${{ env.DSYM_ZIP }}
           retention-days: 90
 
       - name: Delete temporary keychain

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,15 +146,18 @@ jobs:
 
           gh run download "$RUN_ID" --name Homebrew-pkg --dir dist
           gh run download "$RUN_ID" --name Homebrew-app --dir dist
+          gh run download "$RUN_ID" --name Homebrew-dsyms --dir dsyms
           shopt -s nullglob
           pkgs=(dist/Homebrew-*.pkg)
           zips=(dist/Homebrew-*.zip)
-          if [ ${#pkgs[@]} -eq 0 ] || [ ${#zips[@]} -eq 0 ]; then
-            echo "::error::Downloaded artifacts are missing a Homebrew-*.pkg or Homebrew-*.zip."
+          dsyms=(dsyms/Homebrew-*.dSYMs.zip)
+          if [ ${#pkgs[@]} -eq 0 ] || [ ${#zips[@]} -eq 0 ] || [ ${#dsyms[@]} -eq 0 ]; then
+            echo "::error::Downloaded artifacts are missing a Homebrew-*.pkg, Homebrew-*.zip, or Homebrew-*.dSYMs.zip."
             exit 1
           fi
           PKG_PATH="${pkgs[0]}"
           APP_ZIP="${zips[0]}"
+          DSYM_ZIP="${dsyms[0]}"
 
           base=$(basename "$PKG_PATH")
           VERSION="${base#Homebrew-}"; VERSION="${VERSION%.pkg}"
@@ -175,6 +178,7 @@ jobs:
           {
             echo "PKG_PATH=$PKG_PATH"
             echo "APP_ZIP=$APP_ZIP"
+            echo "DSYM_ZIP=$DSYM_ZIP"
             echo "VERSION=$VERSION"
             echo "TAG=$TAG"
             echo "TARGET=$TARGET"
@@ -188,9 +192,10 @@ jobs:
           subject-path: |
             ${{ env.PKG_PATH }}
             ${{ env.APP_ZIP }}
+            ${{ env.DSYM_ZIP }}
 
       - name: Create tag and release
         if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
         run: |
-          gh release create "$TAG" "$PKG_PATH" "$APP_ZIP" \
+          gh release create "$TAG" "$PKG_PATH" "$APP_ZIP" "$DSYM_ZIP" \
             --target "$TARGET" --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,18 +146,29 @@ jobs:
 
           gh run download "$RUN_ID" --name Homebrew-pkg --dir dist
           gh run download "$RUN_ID" --name Homebrew-app --dir dist
-          gh run download "$RUN_ID" --name Homebrew-dsyms --dir dsyms
+          # The dSYMs artifact only exists on builds cut after it was introduced,
+          # so a dry run promoting an older main build won't have one. Tolerate
+          # that here; a real release still requires it (checked below).
+          gh run download "$RUN_ID" --name Homebrew-dsyms --dir dsyms || true
           shopt -s nullglob
           pkgs=(dist/Homebrew-*.pkg)
           zips=(dist/Homebrew-*.zip)
           dsyms=(dsyms/Homebrew-*.dSYMs.zip)
-          if [ ${#pkgs[@]} -eq 0 ] || [ ${#zips[@]} -eq 0 ] || [ ${#dsyms[@]} -eq 0 ]; then
-            echo "::error::Downloaded artifacts are missing a Homebrew-*.pkg, Homebrew-*.zip, or Homebrew-*.dSYMs.zip."
+          if [ ${#pkgs[@]} -eq 0 ] || [ ${#zips[@]} -eq 0 ]; then
+            echo "::error::Downloaded artifacts are missing a Homebrew-*.pkg or Homebrew-*.zip."
             exit 1
           fi
           PKG_PATH="${pkgs[0]}"
           APP_ZIP="${zips[0]}"
-          DSYM_ZIP="${dsyms[0]}"
+          if [ ${#dsyms[@]} -gt 0 ]; then
+            DSYM_ZIP="${dsyms[0]}"
+          elif [ "$dry_run" = true ]; then
+            DSYM_ZIP=""
+            echo "::warning::No Homebrew-*.dSYMs.zip on run $RUN_ID; tolerated for this dry run (real releases require it)."
+          else
+            echo "::error::Downloaded artifacts are missing a Homebrew-*.dSYMs.zip."
+            exit 1
+          fi
 
           base=$(basename "$PKG_PATH")
           VERSION="${base#Homebrew-}"; VERSION="${VERSION%.pkg}"

--- a/Homebrew.xcodeproj/project.pbxproj
+++ b/Homebrew.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		EEAA110A00000000000000BA /* BrewAppEnvironment in Frameworks */ = {isa = PBXBuildFile; productRef = EEAA100A00000000000000CA /* BrewAppEnvironment */; };
 		EEAA110B00000000000000BB /* BrewFeatureDoctor in Frameworks */ = {isa = PBXBuildFile; productRef = EEAA100B00000000000000CB /* BrewFeatureDoctor */; };
 		EEAA110C00000000000000BC /* BrewFeatureConfig in Frameworks */ = {isa = PBXBuildFile; productRef = EEAA100C00000000000000CC /* BrewFeatureConfig */; };
+		EEAA110D00000000000000BD /* BrewCrashReporting in Frameworks */ = {isa = PBXBuildFile; productRef = EEAA100D00000000000000CD /* BrewCrashReporting */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -87,6 +88,7 @@
 				EEAA110A00000000000000BA /* BrewAppEnvironment in Frameworks */,
 				EEAA110B00000000000000BB /* BrewFeatureDoctor in Frameworks */,
 				EEAA110C00000000000000BC /* BrewFeatureConfig in Frameworks */,
+				EEAA110D00000000000000BD /* BrewCrashReporting in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -175,6 +177,7 @@
 				EEAA100A00000000000000CA /* BrewAppEnvironment */,
 				EEAA100B00000000000000CB /* BrewFeatureDoctor */,
 				EEAA100C00000000000000CC /* BrewFeatureConfig */,
+				EEAA100D00000000000000CD /* BrewCrashReporting */,
 			);
 			productName = Brew;
 			productReference = EEC39EBF2F5AB4B900269514 /* Homebrew.app */;
@@ -733,6 +736,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = EEAA1F0000000000000000FF /* XCLocalSwiftPackageReference "." */;
 			productName = BrewFeatureConfig;
+		};
+		EEAA100D00000000000000CD /* BrewCrashReporting */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = EEAA1F0000000000000000FF /* XCLocalSwiftPackageReference "." */;
+			productName = BrewCrashReporting;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Homebrew/BrewApp.swift
+++ b/Homebrew/BrewApp.swift
@@ -20,6 +20,10 @@ struct BrewApp: App {
     /// Homebrew's online documentation, surfaced from the Help menu.
     private static let documentationURL = URL(string: "https://docs.brew.sh/")!
 
+    /// The app's GitHub issue tracker, surfaced from the Help menu so users can
+    /// file a bug or feature request without hunting for the repository.
+    private static let reportIssueURL = URL(string: "https://github.com/Homebrew/BrewUI/issues/new")!
+
     @Environment(\.scenePhase) private var scenePhase
 
     private let commandCenter: SerialBrewCommandCenter
@@ -107,6 +111,7 @@ struct BrewApp: App {
             // non-existent help book) with a link to the online documentation.
             CommandGroup(replacing: .help) {
                 Link("Homebrew Documentation", destination: Self.documentationURL)
+                Link("Report an Issue…", destination: Self.reportIssueURL)
             }
         }
         #if DEBUG

--- a/Homebrew/BrewApp.swift
+++ b/Homebrew/BrewApp.swift
@@ -18,11 +18,7 @@ import SwiftUI
 
 @main
 struct BrewApp: App {
-    /// Homebrew's online documentation, surfaced from the Help menu.
     private static let documentationURL = URL(string: "https://docs.brew.sh/")!
-
-    /// The app's GitHub issue tracker, surfaced from the Help menu so users can
-    /// file a bug or feature request without hunting for the repository.
     private static let reportIssueURL = URL(string: "https://github.com/Homebrew/BrewUI/issues/new")!
 
     @Environment(\.scenePhase) private var scenePhase
@@ -42,9 +38,7 @@ struct BrewApp: App {
     private let crashReportController: CrashReportController
 
     init() {
-        // Install crash capture first, before any other launch work, so a crash
-        // during startup is still recorded. The controller reads reports written
-        // by a *previous* launch and drives the report-it dialog.
+        // Install crash capture before any other launch work so startup crashes are recorded.
         let crashReportStore = CrashReportStore()
         CrashReportInstaller.install(store: crashReportStore, environment: .current())
         crashReportController = CrashReportController(store: crashReportStore)

--- a/Homebrew/BrewApp.swift
+++ b/Homebrew/BrewApp.swift
@@ -8,6 +8,7 @@
 import BrewAppEnvironment
 import BrewCLI
 import BrewCore
+import BrewCrashReporting
 import BrewFeatureConsole
 import BrewNetworking
 import BrewRepositories
@@ -38,8 +39,16 @@ struct BrewApp: App {
     private let discoverPackagesRepository: BrewDiscoverPackagesRepository
     private let doctorRepository: BrewDoctorRepository
     private let configRepository: BrewConfigRepository
+    private let crashReportController: CrashReportController
 
     init() {
+        // Install crash capture first, before any other launch work, so a crash
+        // during startup is still recorded. The controller reads reports written
+        // by a *previous* launch and drives the report-it dialog.
+        let crashReportStore = CrashReportStore()
+        CrashReportInstaller.install(store: crashReportStore, environment: .current())
+        crashReportController = CrashReportController(store: crashReportStore)
+
         let inventoryCache = InstalledInventoryCache()
         let catalogue = CatalogueCache()
         let discoverAnalytics = DiscoverAnalyticsCache()
@@ -97,6 +106,7 @@ struct BrewApp: App {
                     minWidth: BrewLayout.minWindowWidth,
                     minHeight: BrewLayout.minWindowHeight,
                 )
+                .crashReportSheet(controller: crashReportController)
         }
         .defaultSize(
             width: BrewLayout.defaultWindowWidth,

--- a/Homebrew/Debug/DebugMenuCommands.swift
+++ b/Homebrew/Debug/DebugMenuCommands.swift
@@ -16,9 +16,7 @@ import SwiftUI
 
                 Divider()
 
-                // Deliberately crash the app so the crash-reporting flow can be
-                // exercised: the report should appear on the next launch. These
-                // exist only in DEBUG builds.
+                // Exercises the crash-reporting flow: the report appears on next launch.
                 Menu("Force Crash") {
                     Button("Fatal Error (signal)") {
                         fatalError("Debug menu: forced fatalError")

--- a/Homebrew/Debug/DebugMenuCommands.swift
+++ b/Homebrew/Debug/DebugMenuCommands.swift
@@ -3,6 +3,7 @@
 //  Brew
 //
 
+import Foundation
 import SwiftUI
 
 #if DEBUG
@@ -11,6 +12,24 @@ import SwiftUI
             CommandMenu("Debug") {
                 Button("Clear UserDefaults") {
                     UserDefaultsDebug.clearAll()
+                }
+
+                Divider()
+
+                // Deliberately crash the app so the crash-reporting flow can be
+                // exercised: the report should appear on the next launch. These
+                // exist only in DEBUG builds.
+                Menu("Force Crash") {
+                    Button("Fatal Error (signal)") {
+                        fatalError("Debug menu: forced fatalError")
+                    }
+                    Button("Uncaught Exception") {
+                        NSException(
+                            name: .genericException,
+                            reason: "Debug menu: forced NSException",
+                            userInfo: nil,
+                        ).raise()
+                    }
                 }
             }
         }

--- a/Homebrew/Features/CrashReporting/CrashReportDialog.swift
+++ b/Homebrew/Features/CrashReporting/CrashReportDialog.swift
@@ -1,0 +1,97 @@
+//
+//  CrashReportDialog.swift
+//  Brew
+//
+
+import BrewCrashReporting
+import SwiftUI
+
+/// The dialog shown on the launch after a crash. It offers to file the captured
+/// report as a GitHub issue, or to discard it. Nothing is transmitted unless the
+/// user chooses to open the pre-filled issue.
+///
+/// Passive by design (per `CONVENTIONS.md`): it renders the report and forwards
+/// two intents — report or dismiss — to its owner.
+struct CrashReportDialog: View {
+    let report: CrashReport
+    /// Pre-filled GitHub new-issue URL for this report.
+    let issueURL: URL
+    /// Called after the user reports or discards; the report is removed either way.
+    let onDismiss: () -> Void
+
+    @Environment(\.openURL) private var openURL
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            header
+
+            Text("A report was saved after the app quit unexpectedly. You can send it " +
+                "to the Homebrew team on GitHub to help fix the problem, or discard it.")
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            GroupBox {
+                ScrollView {
+                    Text(report.text)
+                        .font(.system(.caption, design: .monospaced))
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(4)
+                }
+            }
+            .frame(maxHeight: .infinity)
+
+            footer
+        }
+        .padding(24)
+        .frame(width: 540, height: 480)
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.largeTitle)
+                .foregroundStyle(.orange)
+            Text("The Homebrew app quit unexpectedly")
+                .font(.title2)
+                .fontWeight(.semibold)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var footer: some View {
+        HStack {
+            Spacer()
+            Button("Discard", role: .cancel, action: onDismiss)
+            Button("Report on GitHub…") {
+                openURL(issueURL)
+                onDismiss()
+            }
+            .keyboardShortcut(.defaultAction)
+        }
+    }
+}
+
+#if DEBUG
+    #Preview {
+        CrashReportDialog(
+            report: CrashReport(
+                id: "crash-1.log",
+                capturedAt: .now,
+                text: """
+                Homebrew.app crash report
+                =========================
+                Date: 2026-07-10T09:41:00Z
+                App version: 1.0 (1)
+                macOS: Version 26.0 (Build 26A1)
+                Signal: SIGSEGV
+
+                Call stack:
+                0   Homebrew    0x0000000102a4c1b0 main + 42
+                """,
+            ),
+            issueURL: URL(string: "https://github.com/Homebrew/BrewUI/issues/new")!,
+            onDismiss: {},
+        )
+    }
+#endif

--- a/Homebrew/Features/CrashReporting/CrashReportDialog.swift
+++ b/Homebrew/Features/CrashReporting/CrashReportDialog.swift
@@ -48,6 +48,7 @@ struct CrashReportDialog: View {
             Image(systemName: "exclamationmark.triangle.fill")
                 .font(.largeTitle)
                 .foregroundStyle(.orange)
+                .accessibilityHidden(true)
             Text("The Homebrew app quit unexpectedly")
                 .font(.title2)
                 .fontWeight(.semibold)

--- a/Homebrew/Features/CrashReporting/CrashReportDialog.swift
+++ b/Homebrew/Features/CrashReporting/CrashReportDialog.swift
@@ -6,15 +6,11 @@
 import BrewCrashReporting
 import SwiftUI
 
-/// The dialog shown on the launch after a crash. It offers to file the captured
-/// report as a GitHub issue, or to discard it. Nothing is transmitted unless the
-/// user chooses to open the pre-filled issue.
-///
-/// Passive by design (per `CONVENTIONS.md`): it renders the report and forwards
-/// two intents — report or dismiss — to its owner.
+/// The dialog shown on the launch after a crash, offering to file the report as
+/// a GitHub issue or discard it. Passive (per `CONVENTIONS.md`): it renders the
+/// report and forwards report/dismiss intents to its owner.
 struct CrashReportDialog: View {
     let report: CrashReport
-    /// Pre-filled GitHub new-issue URL for this report.
     let issueURL: URL
     /// Called after the user reports or discards; the report is removed either way.
     let onDismiss: () -> Void

--- a/Homebrew/Features/CrashReporting/CrashReportSheet.swift
+++ b/Homebrew/Features/CrashReporting/CrashReportSheet.swift
@@ -1,0 +1,52 @@
+//
+//  CrashReportSheet.swift
+//  Brew
+//
+
+import BrewCrashReporting
+import SwiftUI
+
+/// Loads any crash reports left by a previous launch and presents
+/// ``CrashReportDialog`` for them one at a time.
+///
+/// Lives as a `ViewModifier` so `BrewApp` can attach it to the main window with
+/// a single call while keeping observation of the `@Observable` controller
+/// anchored inside a real view body.
+private struct CrashReportSheetModifier: ViewModifier {
+    @Bindable var controller: CrashReportController
+
+    func body(content: Content) -> some View {
+        content
+            .task { await controller.loadPendingReports() }
+            .sheet(item: currentReport) { report in
+                CrashReportDialog(
+                    report: report,
+                    issueURL: controller.issueURL(for: report),
+                    onDismiss: { controller.discard(report) },
+                )
+                .interactiveDismissDisabled()
+            }
+    }
+
+    /// Bridges the controller's read-only `currentReport` to the `Binding` that
+    /// `sheet(item:)` needs. Dismissing the sheet (e.g. via the report/discard
+    /// buttons or the window) discards the current report, which advances the
+    /// queue to the next one — or closes the sheet when none remain.
+    private var currentReport: Binding<CrashReport?> {
+        Binding(
+            get: { controller.currentReport },
+            set: { newValue in
+                if newValue == nil, let current = controller.currentReport {
+                    controller.discard(current)
+                }
+            },
+        )
+    }
+}
+
+extension View {
+    /// Presents the post-crash reporting dialog for `controller`'s pending reports.
+    func crashReportSheet(controller: CrashReportController) -> some View {
+        modifier(CrashReportSheetModifier(controller: controller))
+    }
+}

--- a/Homebrew/Features/CrashReporting/CrashReportSheet.swift
+++ b/Homebrew/Features/CrashReporting/CrashReportSheet.swift
@@ -8,10 +8,6 @@ import SwiftUI
 
 /// Loads any crash reports left by a previous launch and presents
 /// ``CrashReportDialog`` for them one at a time.
-///
-/// Lives as a `ViewModifier` so `BrewApp` can attach it to the main window with
-/// a single call while keeping observation of the `@Observable` controller
-/// anchored inside a real view body.
 private struct CrashReportSheetModifier: ViewModifier {
     @Bindable var controller: CrashReportController
 
@@ -28,10 +24,8 @@ private struct CrashReportSheetModifier: ViewModifier {
             }
     }
 
-    /// Bridges the controller's read-only `currentReport` to the `Binding` that
-    /// `sheet(item:)` needs. Dismissing the sheet (e.g. via the report/discard
-    /// buttons or the window) discards the current report, which advances the
-    /// queue to the next one — or closes the sheet when none remain.
+    /// Bridges the read-only `currentReport` to the `Binding` `sheet(item:)`
+    /// needs. Any dismissal discards the current report, advancing the queue.
     private var currentReport: Binding<CrashReport?> {
         Binding(
             get: { controller.currentReport },
@@ -45,7 +39,6 @@ private struct CrashReportSheetModifier: ViewModifier {
 }
 
 extension View {
-    /// Presents the post-crash reporting dialog for `controller`'s pending reports.
     func crashReportSheet(controller: CrashReportController) -> some View {
         modifier(CrashReportSheetModifier(controller: controller))
     }

--- a/Homebrew/Features/CrashReporting/CrashReportSheet.swift
+++ b/Homebrew/Features/CrashReporting/CrashReportSheet.swift
@@ -25,15 +25,14 @@ private struct CrashReportSheetModifier: ViewModifier {
     }
 
     /// Bridges the read-only `currentReport` to the `Binding` `sheet(item:)`
-    /// needs. Any dismissal discards the current report, advancing the queue.
+    /// needs. The setter is intentionally inert: presentation is driven by the
+    /// getter going `nil` after the dialog's explicit discard, so acting on a
+    /// SwiftUI/system-initiated nil-set here would delete the head of the queue
+    /// with no user choice.
     private var currentReport: Binding<CrashReport?> {
         Binding(
             get: { controller.currentReport },
-            set: { newValue in
-                if newValue == nil, let current = controller.currentReport {
-                    controller.discard(current)
-                }
-            },
+            set: { _ in },
         )
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,7 @@ let package = Package(
     ],
     products: [
         .library(name: "BrewCore", targets: ["BrewCore"]),
+        .library(name: "BrewCrashReporting", targets: ["BrewCrashReporting"]),
         .library(name: "BrewUIComponents", targets: ["BrewUIComponents"]),
         .library(name: "BrewCLI", targets: ["BrewCLI"]),
         .library(name: "BrewNetworking", targets: ["BrewNetworking"]),
@@ -25,6 +26,13 @@ let package = Package(
     targets: [
         .target(
             name: "BrewCore",
+            swiftSettings: [
+                .defaultIsolation(nil),
+                .swiftLanguageMode(.v6),
+            ],
+        ),
+        .target(
+            name: "BrewCrashReporting",
             swiftSettings: [
                 .defaultIsolation(nil),
                 .swiftLanguageMode(.v6),
@@ -172,6 +180,14 @@ let package = Package(
 
         // MARK: - Test targets
 
+        .testTarget(
+            name: "BrewCrashReportingTests",
+            dependencies: ["BrewCrashReporting"],
+            swiftSettings: [
+                .defaultIsolation(nil),
+                .swiftLanguageMode(.v6),
+            ],
+        ),
         .testTarget(
             name: "BrewCoreTests",
             dependencies: ["BrewCore", "BrewCoreTestSupport"],

--- a/Sources/BrewCrashReporting/CrashReport.swift
+++ b/Sources/BrewCrashReporting/CrashReport.swift
@@ -1,0 +1,42 @@
+//
+//  CrashReport.swift
+//  Brew
+//
+
+import Foundation
+
+/// A single persisted crash report, read back from disk on the launch *after*
+/// the crash occurred.
+///
+/// The `text` is the full, human-readable report exactly as written at crash
+/// time — it is what gets shown to the user and pasted into a GitHub issue, so
+/// it is stored verbatim rather than as a `Codable` model. Deliberately not
+/// `Codable`: the on-disk artifact is plain text, not an encoded value type.
+public struct CrashReport: Sendable, Equatable, Identifiable {
+    /// The report's file name (unique per crash); doubles as a stable identity
+    /// for SwiftUI list/sheet presentation.
+    public let id: String
+    /// When the crash was captured, derived from the file name timestamp.
+    public let capturedAt: Date
+    /// The full report body (header + call stack).
+    public let text: String
+
+    public init(id: String, capturedAt: Date, text: String) {
+        self.id = id
+        self.capturedAt = capturedAt
+        self.text = text
+    }
+
+    /// A one-line summary — the first non-empty, non-separator line of the
+    /// report — used for the GitHub issue title and any compact UI.
+    public var summary: String {
+        for line in text.split(whereSeparator: \.isNewline) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty || trimmed.allSatisfy({ $0 == "=" || $0 == "-" }) {
+                continue
+            }
+            return trimmed
+        }
+        return "Unexpected crash"
+    }
+}

--- a/Sources/BrewCrashReporting/CrashReport.swift
+++ b/Sources/BrewCrashReporting/CrashReport.swift
@@ -5,20 +5,13 @@
 
 import Foundation
 
-/// A single persisted crash report, read back from disk on the launch *after*
-/// the crash occurred.
-///
-/// The `text` is the full, human-readable report exactly as written at crash
-/// time — it is what gets shown to the user and pasted into a GitHub issue, so
-/// it is stored verbatim rather than as a `Codable` model. Deliberately not
-/// `Codable`: the on-disk artifact is plain text, not an encoded value type.
+/// A single persisted crash report, read back on the launch after the crash.
+/// `text` is the verbatim report shown to the user and pasted into a GitHub
+/// issue; the on-disk artifact is plain text, so this is not `Codable`.
 public struct CrashReport: Sendable, Equatable, Identifiable {
-    /// The report's file name (unique per crash); doubles as a stable identity
-    /// for SwiftUI list/sheet presentation.
+    /// The report's file name, unique per crash; also its presentation identity.
     public let id: String
-    /// When the crash was captured, derived from the file name timestamp.
     public let capturedAt: Date
-    /// The full report body (header + call stack).
     public let text: String
 
     public init(id: String, capturedAt: Date, text: String) {
@@ -27,8 +20,7 @@ public struct CrashReport: Sendable, Equatable, Identifiable {
         self.text = text
     }
 
-    /// A one-line summary — the first non-empty, non-separator line of the
-    /// report — used for the GitHub issue title and any compact UI.
+    /// The first non-empty, non-separator line, used for the issue title.
     public var summary: String {
         for line in text.split(whereSeparator: \.isNewline) {
             let trimmed = line.trimmingCharacters(in: .whitespaces)

--- a/Sources/BrewCrashReporting/CrashReportController.swift
+++ b/Sources/BrewCrashReporting/CrashReportController.swift
@@ -6,16 +6,11 @@
 import Foundation
 import Observation
 
-/// Drives the "you crashed last time" UI. Loads any reports left behind by a
-/// previous launch, exposes the one currently being shown, and handles the
-/// user's response (file an issue, or discard).
-///
-/// UI-facing state, so it is `@MainActor`; the actual disk work is hopped off
-/// the main actor.
+/// Drives the "you crashed last time" UI: loads reports left by a previous
+/// launch, exposes the one currently shown, and handles the user's response.
 @MainActor
 @Observable
 public final class CrashReportController {
-    /// Reports awaiting the user's attention, oldest first.
     public private(set) var pendingReports: [CrashReport] = []
 
     private let store: CrashReportStore
@@ -24,12 +19,11 @@ public final class CrashReportController {
         self.store = store
     }
 
-    /// The report to surface right now, or `nil` when there is nothing to show.
     public var currentReport: CrashReport? {
         pendingReports.first
     }
 
-    /// Loads persisted reports from disk. Called once on launch.
+    /// Loads persisted reports off the main actor. Called once on launch.
     public func loadPendingReports() async {
         let store = store
         pendingReports = await Task.detached(priority: .utility) {
@@ -37,14 +31,11 @@ public final class CrashReportController {
         }.value
     }
 
-    /// A pre-filled GitHub issue URL for `report`. Opening it is the caller's
-    /// responsibility (via `openURL`), so nothing is transmitted automatically.
     public func issueURL(for report: CrashReport) -> URL {
         CrashReportIssue.url(for: report)
     }
 
-    /// Removes `report` from disk and drops it from the queue, advancing to the
-    /// next pending report (if any).
+    /// Removes `report` from disk and the queue, advancing to the next pending one.
     public func discard(_ report: CrashReport) {
         store.remove(report)
         pendingReports.removeAll { $0.id == report.id }

--- a/Sources/BrewCrashReporting/CrashReportController.swift
+++ b/Sources/BrewCrashReporting/CrashReportController.swift
@@ -1,0 +1,52 @@
+//
+//  CrashReportController.swift
+//  Brew
+//
+
+import Foundation
+import Observation
+
+/// Drives the "you crashed last time" UI. Loads any reports left behind by a
+/// previous launch, exposes the one currently being shown, and handles the
+/// user's response (file an issue, or discard).
+///
+/// UI-facing state, so it is `@MainActor`; the actual disk work is hopped off
+/// the main actor.
+@MainActor
+@Observable
+public final class CrashReportController {
+    /// Reports awaiting the user's attention, oldest first.
+    public private(set) var pendingReports: [CrashReport] = []
+
+    private let store: CrashReportStore
+
+    public init(store: CrashReportStore) {
+        self.store = store
+    }
+
+    /// The report to surface right now, or `nil` when there is nothing to show.
+    public var currentReport: CrashReport? {
+        pendingReports.first
+    }
+
+    /// Loads persisted reports from disk. Called once on launch.
+    public func loadPendingReports() async {
+        let store = store
+        pendingReports = await Task.detached(priority: .utility) {
+            store.pendingReports()
+        }.value
+    }
+
+    /// A pre-filled GitHub issue URL for `report`. Opening it is the caller's
+    /// responsibility (via `openURL`), so nothing is transmitted automatically.
+    public func issueURL(for report: CrashReport) -> URL {
+        CrashReportIssue.url(for: report)
+    }
+
+    /// Removes `report` from disk and drops it from the queue, advancing to the
+    /// next pending report (if any).
+    public func discard(_ report: CrashReport) {
+        store.remove(report)
+        pendingReports.removeAll { $0.id == report.id }
+    }
+}

--- a/Sources/BrewCrashReporting/CrashReportEnvironment.swift
+++ b/Sources/BrewCrashReporting/CrashReportEnvironment.swift
@@ -5,11 +5,9 @@
 
 import Foundation
 
-/// The static environment details captured alongside a crash so a maintainer
-/// reading the resulting GitHub issue can tell which build and OS produced it.
-///
-/// Kept deliberately small and `Sendable` so it can be stashed in the global
-/// state a signal handler reads (see `CrashReportInstaller`).
+/// Build and OS details captured alongside a crash so a maintainer reading the
+/// GitHub issue can tell which version produced it. `Sendable` so a signal
+/// handler can read it from global state (see `CrashReportInstaller`).
 public struct CrashReportEnvironment: Sendable, Equatable {
     public let appVersion: String
     public let buildNumber: String
@@ -21,10 +19,8 @@ public struct CrashReportEnvironment: Sendable, Equatable {
         self.osVersion = osVersion
     }
 
-    /// Reads the running app's version + OS from `bundle` / `ProcessInfo`.
-    ///
-    /// Falls back to `"unknown"` rather than crashing while *reporting* a crash —
-    /// a missing Info.plist key must never take precedence over the real report.
+    /// Reads the running app's version and OS, falling back to `"unknown"` — a
+    /// missing Info.plist key must never derail reporting an actual crash.
     public static func current(
         bundle: Bundle = .main,
         processInfo: ProcessInfo = .processInfo,

--- a/Sources/BrewCrashReporting/CrashReportEnvironment.swift
+++ b/Sources/BrewCrashReporting/CrashReportEnvironment.swift
@@ -1,0 +1,41 @@
+//
+//  CrashReportEnvironment.swift
+//  Brew
+//
+
+import Foundation
+
+/// The static environment details captured alongside a crash so a maintainer
+/// reading the resulting GitHub issue can tell which build and OS produced it.
+///
+/// Kept deliberately small and `Sendable` so it can be stashed in the global
+/// state a signal handler reads (see `CrashReportInstaller`).
+public struct CrashReportEnvironment: Sendable, Equatable {
+    public let appVersion: String
+    public let buildNumber: String
+    public let osVersion: String
+
+    public init(appVersion: String, buildNumber: String, osVersion: String) {
+        self.appVersion = appVersion
+        self.buildNumber = buildNumber
+        self.osVersion = osVersion
+    }
+
+    /// Reads the running app's version + OS from `bundle` / `ProcessInfo`.
+    ///
+    /// Falls back to `"unknown"` rather than crashing while *reporting* a crash —
+    /// a missing Info.plist key must never take precedence over the real report.
+    public static func current(
+        bundle: Bundle = .main,
+        processInfo: ProcessInfo = .processInfo,
+    ) -> CrashReportEnvironment {
+        let info = bundle.infoDictionary
+        let shortVersion = info?["CFBundleShortVersionString"] as? String ?? "unknown"
+        let build = info?["CFBundleVersion"] as? String ?? "unknown"
+        return CrashReportEnvironment(
+            appVersion: shortVersion,
+            buildNumber: build,
+            osVersion: processInfo.operatingSystemVersionString,
+        )
+    }
+}

--- a/Sources/BrewCrashReporting/CrashReportFormatter.swift
+++ b/Sources/BrewCrashReporting/CrashReportFormatter.swift
@@ -1,0 +1,72 @@
+//
+//  CrashReportFormatter.swift
+//  Brew
+//
+
+import Foundation
+
+/// Builds the human-readable text of a crash report.
+///
+/// Two entry points, matching the two capture paths:
+/// - ``signalReportHeader(environment:date:)`` produces the fixed header string
+///   that a signal handler writes ahead of a raw `backtrace_symbols_fd` dump.
+///   It must be fully materialised *before* the crash (at install time) because
+///   building strings inside a signal handler is not async-signal-safe.
+/// - ``makeReportText(kind:detail:callStack:environment:date:)`` builds a
+///   complete report for the uncaught-exception path, where Foundation is safe
+///   to use.
+public enum CrashReportFormatter {
+    /// The header written before a signal handler's raw stack dump. The call
+    /// stack itself is appended by `backtrace_symbols_fd`, so this ends with a
+    /// `Call stack:` marker and trailing newline.
+    public static func signalReportHeader(
+        environment: CrashReportEnvironment,
+        date: Date,
+    ) -> String {
+        """
+        Homebrew.app crash report
+        =========================
+        \(environmentLines(environment: environment, date: date))
+        Type: Fatal signal
+
+        Call stack:
+        """ + "\n"
+    }
+
+    /// A complete report for the uncaught-exception path.
+    public static func makeReportText(
+        kind: String,
+        detail: String?,
+        callStack: [String],
+        environment: CrashReportEnvironment,
+        date: Date,
+    ) -> String {
+        var lines = """
+        Homebrew.app crash report
+        =========================
+        \(environmentLines(environment: environment, date: date))
+        Type: \(kind)
+        """
+
+        if let detail, !detail.isEmpty {
+            lines += "\nReason: \(detail)"
+        }
+
+        lines += "\n\nCall stack:\n"
+        lines += callStack.joined(separator: "\n")
+        return lines
+    }
+
+    private static func environmentLines(
+        environment: CrashReportEnvironment,
+        date: Date,
+    ) -> String {
+        // `ISO8601Format()` is a `Sendable` value-type formatter — stable,
+        // sortable, and readable in a GitHub issue.
+        """
+        Date: \(date.ISO8601Format())
+        App version: \(environment.appVersion) (\(environment.buildNumber))
+        macOS: \(environment.osVersion)
+        """
+    }
+}

--- a/Sources/BrewCrashReporting/CrashReportFormatter.swift
+++ b/Sources/BrewCrashReporting/CrashReportFormatter.swift
@@ -6,19 +6,10 @@
 import Foundation
 
 /// Builds the human-readable text of a crash report.
-///
-/// Two entry points, matching the two capture paths:
-/// - ``signalReportHeader(environment:date:)`` produces the fixed header string
-///   that a signal handler writes ahead of a raw `backtrace_symbols_fd` dump.
-///   It must be fully materialised *before* the crash (at install time) because
-///   building strings inside a signal handler is not async-signal-safe.
-/// - ``makeReportText(kind:detail:callStack:environment:date:)`` builds a
-///   complete report for the uncaught-exception path, where Foundation is safe
-///   to use.
 public enum CrashReportFormatter {
-    /// The header written before a signal handler's raw stack dump. The call
-    /// stack itself is appended by `backtrace_symbols_fd`, so this ends with a
-    /// `Call stack:` marker and trailing newline.
+    /// The header a signal handler writes before its raw `backtrace_symbols_fd`
+    /// dump, so it ends with a `Call stack:` marker and newline. Must be built
+    /// before the crash — string building is not async-signal-safe.
     public static func signalReportHeader(
         environment: CrashReportEnvironment,
         date: Date,
@@ -33,7 +24,6 @@ public enum CrashReportFormatter {
         """ + "\n"
     }
 
-    /// A complete report for the uncaught-exception path.
     public static func makeReportText(
         kind: String,
         detail: String?,
@@ -61,8 +51,6 @@ public enum CrashReportFormatter {
         environment: CrashReportEnvironment,
         date: Date,
     ) -> String {
-        // `ISO8601Format()` is a `Sendable` value-type formatter — stable,
-        // sortable, and readable in a GitHub issue.
         """
         Date: \(date.ISO8601Format())
         App version: \(environment.appVersion) (\(environment.buildNumber))

--- a/Sources/BrewCrashReporting/CrashReportInstaller.swift
+++ b/Sources/BrewCrashReporting/CrashReportInstaller.swift
@@ -1,0 +1,149 @@
+//
+//  CrashReportInstaller.swift
+//  Brew
+//
+
+import Darwin
+import Foundation
+
+/// Installs process-wide crash capture: an uncaught-Objective-C-exception
+/// handler and POSIX signal handlers for the common fatal signals. When either
+/// fires, a report is written to the ``CrashReportStore`` so it can be shown on
+/// the next launch.
+///
+/// This is intentionally *basic* crash handling. The signal path is written to
+/// respect async-signal-safety as far as is practical from Swift: the file path
+/// and header are materialised up-front (at install time), and at crash time we
+/// only `open`/`write`/`backtrace_symbols_fd`/`close`, then restore the default
+/// handler and re-raise so the OS still records its own crash report. Building
+/// Swift strings inside a signal handler is unsafe, so the signal path never
+/// does — it writes a pre-built C string header and static literals only.
+public enum CrashReportInstaller {
+    /// Fatal signals we install handlers for. `SIGABRT` covers Swift runtime
+    /// traps and failed assertions; the rest are hardware/EXC faults.
+    private static let handledSignals: [Int32] = [SIGABRT, SIGBUS, SIGFPE, SIGILL, SIGSEGV, SIGTRAP]
+
+    /// Installs the handlers. Safe to call once, early in app launch.
+    ///
+    /// - Parameters:
+    ///   - store: where reports are written.
+    ///   - environment: build/OS details baked into every report.
+    ///   - date: capture time for the signal-path file (defaults to now); the
+    ///     signal handler cannot compute a timestamp safely, so it is fixed here.
+    public static func install(
+        store: CrashReportStore,
+        environment: CrashReportEnvironment,
+        date: Date = Date(),
+    ) {
+        try? store.ensureDirectoryExists()
+
+        // Pre-materialise everything the signal handler needs. `strdup` heap
+        // allocations happen here, at install time — never inside the handler.
+        let path = store.reportFileURL(for: date).path
+        signalReportPath = strdup(path)
+        signalReportHeader = strdup(CrashReportFormatter.signalReportHeader(
+            environment: environment,
+            date: date,
+        ))
+
+        // The uncaught-exception path runs in a near-normal context where
+        // Foundation is safe, so it can build a richer report on the fly.
+        exceptionStore = store
+        exceptionEnvironment = environment
+
+        NSSetUncaughtExceptionHandler(handleUncaughtException)
+
+        for signalNumber in handledSignals {
+            signal(signalNumber, handleFatalSignal)
+        }
+    }
+}
+
+// MARK: - Global handler state
+
+//
+// Signal handlers and `NSSetUncaughtExceptionHandler` take non-capturing
+// C function pointers, so the context they need lives in module-global state.
+// Synchronisation: each variable is written exactly once, during `install()` at
+// launch, strictly before any handler can fire; thereafter it is read-only and
+// only touched from the crashing thread. That write-once-then-read-only
+// discipline is the external synchronisation that makes the unchecked
+// annotation below sound.
+
+// swiftlint:disable:next nonisolated_unsafe
+private nonisolated(unsafe) var signalReportPath: UnsafeMutablePointer<CChar>?
+// swiftlint:disable:next nonisolated_unsafe
+private nonisolated(unsafe) var signalReportHeader: UnsafeMutablePointer<CChar>?
+// swiftlint:disable:next nonisolated_unsafe
+private nonisolated(unsafe) var exceptionStore: CrashReportStore?
+// swiftlint:disable:next nonisolated_unsafe
+private nonisolated(unsafe) var exceptionEnvironment: CrashReportEnvironment?
+
+// MARK: - Signal path (async-signal-safe)
+
+private let handleFatalSignal: @convention(c) (Int32) -> Void = { signalNumber in
+    if let path = signalReportPath {
+        let fileDescriptor = open(path, O_WRONLY | O_CREAT | O_APPEND, 0o644)
+        if fileDescriptor >= 0 {
+            if let header = signalReportHeader {
+                _ = write(fileDescriptor, header, strlen(header))
+            }
+            writeSignalName(fileDescriptor, signalNumber)
+            writeBacktrace(to: fileDescriptor)
+            close(fileDescriptor)
+        }
+    }
+
+    // Restore the default disposition and re-raise so the OS produces its own
+    // crash report and the process terminates as it normally would.
+    signal(signalNumber, SIG_DFL)
+    raise(signalNumber)
+}
+
+/// Writes the signal's name using `StaticString`, whose bytes live in static
+/// storage — no allocation, so this is safe inside a signal handler.
+private func writeSignalName(_ fileDescriptor: Int32, _ signalNumber: Int32) {
+    let name: StaticString = switch signalNumber {
+    case SIGABRT: "Signal: SIGABRT\n"
+    case SIGBUS: "Signal: SIGBUS\n"
+    case SIGFPE: "Signal: SIGFPE\n"
+    case SIGILL: "Signal: SIGILL\n"
+    case SIGSEGV: "Signal: SIGSEGV\n"
+    case SIGTRAP: "Signal: SIGTRAP\n"
+    default: "Signal: unknown\n"
+    }
+    name.withUTF8Buffer { buffer in
+        _ = write(fileDescriptor, buffer.baseAddress, buffer.count)
+    }
+}
+
+/// Dumps the current call stack straight to `fileDescriptor`.
+/// `backtrace_symbols_fd` is documented as async-signal-safe, and the frame
+/// buffer is stack-allocated to avoid touching the heap.
+private func writeBacktrace(to fileDescriptor: Int32) {
+    let maxFrames = 128
+    withUnsafeTemporaryAllocation(
+        of: UnsafeMutableRawPointer?.self,
+        capacity: maxFrames,
+    ) { buffer in
+        let frameCount = backtrace(buffer.baseAddress, Int32(maxFrames))
+        backtrace_symbols_fd(buffer.baseAddress, frameCount, fileDescriptor)
+    }
+}
+
+// MARK: - Uncaught-exception path
+
+private let handleUncaughtException: @convention(c) (NSException) -> Void = { exception in
+    guard let store = exceptionStore, let environment = exceptionEnvironment else {
+        return
+    }
+
+    let text = CrashReportFormatter.makeReportText(
+        kind: "Uncaught exception \(exception.name.rawValue)",
+        detail: exception.reason,
+        callStack: exception.callStackSymbols,
+        environment: environment,
+        date: Date(),
+    )
+    _ = try? store.save(text: text, date: Date())
+}

--- a/Sources/BrewCrashReporting/CrashReportInstaller.swift
+++ b/Sources/BrewCrashReporting/CrashReportInstaller.swift
@@ -26,13 +26,18 @@ public enum CrashReportInstaller {
     ) {
         try? store.ensureDirectoryExists()
 
-        // `strdup` heap allocations happen here so the signal handler never touches the heap.
+        // Everything the signal handler touches is allocated here, at install
+        // time, so the handler itself never reaches for the heap.
         let path = store.reportFileURL(for: date).path
         signalReportPath = strdup(path)
-        signalReportHeader = strdup(CrashReportFormatter.signalReportHeader(
-            environment: environment,
-            date: date,
-        ))
+
+        let header = CrashReportFormatter.signalReportHeader(environment: environment, date: date)
+        signalReportHeader = strdup(header)
+        signalReportHeaderLength = header.utf8.count
+
+        signalFrameBuffer = UnsafeMutablePointer<UnsafeMutableRawPointer?>.allocate(
+            capacity: signalFrameCapacity,
+        )
 
         // The exception path runs in a near-normal context, so it builds its report on the fly.
         exceptionStore = store
@@ -40,8 +45,15 @@ public enum CrashReportInstaller {
 
         NSSetUncaughtExceptionHandler(handleUncaughtException)
 
+        // `SA_RESETHAND` restores the default disposition before the handler
+        // runs (so the re-raise below terminates the process); `SA_NODEFER`
+        // lets that re-raise deliver synchronously rather than being blocked.
+        var action = sigaction()
+        action.__sigaction_u.__sa_handler = handleFatalSignal
+        action.sa_flags = SA_RESETHAND | SA_NODEFER
+        sigemptyset(&action.sa_mask)
         for signalNumber in handledSignals {
-            signal(signalNumber, handleFatalSignal)
+            sigaction(signalNumber, &action, nil)
         }
     }
 }
@@ -56,6 +68,13 @@ public enum CrashReportInstaller {
 private nonisolated(unsafe) var signalReportPath: UnsafeMutablePointer<CChar>?
 // swiftlint:disable:next nonisolated_unsafe
 private nonisolated(unsafe) var signalReportHeader: UnsafeMutablePointer<CChar>?
+// The header's byte length, computed at install time so the handler avoids `strlen`.
+// swiftlint:disable:next nonisolated_unsafe
+private nonisolated(unsafe) var signalReportHeaderLength = 0
+/// Backtrace frame buffer, allocated once at install time so the handler never calls `malloc`.
+private let signalFrameCapacity = 128
+// swiftlint:disable:next nonisolated_unsafe
+private nonisolated(unsafe) var signalFrameBuffer: UnsafeMutablePointer<UnsafeMutableRawPointer?>?
 // swiftlint:disable:next nonisolated_unsafe
 private nonisolated(unsafe) var exceptionStore: CrashReportStore?
 // swiftlint:disable:next nonisolated_unsafe
@@ -68,7 +87,7 @@ private let handleFatalSignal: @convention(c) (Int32) -> Void = { signalNumber i
         let fileDescriptor = open(path, O_WRONLY | O_CREAT | O_APPEND, 0o644)
         if fileDescriptor >= 0 {
             if let header = signalReportHeader {
-                _ = write(fileDescriptor, header, strlen(header))
+                _ = write(fileDescriptor, header, signalReportHeaderLength)
             }
             writeSignalName(fileDescriptor, signalNumber)
             writeBacktrace(to: fileDescriptor)
@@ -76,8 +95,8 @@ private let handleFatalSignal: @convention(c) (Int32) -> Void = { signalNumber i
         }
     }
 
-    // Re-raise under the default handler so the OS records its own report and terminates.
-    signal(signalNumber, SIG_DFL)
+    // `SA_RESETHAND` has already restored the default disposition; re-raise so
+    // the OS records its own report and the process terminates.
     raise(signalNumber)
 }
 
@@ -97,17 +116,14 @@ private func writeSignalName(_ fileDescriptor: Int32, _ signalNumber: Int32) {
     }
 }
 
-/// `backtrace_symbols_fd` is async-signal-safe; the frame buffer is stack-allocated
-/// to keep off the heap.
+/// `backtrace_symbols_fd` is async-signal-safe; it writes into the buffer that
+/// was pre-allocated at install time, so nothing here touches the heap.
 private func writeBacktrace(to fileDescriptor: Int32) {
-    let maxFrames = 128
-    withUnsafeTemporaryAllocation(
-        of: UnsafeMutableRawPointer?.self,
-        capacity: maxFrames,
-    ) { buffer in
-        let frameCount = backtrace(buffer.baseAddress, Int32(maxFrames))
-        backtrace_symbols_fd(buffer.baseAddress, frameCount, fileDescriptor)
+    guard let buffer = signalFrameBuffer else {
+        return
     }
+    let frameCount = backtrace(buffer, Int32(signalFrameCapacity))
+    backtrace_symbols_fd(buffer, frameCount, fileDescriptor)
 }
 
 // MARK: - Uncaught-exception path

--- a/Sources/BrewCrashReporting/CrashReportInstaller.swift
+++ b/Sources/BrewCrashReporting/CrashReportInstaller.swift
@@ -117,12 +117,13 @@ private let handleUncaughtException: @convention(c) (NSException) -> Void = { ex
         return
     }
 
+    let date = Date()
     let text = CrashReportFormatter.makeReportText(
         kind: "Uncaught exception \(exception.name.rawValue)",
         detail: exception.reason,
         callStack: exception.callStackSymbols,
         environment: environment,
-        date: Date(),
+        date: date,
     )
-    _ = try? store.save(text: text, date: Date())
+    _ = try? store.save(text: text, date: date)
 }

--- a/Sources/BrewCrashReporting/CrashReportInstaller.swift
+++ b/Sources/BrewCrashReporting/CrashReportInstaller.swift
@@ -6,30 +6,19 @@
 import Darwin
 import Foundation
 
-/// Installs process-wide crash capture: an uncaught-Objective-C-exception
-/// handler and POSIX signal handlers for the common fatal signals. When either
-/// fires, a report is written to the ``CrashReportStore`` so it can be shown on
-/// the next launch.
+/// Installs process-wide crash capture — an uncaught-exception handler plus
+/// POSIX signal handlers — that writes a report to the ``CrashReportStore`` for
+/// display on the next launch.
 ///
-/// This is intentionally *basic* crash handling. The signal path is written to
-/// respect async-signal-safety as far as is practical from Swift: the file path
-/// and header are materialised up-front (at install time), and at crash time we
-/// only `open`/`write`/`backtrace_symbols_fd`/`close`, then restore the default
-/// handler and re-raise so the OS still records its own crash report. Building
-/// Swift strings inside a signal handler is unsafe, so the signal path never
-/// does — it writes a pre-built C string header and static literals only.
+/// The signal path is async-signal-safe: everything it needs (file path,
+/// header) is materialised at install time, and at crash time it only does
+/// `open`/`write`/`backtrace_symbols_fd`/`close` before re-raising so the OS
+/// still records its own report. It never builds Swift strings.
 public enum CrashReportInstaller {
-    /// Fatal signals we install handlers for. `SIGABRT` covers Swift runtime
-    /// traps and failed assertions; the rest are hardware/EXC faults.
     private static let handledSignals: [Int32] = [SIGABRT, SIGBUS, SIGFPE, SIGILL, SIGSEGV, SIGTRAP]
 
-    /// Installs the handlers. Safe to call once, early in app launch.
-    ///
-    /// - Parameters:
-    ///   - store: where reports are written.
-    ///   - environment: build/OS details baked into every report.
-    ///   - date: capture time for the signal-path file (defaults to now); the
-    ///     signal handler cannot compute a timestamp safely, so it is fixed here.
+    /// Call once, early in launch. `date` is fixed here because the signal
+    /// handler cannot compute a timestamp safely.
     public static func install(
         store: CrashReportStore,
         environment: CrashReportEnvironment,
@@ -37,8 +26,7 @@ public enum CrashReportInstaller {
     ) {
         try? store.ensureDirectoryExists()
 
-        // Pre-materialise everything the signal handler needs. `strdup` heap
-        // allocations happen here, at install time — never inside the handler.
+        // `strdup` heap allocations happen here so the signal handler never touches the heap.
         let path = store.reportFileURL(for: date).path
         signalReportPath = strdup(path)
         signalReportHeader = strdup(CrashReportFormatter.signalReportHeader(
@@ -46,8 +34,7 @@ public enum CrashReportInstaller {
             date: date,
         ))
 
-        // The uncaught-exception path runs in a near-normal context where
-        // Foundation is safe, so it can build a richer report on the fly.
+        // The exception path runs in a near-normal context, so it builds its report on the fly.
         exceptionStore = store
         exceptionEnvironment = environment
 
@@ -61,14 +48,9 @@ public enum CrashReportInstaller {
 
 // MARK: - Global handler state
 
-//
-// Signal handlers and `NSSetUncaughtExceptionHandler` take non-capturing
-// C function pointers, so the context they need lives in module-global state.
-// Synchronisation: each variable is written exactly once, during `install()` at
-// launch, strictly before any handler can fire; thereafter it is read-only and
-// only touched from the crashing thread. That write-once-then-read-only
-// discipline is the external synchronisation that makes the unchecked
-// annotation below sound.
+// C function-pointer handlers can't capture context, so it lives in module globals.
+// Each is written exactly once during `install()`, before any handler can fire, then
+// read-only — that discipline is what makes the unchecked annotation below sound.
 
 // swiftlint:disable:next nonisolated_unsafe
 private nonisolated(unsafe) var signalReportPath: UnsafeMutablePointer<CChar>?
@@ -94,14 +76,12 @@ private let handleFatalSignal: @convention(c) (Int32) -> Void = { signalNumber i
         }
     }
 
-    // Restore the default disposition and re-raise so the OS produces its own
-    // crash report and the process terminates as it normally would.
+    // Re-raise under the default handler so the OS records its own report and terminates.
     signal(signalNumber, SIG_DFL)
     raise(signalNumber)
 }
 
-/// Writes the signal's name using `StaticString`, whose bytes live in static
-/// storage — no allocation, so this is safe inside a signal handler.
+/// `StaticString` bytes live in static storage, so writing them allocates nothing.
 private func writeSignalName(_ fileDescriptor: Int32, _ signalNumber: Int32) {
     let name: StaticString = switch signalNumber {
     case SIGABRT: "Signal: SIGABRT\n"
@@ -117,9 +97,8 @@ private func writeSignalName(_ fileDescriptor: Int32, _ signalNumber: Int32) {
     }
 }
 
-/// Dumps the current call stack straight to `fileDescriptor`.
-/// `backtrace_symbols_fd` is documented as async-signal-safe, and the frame
-/// buffer is stack-allocated to avoid touching the heap.
+/// `backtrace_symbols_fd` is async-signal-safe; the frame buffer is stack-allocated
+/// to keep off the heap.
 private func writeBacktrace(to fileDescriptor: Int32) {
     let maxFrames = 128
     withUnsafeTemporaryAllocation(

--- a/Sources/BrewCrashReporting/CrashReportIssue.swift
+++ b/Sources/BrewCrashReporting/CrashReportIssue.swift
@@ -1,0 +1,62 @@
+//
+//  CrashReportIssue.swift
+//  Brew
+//
+
+import Foundation
+
+/// Builds a pre-filled "new issue" URL on the app's GitHub repository from a
+/// crash report, so a user can file it with one click.
+public enum CrashReportIssue {
+    /// The app's GitHub repository.
+    public static let repositoryURL = URL(string: "https://github.com/Homebrew/BrewUI")!
+
+    /// GitHub rejects issue URLs whose body is too long. Keep the encoded body
+    /// well under GitHub's ~8k URL ceiling; anything longer is truncated with a
+    /// note asking the user to attach the full log.
+    static let maxBodyLength = 6000
+
+    /// A pre-filled new-issue URL. The user still reviews and submits it on
+    /// GitHub — nothing is sent automatically.
+    public static func url(for report: CrashReport) -> URL {
+        var components = URLComponents(
+            url: repositoryURL.appendingPathComponent("issues/new"),
+            resolvingAgainstBaseURL: false,
+        )!
+        components.queryItems = [
+            URLQueryItem(name: "title", value: "Crash: \(report.summary)"),
+            URLQueryItem(name: "body", value: body(for: report)),
+        ]
+        // `URLComponents` leaves some sub-delimiters unescaped; GitHub is happy
+        // with the default encoding, so `components.url` is sufficient.
+        return components.url ?? repositoryURL
+    }
+
+    private static func body(for report: CrashReport) -> String {
+        let log = truncatedLog(report.text)
+        return """
+        <!-- Thanks for helping improve the Homebrew app. -->
+        The app crashed on a previous launch. Please describe what you were \
+        doing when it happened:
+
+
+
+        <details>
+        <summary>Automatic crash report</summary>
+
+        ```
+        \(log)
+        ```
+        </details>
+        """
+    }
+
+    private static func truncatedLog(_ text: String) -> String {
+        guard text.count > maxBodyLength else {
+            return text
+        }
+        let prefix = text.prefix(maxBodyLength)
+        return prefix + "\n… (truncated — please attach the full crash log from " +
+            "~/Library/Application Support/Brew/CrashReports)"
+    }
+}

--- a/Sources/BrewCrashReporting/CrashReportIssue.swift
+++ b/Sources/BrewCrashReporting/CrashReportIssue.swift
@@ -8,16 +8,12 @@ import Foundation
 /// Builds a pre-filled "new issue" URL on the app's GitHub repository from a
 /// crash report, so a user can file it with one click.
 public enum CrashReportIssue {
-    /// The app's GitHub repository.
     public static let repositoryURL = URL(string: "https://github.com/Homebrew/BrewUI")!
 
-    /// GitHub rejects issue URLs whose body is too long. Keep the encoded body
-    /// well under GitHub's ~8k URL ceiling; anything longer is truncated with a
-    /// note asking the user to attach the full log.
+    /// Kept under GitHub's ~8k URL ceiling; longer logs are truncated.
     static let maxBodyLength = 6000
 
-    /// A pre-filled new-issue URL. The user still reviews and submits it on
-    /// GitHub — nothing is sent automatically.
+    /// A pre-filled new-issue URL. Nothing is sent until the user submits it on GitHub.
     public static func url(for report: CrashReport) -> URL {
         var components = URLComponents(
             url: repositoryURL.appendingPathComponent("issues/new"),
@@ -27,8 +23,6 @@ public enum CrashReportIssue {
             URLQueryItem(name: "title", value: "Crash: \(report.summary)"),
             URLQueryItem(name: "body", value: body(for: report)),
         ]
-        // `URLComponents` leaves some sub-delimiters unescaped; GitHub is happy
-        // with the default encoding, so `components.url` is sufficient.
         return components.url ?? repositoryURL
     }
 

--- a/Sources/BrewCrashReporting/CrashReportStore.swift
+++ b/Sources/BrewCrashReporting/CrashReportStore.swift
@@ -5,38 +5,27 @@
 
 import Foundation
 
-/// Persists and enumerates crash reports on disk.
-///
-/// Reports live as individual `crash-<epochMillis>.log` text files in a
-/// dedicated directory so they can be written at crash time (via a raw file
-/// descriptor in a signal handler — see `CrashReportInstaller`) and read back
-/// on the next launch. The epoch-millis file name encodes the capture time,
-/// so no separate index or metadata file is needed.
-///
-/// The type is a small `Sendable` value: it holds only the directory URL and
-/// reaches for `FileManager.default` itself, mirroring `CatalogueCache`.
+/// Persists and enumerates crash reports on disk as individual
+/// `crash-<epochMillis>.log` text files — a format a signal handler can write
+/// via a raw file descriptor (see `CrashReportInstaller`), with the capture
+/// time encoded in the name so no separate index is needed. A small `Sendable`
+/// value holding only the directory, mirroring `CatalogueCache`.
 public struct CrashReportStore: Sendable {
     private let directoryURL: URL
 
-    /// - Parameter directoryURL: overrides the default location; tests pass a
-    ///   unique temporary directory to stay isolated.
     public init(directoryURL: URL? = nil) {
         self.directoryURL = directoryURL ?? Self.defaultDirectoryURL()
     }
 
-    /// The directory holding crash reports. Exposed so the installer can build
-    /// a file path up-front (before any crash) without duplicating the layout.
     public var directory: URL {
         directoryURL
     }
 
-    /// The deterministic file URL for a report captured at `date`.
     public func reportFileURL(for date: Date) -> URL {
         let millis = Int((date.timeIntervalSince1970 * 1000).rounded())
         return directoryURL.appendingPathComponent("crash-\(millis).log")
     }
 
-    /// Creates the reports directory if it does not already exist.
     public func ensureDirectoryExists() throws {
         try FileManager.default.createDirectory(
             at: directoryURL,
@@ -44,7 +33,6 @@ public struct CrashReportStore: Sendable {
         )
     }
 
-    /// Writes a full report and returns the persisted value.
     @discardableResult
     public func save(text: String, date: Date) throws -> CrashReport {
         try ensureDirectoryExists()
@@ -53,8 +41,8 @@ public struct CrashReportStore: Sendable {
         return CrashReport(id: url.lastPathComponent, capturedAt: date, text: text)
     }
 
-    /// All persisted reports, oldest first. Unreadable or malformed files are
-    /// skipped rather than surfaced — a broken report must not block the app.
+    /// All persisted reports, oldest first; unreadable files are skipped so a
+    /// broken report can't block the app.
     public func pendingReports() -> [CrashReport] {
         let fileManager = FileManager.default
         guard let names = try? fileManager.contentsOfDirectory(atPath: directoryURL.path) else {
@@ -66,13 +54,10 @@ public struct CrashReportStore: Sendable {
             .sorted { $0.capturedAt < $1.capturedAt }
     }
 
-    /// Deletes a single report. Best-effort: a failure to delete is not worth
-    /// crashing over.
     public func remove(_ report: CrashReport) {
         try? FileManager.default.removeItem(at: directoryURL.appendingPathComponent(report.id))
     }
 
-    /// Deletes every persisted report.
     public func removeAll() {
         for report in pendingReports() {
             remove(report)

--- a/Sources/BrewCrashReporting/CrashReportStore.swift
+++ b/Sources/BrewCrashReporting/CrashReportStore.swift
@@ -1,0 +1,112 @@
+//
+//  CrashReportStore.swift
+//  Brew
+//
+
+import Foundation
+
+/// Persists and enumerates crash reports on disk.
+///
+/// Reports live as individual `crash-<epochMillis>.log` text files in a
+/// dedicated directory so they can be written at crash time (via a raw file
+/// descriptor in a signal handler — see `CrashReportInstaller`) and read back
+/// on the next launch. The epoch-millis file name encodes the capture time,
+/// so no separate index or metadata file is needed.
+///
+/// The type is a small `Sendable` value: it holds only the directory URL and
+/// reaches for `FileManager.default` itself, mirroring `CatalogueCache`.
+public struct CrashReportStore: Sendable {
+    private let directoryURL: URL
+
+    /// - Parameter directoryURL: overrides the default location; tests pass a
+    ///   unique temporary directory to stay isolated.
+    public init(directoryURL: URL? = nil) {
+        self.directoryURL = directoryURL ?? Self.defaultDirectoryURL()
+    }
+
+    /// The directory holding crash reports. Exposed so the installer can build
+    /// a file path up-front (before any crash) without duplicating the layout.
+    public var directory: URL {
+        directoryURL
+    }
+
+    /// The deterministic file URL for a report captured at `date`.
+    public func reportFileURL(for date: Date) -> URL {
+        let millis = Int((date.timeIntervalSince1970 * 1000).rounded())
+        return directoryURL.appendingPathComponent("crash-\(millis).log")
+    }
+
+    /// Creates the reports directory if it does not already exist.
+    public func ensureDirectoryExists() throws {
+        try FileManager.default.createDirectory(
+            at: directoryURL,
+            withIntermediateDirectories: true,
+        )
+    }
+
+    /// Writes a full report and returns the persisted value.
+    @discardableResult
+    public func save(text: String, date: Date) throws -> CrashReport {
+        try ensureDirectoryExists()
+        let url = reportFileURL(for: date)
+        try Data(text.utf8).write(to: url, options: .atomic)
+        return CrashReport(id: url.lastPathComponent, capturedAt: date, text: text)
+    }
+
+    /// All persisted reports, oldest first. Unreadable or malformed files are
+    /// skipped rather than surfaced — a broken report must not block the app.
+    public func pendingReports() -> [CrashReport] {
+        let fileManager = FileManager.default
+        guard let names = try? fileManager.contentsOfDirectory(atPath: directoryURL.path) else {
+            return []
+        }
+
+        return names
+            .compactMap(makeReport(fromFileNamed:))
+            .sorted { $0.capturedAt < $1.capturedAt }
+    }
+
+    /// Deletes a single report. Best-effort: a failure to delete is not worth
+    /// crashing over.
+    public func remove(_ report: CrashReport) {
+        try? FileManager.default.removeItem(at: directoryURL.appendingPathComponent(report.id))
+    }
+
+    /// Deletes every persisted report.
+    public func removeAll() {
+        for report in pendingReports() {
+            remove(report)
+        }
+    }
+
+    private func makeReport(fromFileNamed name: String) -> CrashReport? {
+        guard name.hasPrefix("crash-"), name.hasSuffix(".log") else {
+            return nil
+        }
+
+        let stem = name.dropFirst("crash-".count).dropLast(".log".count)
+        guard let millis = Int(stem) else {
+            return nil
+        }
+
+        let url = directoryURL.appendingPathComponent(name)
+        guard let text = try? String(contentsOf: url, encoding: .utf8) else {
+            return nil
+        }
+
+        return CrashReport(
+            id: name,
+            capturedAt: Date(timeIntervalSince1970: Double(millis) / 1000),
+            text: text,
+        )
+    }
+
+    private static func defaultDirectoryURL() -> URL {
+        let fileManager = FileManager.default
+        let base = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? fileManager.temporaryDirectory
+        return base
+            .appendingPathComponent("Brew", isDirectory: true)
+            .appendingPathComponent("CrashReports", isDirectory: true)
+    }
+}

--- a/Sources/BrewCrashReporting/CrashReportStore.swift
+++ b/Sources/BrewCrashReporting/CrashReportStore.swift
@@ -7,9 +7,9 @@ import Foundation
 
 /// Persists and enumerates crash reports on disk as individual
 /// `crash-<epochMillis>.log` text files — a format a signal handler can write
-/// via a raw file descriptor (see `CrashReportInstaller`), with the capture
-/// time encoded in the name so no separate index is needed. A small `Sendable`
-/// value holding only the directory, mirroring `CatalogueCache`.
+/// via a raw file descriptor (see `CrashReportInstaller`). The timestamp in the
+/// name is provided by the caller (for fatal signals it's the install-time `date`).
+/// A small `Sendable` value holding only the directory, mirroring `CatalogueCache`.
 public struct CrashReportStore: Sendable {
     private let directoryURL: URL
 

--- a/Tests/BrewCrashReportingTests/CrashReportControllerTests.swift
+++ b/Tests/BrewCrashReportingTests/CrashReportControllerTests.swift
@@ -1,0 +1,50 @@
+//
+//  CrashReportControllerTests.swift
+//  BrewTests
+//
+
+@testable import BrewCrashReporting
+import Foundation
+import Testing
+
+private func makeTemporaryStore() -> CrashReportStore {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("CrashReportControllerTests-\(UUID().uuidString)", isDirectory: true)
+    return CrashReportStore(directoryURL: directory)
+}
+
+@MainActor
+struct CrashReportControllerTests {
+    @Test func `loading surfaces the oldest report first`() async throws {
+        let store = makeTemporaryStore()
+        try store.save(text: "older", date: Date(timeIntervalSince1970: 1000))
+        try store.save(text: "newer", date: Date(timeIntervalSince1970: 2000))
+        let controller = CrashReportController(store: store)
+
+        await controller.loadPendingReports()
+
+        #expect(controller.currentReport?.text == "older")
+    }
+
+    @Test func `discarding advances to the next report and deletes it from disk`() async throws {
+        let store = makeTemporaryStore()
+        try store.save(text: "older", date: Date(timeIntervalSince1970: 1000))
+        try store.save(text: "newer", date: Date(timeIntervalSince1970: 2000))
+        let controller = CrashReportController(store: store)
+        await controller.loadPendingReports()
+
+        let older = try #require(controller.currentReport)
+        controller.discard(older)
+
+        #expect(controller.currentReport?.text == "newer")
+        #expect(store.pendingReports().map(\.text) == ["newer"])
+    }
+
+    @Test func `current report is nil when nothing is pending`() async {
+        let controller = CrashReportController(store: makeTemporaryStore())
+
+        await controller.loadPendingReports()
+
+        #expect(controller.currentReport == nil)
+    }
+}

--- a/Tests/BrewCrashReportingTests/CrashReportFormatterTests.swift
+++ b/Tests/BrewCrashReportingTests/CrashReportFormatterTests.swift
@@ -1,0 +1,53 @@
+//
+//  CrashReportFormatterTests.swift
+//  BrewTests
+//
+
+@testable import BrewCrashReporting
+import Foundation
+import Testing
+
+private let sampleEnvironment = CrashReportEnvironment(
+    appVersion: "1.2.3",
+    buildNumber: "45",
+    osVersion: "Version 26.0 (Build 26A1)",
+)
+
+struct CrashReportFormatterTests {
+    @Test func `signal header includes version, os, and a call-stack marker`() {
+        let header = CrashReportFormatter.signalReportHeader(
+            environment: sampleEnvironment,
+            date: Date(timeIntervalSince1970: 0),
+        )
+
+        #expect(header.contains("App version: 1.2.3 (45)"))
+        #expect(header.contains("macOS: Version 26.0 (Build 26A1)"))
+        #expect(header.hasSuffix("Call stack:\n"))
+    }
+
+    @Test func `exception report joins the call stack and includes the reason`() {
+        let text = CrashReportFormatter.makeReportText(
+            kind: "Uncaught exception NSRangeException",
+            detail: "index out of bounds",
+            callStack: ["0 frame-a", "1 frame-b"],
+            environment: sampleEnvironment,
+            date: Date(timeIntervalSince1970: 0),
+        )
+
+        #expect(text.contains("Type: Uncaught exception NSRangeException"))
+        #expect(text.contains("Reason: index out of bounds"))
+        #expect(text.contains("0 frame-a\n1 frame-b"))
+    }
+
+    @Test func `exception report omits the reason line when there is none`() {
+        let text = CrashReportFormatter.makeReportText(
+            kind: "Fatal signal",
+            detail: nil,
+            callStack: ["0 frame-a"],
+            environment: sampleEnvironment,
+            date: Date(timeIntervalSince1970: 0),
+        )
+
+        #expect(!text.contains("Reason:"))
+    }
+}

--- a/Tests/BrewCrashReportingTests/CrashReportIssueTests.swift
+++ b/Tests/BrewCrashReportingTests/CrashReportIssueTests.swift
@@ -1,0 +1,48 @@
+//
+//  CrashReportIssueTests.swift
+//  BrewTests
+//
+
+@testable import BrewCrashReporting
+import Foundation
+import Testing
+
+private func queryItems(of url: URL) -> [String: String] {
+    let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+    return Dictionary(
+        uniqueKeysWithValues: (components?.queryItems ?? []).map { ($0.name, $0.value ?? "") },
+    )
+}
+
+struct CrashReportIssueTests {
+    private func makeReport(text: String) -> CrashReport {
+        CrashReport(id: "crash-1.log", capturedAt: Date(timeIntervalSince1970: 0), text: text)
+    }
+
+    @Test func `issue url targets the new-issue page on the app repository`() {
+        let url = CrashReportIssue.url(for: makeReport(text: "Homebrew.app crash report"))
+
+        #expect(url.absoluteString.hasPrefix("https://github.com/Homebrew/BrewUI/issues/new"))
+    }
+
+    @Test func `issue title carries the report summary`() {
+        let url = CrashReportIssue.url(for: makeReport(text: "Homebrew.app crash report\n===\nSignal: SIGSEGV"))
+
+        #expect(queryItems(of: url)["title"] == "Crash: Homebrew.app crash report")
+    }
+
+    @Test func `issue body embeds the crash log in a code fence`() {
+        let url = CrashReportIssue.url(for: makeReport(text: "boom-marker"))
+
+        let body = try? #require(queryItems(of: url)["body"])
+        #expect(body?.contains("```\nboom-marker\n```") == true)
+    }
+
+    @Test func `oversized logs are truncated with an attach note`() {
+        let longText = String(repeating: "x", count: CrashReportIssue.maxBodyLength + 500)
+        let url = CrashReportIssue.url(for: makeReport(text: longText))
+
+        let body = try? #require(queryItems(of: url)["body"])
+        #expect(body?.contains("truncated") == true)
+    }
+}

--- a/Tests/BrewCrashReportingTests/CrashReportStoreTests.swift
+++ b/Tests/BrewCrashReportingTests/CrashReportStoreTests.swift
@@ -1,0 +1,81 @@
+//
+//  CrashReportStoreTests.swift
+//  BrewTests
+//
+
+@testable import BrewCrashReporting
+import Foundation
+import Testing
+
+private func makeTemporaryStore() -> CrashReportStore {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("CrashReportStoreTests-\(UUID().uuidString)", isDirectory: true)
+    return CrashReportStore(directoryURL: directory)
+}
+
+struct CrashReportStoreTests {
+    @Test func `save then pending reports round-trips the text`() throws {
+        let store = makeTemporaryStore()
+        let saved = try store.save(text: "boom", date: Date(timeIntervalSince1970: 1000))
+
+        let pending = store.pendingReports()
+
+        #expect(pending == [saved])
+    }
+
+    @Test func `pending reports are ordered oldest first`() throws {
+        let store = makeTemporaryStore()
+        try store.save(text: "newer", date: Date(timeIntervalSince1970: 2000))
+        try store.save(text: "older", date: Date(timeIntervalSince1970: 1000))
+
+        let texts = store.pendingReports().map(\.text)
+
+        #expect(texts == ["older", "newer"])
+    }
+
+    @Test func `capture time is recovered from the file name`() throws {
+        let store = makeTemporaryStore()
+        let date = Date(timeIntervalSince1970: 1234.567)
+        try store.save(text: "boom", date: date)
+
+        let captured = try #require(store.pendingReports().first).capturedAt
+
+        // File names carry millisecond precision, so allow sub-millisecond drift.
+        #expect(abs(captured.timeIntervalSince(date)) < 0.001)
+    }
+
+    @Test func `remove deletes a single report`() throws {
+        let store = makeTemporaryStore()
+        let first = try store.save(text: "first", date: Date(timeIntervalSince1970: 1000))
+        try store.save(text: "second", date: Date(timeIntervalSince1970: 2000))
+
+        store.remove(first)
+
+        #expect(store.pendingReports().map(\.text) == ["second"])
+    }
+
+    @Test func `remove all clears every report`() throws {
+        let store = makeTemporaryStore()
+        try store.save(text: "a", date: Date(timeIntervalSince1970: 1000))
+        try store.save(text: "b", date: Date(timeIntervalSince1970: 2000))
+
+        store.removeAll()
+
+        #expect(store.pendingReports().isEmpty)
+    }
+
+    @Test func `unrelated files in the directory are ignored`() throws {
+        let store = makeTemporaryStore()
+        try store.ensureDirectoryExists()
+        try Data("noise".utf8).write(to: store.directory.appendingPathComponent("notes.txt"))
+        let saved = try store.save(text: "boom", date: Date(timeIntervalSince1970: 1000))
+
+        #expect(store.pendingReports() == [saved])
+    }
+
+    @Test func `pending reports is empty when the directory is absent`() {
+        let store = makeTemporaryStore()
+
+        #expect(store.pendingReports().isEmpty)
+    }
+}

--- a/Tests/BrewCrashReportingTests/CrashReportTests.swift
+++ b/Tests/BrewCrashReportingTests/CrashReportTests.swift
@@ -1,0 +1,31 @@
+//
+//  CrashReportTests.swift
+//  BrewTests
+//
+
+@testable import BrewCrashReporting
+import Foundation
+import Testing
+
+struct CrashReportTests {
+    @Test func `summary is the first content line, skipping separators`() {
+        let report = CrashReport(
+            id: "crash-1.log",
+            capturedAt: Date(timeIntervalSince1970: 0),
+            text: """
+            Homebrew.app crash report
+            =========================
+
+            Signal: SIGSEGV
+            """,
+        )
+
+        #expect(report.summary == "Homebrew.app crash report")
+    }
+
+    @Test func `summary falls back when there is no content`() {
+        let report = CrashReport(id: "crash-1.log", capturedAt: Date(), text: "\n===\n")
+
+        #expect(report.summary == "Unexpected crash")
+    }
+}


### PR DESCRIPTION
# PR: Basic crash handling with a next-launch report dialog

## Summary

Adds lightweight crash capture to the Homebrew app. When the app crashes, a
report is written to disk; on the next launch the user is offered a pre-filled
GitHub issue so the crash can be reported in one click. Nothing is transmitted
automatically.

## Changes

**Core (`BrewCrashReporting`, new SwiftPM target):**
- `CrashReportInstaller` installs an uncaught-exception handler plus POSIX
  signal handlers (SIGABRT/BUS/FPE/ILL/SEGV/TRAP). The signal path is
  async-signal-safe: the file path and header are materialised at install time,
  and the handler only does `open`/`write`/`backtrace_symbols_fd`/`close` before
  re-raising so the OS still records its own report.
- `CrashReportStore` persists reports as `crash-<epochMillis>.log` text files;
  `CrashReportFormatter`/`CrashReportEnvironment` build the report body with
  app version and OS; `CrashReportIssue` builds the pre-filled new-issue URL;
  `CrashReportController` drives the UI state.

**App wiring:**
- Crash capture installs first thing in `BrewApp.init()`; `CrashReportSheet`
  presents `CrashReportDialog` for any pending reports one at a time.
- Help menu gains a "Report an Issue…" link.
- Debug menu gains a "Force Crash" submenu (DEBUG only) to exercise the flow.

**Release:**
- The archive's `Homebrew.app.dSYM` is now zipped, uploaded, and attached to the
  GitHub release so shipped crashes are symbolicatable (one set covers both the
  .pkg and .zip, which share a single archive).

## Why this split

Stacked on the release-pipeline branch; the dSYM change belongs here because it
makes captured crashes actionable.

## Testing

- [x] `scripts/test` — 19 new `BrewCrashReporting` unit tests pass.
- [x] `swiftformat --lint` and `swiftlint --strict` clean on changed scope.
- [x] Manually triggered both Debug "Force Crash" items; report appears on next launch.

## PR checklist

- [x] Have you followed this repository's contribution and workflow guidance?
- [x] Have you explained what changed and why this should land now?
- [x] Have you run relevant local checks for the changed scope?
- [x] Are changes scoped and free of unrelated modifications?

-----

- [x] AI was used to generate or assist with generating this PR.
- [x] If yes, describe exactly how AI was used and what manual verification was
  performed: Claude Code implemented the feature, tests, and release changes;
  the author reviewed the diff, ran the local checks above, and manually
  verified the crash-to-report flow in a DEBUG build.