### PR TITLE
Keep the search bar clickable when switching Installed/Upgrades tabs

### DIFF
--- a/Homebrew/Features/MainWindow/Views/MainWindowView.swift
+++ b/Homebrew/Features/MainWindow/Views/MainWindowView.swift
@@ -58,14 +58,19 @@ struct MainWindowView: View {
     @ViewBuilder
     private var featureColumn: some View {
         switch selectedSidebarItem {
-        case .installed:
-            InstalledColumnsRoot(deepLinkSelection: $pendingInstalledSelection)
-                .navigationTitle("Installed")
-                .navigationSubtitle("Browse or search your installed packages")
-        case .upgrades:
-            UpgradesColumnsRoot()
-                .navigationTitle("Upgrades")
-                .navigationSubtitle("Review and upgrade outdated packages")
+        // Installed and Upgrades share one persistent view so the toolbar search field keeps a
+        // stable identity across switches between them (see `InstalledUpgradesRoot`).
+        case .installed, .upgrades:
+            InstalledUpgradesRoot(
+                mode: selectedSidebarItem == .upgrades ? .upgrades : .installed,
+                deepLinkSelection: $pendingInstalledSelection,
+            )
+            .navigationTitle(selectedSidebarItem == .upgrades ? "Upgrades" : "Installed")
+            .navigationSubtitle(
+                selectedSidebarItem == .upgrades
+                    ? "Review and upgrade outdated packages"
+                    : "Browse or search your installed packages",
+            )
         case .discover:
             DiscoverColumnsRoot()
                 .navigationTitle("Discover")

--- a/Homebrew/Features/MainWindow/Views/MainWindowView.swift
+++ b/Homebrew/Features/MainWindow/Views/MainWindowView.swift
@@ -58,8 +58,8 @@ struct MainWindowView: View {
     @ViewBuilder
     private var featureColumn: some View {
         switch selectedSidebarItem {
-        // Installed and Upgrades share one persistent view so the toolbar search field keeps a
-        // stable identity across switches between them (see `InstalledUpgradesRoot`).
+        // One combined case keeps the shared toolbar search field alive across the switch
+        // (see `InstalledUpgradesRoot`).
         case .installed, .upgrades:
             InstalledUpgradesRoot(
                 mode: selectedSidebarItem == .upgrades ? .upgrades : .installed,

--- a/Sources/BrewFeatureInstalled/Views/InstalledColumns.swift
+++ b/Sources/BrewFeatureInstalled/Views/InstalledColumns.swift
@@ -4,39 +4,12 @@ import BrewRepositoryInterfaces
 import BrewUIComponents
 import SwiftUI
 
-public struct InstalledColumnsRoot: View {
-    @Environment(\.installedPackagesRepository) private var installedPackagesRepository
-    @Binding private var deepLinkSelection: InstalledBrewPackage.ID?
-
-    public init(deepLinkSelection: Binding<InstalledBrewPackage.ID?> = .constant(nil)) {
-        _deepLinkSelection = deepLinkSelection
-    }
-
-    public var body: some View {
-        InstalledColumns(
-            installedPackagesRepository: installedPackagesRepository,
-            deepLinkSelection: $deepLinkSelection,
-        )
-    }
-}
-
-/// Feature-owned content/detail columns for the main window.
+/// Feature-owned content/detail columns for the Installed tab. The view model is owned by
+/// ``InstalledUpgradesContainer`` so it (and the shared toolbar search field) survives switching
+/// between the Installed and Upgrades tabs.
 struct InstalledColumns: View {
-    @State var viewModel: InstalledViewModel
+    let viewModel: InstalledViewModel
     @Binding var deepLinkSelection: InstalledBrewPackage.ID?
-
-    init(
-        installedPackagesRepository: any InstalledPackagesRepository,
-        deepLinkSelection: Binding<InstalledBrewPackage.ID?>,
-    ) {
-        _viewModel = State(
-            initialValue: .init(
-                repository: installedPackagesRepository,
-                initialSelection: deepLinkSelection.wrappedValue,
-            ),
-        )
-        _deepLinkSelection = deepLinkSelection
-    }
 
     var body: some View {
         HSplitView {
@@ -70,8 +43,14 @@ struct InstalledColumns: View {
             )
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .onAppear {
-            if deepLinkSelection != nil { deepLinkSelection = nil }
+        // The view model now persists across tab switches, so a deep link can't be applied via the
+        // model's initialiser. Apply it whenever the pending selection changes (and on first
+        // appearance), then clear it. `initial: true` covers arriving at the tab with a selection
+        // already queued; `setSelection` sets it directly, so it works before the list has loaded.
+        .onChange(of: deepLinkSelection, initial: true) { _, pending in
+            guard let pending else { return }
+            viewModel.setSelection(pending)
+            deepLinkSelection = nil
         }
     }
 }

--- a/Sources/BrewFeatureInstalled/Views/InstalledColumns.swift
+++ b/Sources/BrewFeatureInstalled/Views/InstalledColumns.swift
@@ -4,9 +4,6 @@ import BrewRepositoryInterfaces
 import BrewUIComponents
 import SwiftUI
 
-/// Feature-owned content/detail columns for the Installed tab. The view model is owned by
-/// ``InstalledUpgradesContainer`` so it (and the shared toolbar search field) survives switching
-/// between the Installed and Upgrades tabs.
 struct InstalledColumns: View {
     let viewModel: InstalledViewModel
     @Binding var deepLinkSelection: InstalledBrewPackage.ID?
@@ -43,10 +40,8 @@ struct InstalledColumns: View {
             )
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        // The view model now persists across tab switches, so a deep link can't be applied via the
-        // model's initialiser. Apply it whenever the pending selection changes (and on first
-        // appearance), then clear it. `initial: true` covers arriving at the tab with a selection
-        // already queued; `setSelection` sets it directly, so it works before the list has loaded.
+        // The view model persists across tab switches, so a deep link can't go through its init.
+        // `initial: true` covers arriving with a selection already queued.
         .onChange(of: deepLinkSelection, initial: true) { _, pending in
             guard let pending else { return }
             viewModel.setSelection(pending)

--- a/Sources/BrewFeatureInstalled/Views/InstalledPackagesView.swift
+++ b/Sources/BrewFeatureInstalled/Views/InstalledPackagesView.swift
@@ -40,6 +40,9 @@ struct InstalledPackagesView: View {
                 },
             )
         }
+        .task {
+            await viewModel.load()
+        }
     }
 
     /// Persistent kind filter, always visible. Filters the loaded inventory client-side; never refetches.

--- a/Sources/BrewFeatureInstalled/Views/InstalledPackagesView.swift
+++ b/Sources/BrewFeatureInstalled/Views/InstalledPackagesView.swift
@@ -40,13 +40,6 @@ struct InstalledPackagesView: View {
                 },
             )
         }
-        .searchable(
-            text: $viewModel.searchQuery,
-            isPresented: $viewModel.isSearchFieldPresented,
-            placement: .toolbar,
-            prompt: "Search Installed Packages",
-        )
-        .focusedSceneValue(\.searchPresented, $viewModel.isSearchFieldPresented)
     }
 
     /// Persistent kind filter, always visible. Filters the loaded inventory client-side; never refetches.

--- a/Sources/BrewFeatureInstalled/Views/InstalledUpgradesColumns.swift
+++ b/Sources/BrewFeatureInstalled/Views/InstalledUpgradesColumns.swift
@@ -1,0 +1,123 @@
+import BrewAppEnvironment
+import BrewCore
+import BrewRepositoryInterfaces
+import BrewUIComponents
+import SwiftUI
+
+/// Hosts the Installed and Upgrades columns under a single, stable view identity.
+///
+/// Both tabs previously owned their own `.searchable(placement: .toolbar)`. Because the main
+/// window swaps the entire feature subtree on every sidebar switch, that meant a toolbar-placed
+/// search field was torn down and rebuilt on each Installed⇄Upgrades toggle. After a few cycles
+/// the native search field detached from the toolbar's hit-testing — clicks stopped landing while
+/// ⌘F (which drives `.searchable` programmatically via `isPresented`) still worked.
+///
+/// Keeping one searchable alive here — and only re-routing its bindings to the active tab's view
+/// model — avoids that churn. The two view models persist for as long as either tab is on screen.
+public struct InstalledUpgradesRoot: View {
+    public enum Mode: Sendable { case installed, upgrades }
+
+    @Environment(\.installedPackagesRepository) private var installedPackagesRepository
+    @Environment(\.brewCommandCenter) private var brewCommandCenter
+    @Environment(\.mutatingCommandFactory) private var mutatingCommandFactory
+    @Environment(\.navigateToInstalledPackage) private var navigateToInstalledPackage
+
+    private let mode: Mode
+    @Binding private var deepLinkSelection: InstalledBrewPackage.ID?
+
+    public init(
+        mode: Mode,
+        deepLinkSelection: Binding<InstalledBrewPackage.ID?> = .constant(nil),
+    ) {
+        self.mode = mode
+        _deepLinkSelection = deepLinkSelection
+    }
+
+    public var body: some View {
+        InstalledUpgradesContainer(
+            installedPackagesRepository: installedPackagesRepository,
+            brewCommandCenter: brewCommandCenter,
+            mutatingCommandFactory: mutatingCommandFactory,
+            navigateToInstalledPackage: navigateToInstalledPackage,
+            mode: mode,
+            deepLinkSelection: $deepLinkSelection,
+        )
+    }
+}
+
+/// Owns both view models as persistent `@State` (environment values aren't available in a `View`'s
+/// `init`, hence the Root→Container split) and applies the single shared `.searchable`.
+struct InstalledUpgradesContainer: View {
+    @State private var installed: InstalledViewModel
+    @State private var upgrades: UpgradesViewModel
+    private let mode: InstalledUpgradesRoot.Mode
+    private let navigateToInstalledPackage: @MainActor (InstalledBrewPackage.ID) -> Void
+    @Binding private var deepLinkSelection: InstalledBrewPackage.ID?
+
+    init(
+        installedPackagesRepository: any InstalledPackagesRepository,
+        brewCommandCenter: any BrewCommandCenter,
+        mutatingCommandFactory: any BrewMutatingCommandFactory,
+        navigateToInstalledPackage: @escaping @MainActor (InstalledBrewPackage.ID) -> Void,
+        mode: InstalledUpgradesRoot.Mode,
+        deepLinkSelection: Binding<InstalledBrewPackage.ID?>,
+    ) {
+        _installed = State(
+            initialValue: InstalledViewModel(
+                repository: installedPackagesRepository,
+                initialSelection: deepLinkSelection.wrappedValue,
+            ),
+        )
+        _upgrades = State(
+            initialValue: UpgradesViewModel(
+                repository: installedPackagesRepository,
+                brewCommandCenter: brewCommandCenter,
+                commandFactory: mutatingCommandFactory,
+            ),
+        )
+        self.mode = mode
+        self.navigateToInstalledPackage = navigateToInstalledPackage
+        _deepLinkSelection = deepLinkSelection
+    }
+
+    var body: some View {
+        content
+            .searchable(
+                text: activeSearchQuery,
+                isPresented: activeSearchPresented,
+                placement: .toolbar,
+                prompt: activeSearchPrompt,
+            )
+            .focusedSceneValue(\.searchPresented, activeSearchPresented)
+    }
+
+    @ViewBuilder private var content: some View {
+        switch mode {
+        case .installed:
+            InstalledColumns(viewModel: installed, deepLinkSelection: $deepLinkSelection)
+        case .upgrades:
+            UpgradesColumns(viewModel: upgrades, navigateToInstalledPackage: navigateToInstalledPackage)
+        }
+    }
+
+    private var activeSearchQuery: Binding<String> {
+        switch mode {
+        case .installed: $installed.searchQuery
+        case .upgrades: $upgrades.searchQuery
+        }
+    }
+
+    private var activeSearchPresented: Binding<Bool> {
+        switch mode {
+        case .installed: $installed.isSearchFieldPresented
+        case .upgrades: $upgrades.isSearchFieldPresented
+        }
+    }
+
+    private var activeSearchPrompt: LocalizedStringKey {
+        switch mode {
+        case .installed: "Search Installed Packages"
+        case .upgrades: "Search Upgrades"
+        }
+    }
+}

--- a/Sources/BrewFeatureInstalled/Views/InstalledUpgradesColumns.swift
+++ b/Sources/BrewFeatureInstalled/Views/InstalledUpgradesColumns.swift
@@ -4,16 +4,9 @@ import BrewRepositoryInterfaces
 import BrewUIComponents
 import SwiftUI
 
-/// Hosts the Installed and Upgrades columns under a single, stable view identity.
-///
-/// Both tabs previously owned their own `.searchable(placement: .toolbar)`. Because the main
-/// window swaps the entire feature subtree on every sidebar switch, that meant a toolbar-placed
-/// search field was torn down and rebuilt on each Installed⇄Upgrades toggle. After a few cycles
-/// the native search field detached from the toolbar's hit-testing — clicks stopped landing while
-/// ⌘F (which drives `.searchable` programmatically via `isPresented`) still worked.
-///
-/// Keeping one searchable alive here — and only re-routing its bindings to the active tab's view
-/// model — avoids that churn. The two view models persist for as long as either tab is on screen.
+/// Hosts the Installed and Upgrades columns under one stable view identity so a single toolbar
+/// `.searchable` stays mounted across tab switches. Tearing it down per switch (as separate cases
+/// did) eventually detaches the native search field from the toolbar's mouse hit-testing.
 public struct InstalledUpgradesRoot: View {
     public enum Mode: Sendable { case installed, upgrades }
 
@@ -45,8 +38,8 @@ public struct InstalledUpgradesRoot: View {
     }
 }
 
-/// Owns both view models as persistent `@State` (environment values aren't available in a `View`'s
-/// `init`, hence the Root→Container split) and applies the single shared `.searchable`.
+/// Split from the Root because environment values aren't available in a `View`'s `init`, and both
+/// view models must be constructed there so they persist as `@State`.
 struct InstalledUpgradesContainer: View {
     @State private var installed: InstalledViewModel
     @State private var upgrades: UpgradesViewModel

--- a/Sources/BrewFeatureInstalled/Views/UpgradesColumns.swift
+++ b/Sources/BrewFeatureInstalled/Views/UpgradesColumns.swift
@@ -4,10 +4,6 @@ import BrewRepositoryInterfaces
 import BrewUIComponents
 import SwiftUI
 
-/// Feature-owned content/detail columns for the Upgrades tab. Mirrors ``InstalledColumns`` but
-/// projects only outdated packages and adds an Upgrade All affordance. The view model is owned by
-/// ``InstalledUpgradesContainer`` so it (and the shared toolbar search field) survives switching
-/// between the Installed and Upgrades tabs.
 struct UpgradesColumns: View {
     let viewModel: UpgradesViewModel
     let navigateToInstalledPackage: @MainActor (InstalledBrewPackage.ID) -> Void

--- a/Sources/BrewFeatureInstalled/Views/UpgradesColumns.swift
+++ b/Sources/BrewFeatureInstalled/Views/UpgradesColumns.swift
@@ -4,45 +4,13 @@ import BrewRepositoryInterfaces
 import BrewUIComponents
 import SwiftUI
 
-public struct UpgradesColumnsRoot: View {
-    @Environment(\.installedPackagesRepository) private var installedPackagesRepository
-    @Environment(\.brewCommandCenter) private var brewCommandCenter
-    @Environment(\.mutatingCommandFactory) private var mutatingCommandFactory
-    @Environment(\.navigateToInstalledPackage) private var navigateToInstalledPackage
-
-    public init() {}
-
-    public var body: some View {
-        UpgradesColumns(
-            installedPackagesRepository: installedPackagesRepository,
-            brewCommandCenter: brewCommandCenter,
-            mutatingCommandFactory: mutatingCommandFactory,
-            navigateToInstalledPackage: navigateToInstalledPackage,
-        )
-    }
-}
-
-/// Feature-owned content/detail columns for the Upgrades tab. Mirrors `InstalledColumns`
-/// but projects only outdated packages and adds an Upgrade All affordance.
+/// Feature-owned content/detail columns for the Upgrades tab. Mirrors ``InstalledColumns`` but
+/// projects only outdated packages and adds an Upgrade All affordance. The view model is owned by
+/// ``InstalledUpgradesContainer`` so it (and the shared toolbar search field) survives switching
+/// between the Installed and Upgrades tabs.
 struct UpgradesColumns: View {
-    @State var viewModel: UpgradesViewModel
-    private let navigateToInstalledPackage: @MainActor (InstalledBrewPackage.ID) -> Void
-
-    init(
-        installedPackagesRepository: any InstalledPackagesRepository,
-        brewCommandCenter: any BrewCommandCenter,
-        mutatingCommandFactory: any BrewMutatingCommandFactory,
-        navigateToInstalledPackage: @escaping @MainActor (InstalledBrewPackage.ID) -> Void,
-    ) {
-        _viewModel = State(
-            initialValue: UpgradesViewModel(
-                repository: installedPackagesRepository,
-                brewCommandCenter: brewCommandCenter,
-                commandFactory: mutatingCommandFactory,
-            ),
-        )
-        self.navigateToInstalledPackage = navigateToInstalledPackage
-    }
+    let viewModel: UpgradesViewModel
+    let navigateToInstalledPackage: @MainActor (InstalledBrewPackage.ID) -> Void
 
     var body: some View {
         HSplitView {

--- a/Sources/BrewFeatureInstalled/Views/UpgradesPackagesView.swift
+++ b/Sources/BrewFeatureInstalled/Views/UpgradesPackagesView.swift
@@ -39,13 +39,6 @@ struct UpgradesPackagesView: View {
                 },
             )
         }
-        .searchable(
-            text: $viewModel.searchQuery,
-            isPresented: $viewModel.isSearchFieldPresented,
-            placement: .toolbar,
-            prompt: "Search Upgrades",
-        )
-        .focusedSceneValue(\.searchPresented, $viewModel.isSearchFieldPresented)
     }
 
     private var header: some View {

--- a/Sources/BrewFeatureInstalled/Views/UpgradesPackagesView.swift
+++ b/Sources/BrewFeatureInstalled/Views/UpgradesPackagesView.swift
@@ -39,6 +39,9 @@ struct UpgradesPackagesView: View {
                 },
             )
         }
+        .task {
+            await viewModel.load()
+        }
     }
 
     private var header: some View {


### PR DESCRIPTION
# PR: Keep the search bar clickable when switching Installed/Upgrades tabs

## Summary

Fixes a bug where the toolbar search bar became un-clickable on the Installed tab (and, more rarely, Upgrades) after switching between the two tabs several times. Cmd+F still focused it, but the mouse could not.

## Changes

- **Root cause:** the Installed and Upgrades tabs each mounted their own `.searchable(placement: .toolbar)`. `MainWindowView` swapped the whole feature subtree on every sidebar switch, so a toolbar-placed search field was torn down and rebuilt on each Installed⇄Upgrades toggle. After a few cycles the native search field detached from the toolbar's mouse hit-testing and clicks stopped landing. Cmd+F kept working because it drives `.searchable` programmatically through its `isPresented` binding, bypassing the dead native hit-testing.
- **New `InstalledUpgradesColumns.swift`:** a stable `InstalledUpgradesRoot` container hosts both tabs, owns both view models, and applies a single shared `.searchable`, re-routing its `text`/`isPresented` bindings to the active tab. Toggling now preserves view identity, so the searchable (and its native toolbar item) is never torn down.
- **`MainWindowView.swift`:** collapsed the separate `.installed` and `.upgrades` switch cases into one combined case that routes to `InstalledUpgradesRoot(mode:)`.
- **`InstalledColumns.swift` / `UpgradesColumns.swift`:** accept an injected view model instead of building it as local `@State`. Because the models now persist across the toggle, a deep-link selection is applied via `onChange` rather than the model's `init`.
- **`InstalledPackagesView.swift` / `UpgradesPackagesView.swift`:** dropped the now-duplicated per-view `.searchable` and `.focusedSceneValue`; list-focus logic is unchanged.

## Why this split (optional)

Discover keeps its own inline `.searchable` — it lives in a separate module, has a differently shaped (debounced, remote) search, and is a browse-and-dwell tab that doesn't trigger the repeated-teardown pattern. Generalizing to a cross-feature container was considered and deliberately declined.

## Testing

- [x] `scripts/test` — full suite passes, including the `shouldFocusList` view-model tests.
- [x] `xcodebuild -scheme Brew` — BUILD SUCCEEDED.
- [x] swiftformat, swiftlint --strict, and BrewUILint — clean on changed files.
- [ ] Manual: rapidly switch Installed⇄Upgrades ~15–20 times, clicking the search bar after each switch (owner to confirm on device).

## PR checklist

- [x] Have you followed this repository's contribution and workflow guidance?
- [x] Have you explained what changed and why this should land now?
- [x] Have you run relevant local checks for the changed scope?
- [x] Are changes scoped and free of unrelated modifications?

-----

- [x] AI was used to generate or assist with generating this PR.
- [x] If yes, describe exactly how AI was used and what manual verification was performed: Claude Code diagnosed the root cause, implemented the hoisted-searchable fix, and ran the build, full test suite, and linters. The interactive mouse-click repro across rapid tab switches is left for manual verification on device.

## Follow-ups (optional)

If full robustness across every tab boundary is ever wanted, the principled path is a single `.searchable` hoisted to `MainWindowView` driven by a small app-level search protocol the three view models conform to — not a cross-module container.
