### PR TITLE
Fix styling issues

### DIFF
--- a/Sources/BrewFeatureDiscover/Views/DiscoverInstalledBadge.swift
+++ b/Sources/BrewFeatureDiscover/Views/DiscoverInstalledBadge.swift
@@ -17,8 +17,8 @@ struct DiscoverInstalledBadge: View {
         }
         .font(.brewCaption2)
         .foregroundStyle(Color.brewStatusSuccess)
-        .padding(.horizontal, BrewSpacing.xs)
-        .padding(.vertical, BrewSpacing.xxs)
+        .padding(.horizontal, BrewSpacing.sm)
+        .padding(.vertical, BrewSpacing.xs)
         .background {
             Capsule()
                 .fill(Color.brewStatusSuccessSubtle)

--- a/Sources/BrewFeatureDiscover/Views/DiscoverListRowView.swift
+++ b/Sources/BrewFeatureDiscover/Views/DiscoverListRowView.swift
@@ -107,8 +107,8 @@ struct DiscoverListRowView: View {
         Text(viewModel.packageKindChrome.badgeLabel)
             .font(.brewCaption2)
             .foregroundStyle(accentColor(viewModel.packageKindChrome.accent))
-            .padding(.horizontal, BrewSpacing.xs)
-            .padding(.vertical, BrewSpacing.xxs)
+            .padding(.horizontal, BrewSpacing.sm)
+            .padding(.vertical, BrewSpacing.xs)
             .background {
                 Capsule()
                     .fill(Color.brewSurfaceElevated)

--- a/Sources/BrewFeatureDiscover/Views/DiscoverPackageDetailView.swift
+++ b/Sources/BrewFeatureDiscover/Views/DiscoverPackageDetailView.swift
@@ -95,8 +95,8 @@ private struct DiscoverPackageDetailHeroSection: View {
                     Text(chrome.badgeLabel)
                         .font(.brewCaption2)
                         .foregroundStyle(accentColor(chrome.accent))
-                        .padding(.horizontal, BrewSpacing.xs)
-                        .padding(.vertical, BrewSpacing.xxs)
+                        .padding(.horizontal, BrewSpacing.sm)
+                        .padding(.vertical, BrewSpacing.xs)
                         .background {
                             Capsule()
                                 .fill(Color.brewSurfaceElevated)

--- a/Sources/BrewFeatureInstalled/Views/InstalledListRowView.swift
+++ b/Sources/BrewFeatureInstalled/Views/InstalledListRowView.swift
@@ -100,8 +100,8 @@ struct InstalledListRowView: View {
             Text(viewModel.kind.chrome.badgeLabel)
                 .font(.brewCaption2)
                 .foregroundStyle(accentColor(viewModel.kind.chrome.accent))
-                .padding(.horizontal, BrewSpacing.xs)
-                .padding(.vertical, BrewSpacing.xxs)
+                .padding(.horizontal, BrewSpacing.sm)
+                .padding(.vertical, BrewSpacing.xs)
                 .background {
                     Capsule()
                         .fill(Color.brewSurfaceElevated)

--- a/Sources/BrewFeatureInstalled/Views/InstalledPackageDetailSubviewSections.swift
+++ b/Sources/BrewFeatureInstalled/Views/InstalledPackageDetailSubviewSections.swift
@@ -45,8 +45,8 @@ struct InstalledPackageDetailHeroSection: View {
                     Text(chrome.badgeLabel)
                         .font(.brewCaption2)
                         .foregroundStyle(accentColor(chrome.accent))
-                        .padding(.horizontal, BrewSpacing.xs)
-                        .padding(.vertical, BrewSpacing.xxs)
+                        .padding(.horizontal, BrewSpacing.sm)
+                        .padding(.vertical, BrewSpacing.xs)
                         .background {
                             Capsule()
                                 .fill(Color.brewSurfaceElevated)

--- a/Sources/BrewFeatureInstalled/Views/UpgradesSidebarBadge.swift
+++ b/Sources/BrewFeatureInstalled/Views/UpgradesSidebarBadge.swift
@@ -12,6 +12,7 @@ import SwiftUI
 /// upgrade reconciles the inventory and the outdated count changes.
 public struct UpgradesSidebarBadge: View {
     @Environment(\.installedPackagesRepository) private var repository
+    @Environment(\.colorScheme) private var colorScheme
 
     public init() {}
 
@@ -20,7 +21,9 @@ public struct UpgradesSidebarBadge: View {
         if count > 0 {
             Text("\(count)")
                 .font(.brewCaption2.weight(.semibold))
-                .foregroundStyle(Color.white)
+                // Knock the count out of the amber pill using the sidebar panel's own
+                // background in dark mode; plain white still reads best in light mode.
+                .foregroundStyle(colorScheme == .dark ? Color.brewSurface : Color.white)
                 .padding(.horizontal, BrewSpacing.xs)
                 .padding(.vertical, BrewSpacing.xxs)
                 .background(Capsule().fill(Color.brewStatusWarning))

--- a/Sources/BrewUIComponents/Resources/Media.xcassets/BorderBrand.colorset/Contents.json
+++ b/Sources/BrewUIComponents/Resources/Media.xcassets/BorderBrand.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.251",
-          "green" : "0.690",
-          "red" : "0.984"
+          "blue" : "0.110",
+          "green" : "0.592",
+          "red" : "0.910"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.251",
-          "green" : "0.690",
-          "red" : "0.984"
+          "blue" : "0.110",
+          "green" : "0.592",
+          "red" : "0.910"
         }
       },
       "idiom" : "universal"

--- a/Sources/BrewUIComponents/Resources/Media.xcassets/BrandPrimary.colorset/Contents.json
+++ b/Sources/BrewUIComponents/Resources/Media.xcassets/BrandPrimary.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.251",
-          "green" : "0.690",
-          "red" : "0.984"
+          "blue" : "0.110",
+          "green" : "0.592",
+          "red" : "0.910"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.251",
-          "green" : "0.690",
-          "red" : "0.984"
+          "blue" : "0.110",
+          "green" : "0.592",
+          "red" : "0.910"
         }
       },
       "idiom" : "universal"

--- a/Sources/BrewUIComponents/Resources/Media.xcassets/BrandPrimaryPressed.colorset/Contents.json
+++ b/Sources/BrewUIComponents/Resources/Media.xcassets/BrandPrimaryPressed.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.110",
-          "green" : "0.592",
-          "red" : "0.910"
+          "blue" : "0.251",
+          "green" : "0.690",
+          "red" : "0.984"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.110",
-          "green" : "0.592",
-          "red" : "0.910"
+          "blue" : "0.251",
+          "green" : "0.690",
+          "red" : "0.984"
         }
       },
       "idiom" : "universal"


### PR DESCRIPTION
# PR: Fix chrome pill and brand colour styling

## Summary

Three small, self-contained styling adjustments to the Homebrew app's design-system tokens and chrome components: a brand colour swap, a dark-mode fix for the upgrades sidebar badge, and more breathing room on the package-kind pill labels.

## Changes

- **Swap brand primary/border colours** (`a24d0dc`): `BrandPrimary` and `BorderBrand` (the identical amber token) now take the darker pressed value, and `BrandPrimaryPressed` takes the former primary value. Updated across the three `.colorset` files, both light and dark appearances.
- **Dark-mode upgrades badge text** (`b53c08c`): `UpgradesSidebarBadge` now reads `@Environment(\.colorScheme)` and uses the sidebar panel's own `brewSurface` colour for the count text on the amber pill in dark mode; light mode keeps plain white.
- **Pill label padding** (`fe04d74`): bumped the FORMULA/CASK/INSTALLED pill padding one step up (horizontal `xs`‚Üí`sm`, vertical `xxs`‚Üí`xs`) across all four FORMULA/CASK render sites plus the INSTALLED badge, so the labels have more breathing room and stay consistent in height.

## Why this split

Each commit is scoped to a single visual change so it can be reviewed and reverted independently.

## Testing

- [x] `scripts/test` ‚Äî full Swift package suite passes.
- [x] `xcrun swift build` ‚Äî BrewKit package builds cleanly.

## PR checklist

- [x] Have you followed this repository's contribution and workflow guidance?
- [x] Have you explained what changed and why this should land now?
- [x] Have you run relevant local checks for the changed scope?
- [x] Are changes scoped and free of unrelated modifications?

-----

- [x] AI was used to generate or assist with generating this PR.
- [x] If yes, describe exactly how AI was used: Claude Code made the token/view edits and drafted this description; the author reviewed the diffs and ran the local build and test suite to verify.
