### PR TITLE
Dead code cleanup + linting

### DIFF
--- a/.github/workflows/pr_build_test.yml
+++ b/.github/workflows/pr_build_test.yml
@@ -16,6 +16,7 @@ on:
       - "Package.resolved"
       - "Tools/BrewUILint/**"
       - "scripts/test"
+      - "Brewfile"
       - "Mintfile"
       - ".periphery.yml"
       - ".periphery-baseline.json"

--- a/.github/workflows/pr_build_test.yml
+++ b/.github/workflows/pr_build_test.yml
@@ -16,6 +16,9 @@ on:
       - "Package.resolved"
       - "Tools/BrewUILint/**"
       - "scripts/test"
+      - "Mintfile"
+      - ".periphery.yml"
+      - ".periphery-baseline.json"
       - ".github/workflows/pr_build_test.yml"
   pull_request:
     types: [opened, reopened, synchronize]
@@ -31,6 +34,9 @@ on:
       - "Package.resolved"
       - "Tools/BrewUILint/**"
       - "scripts/test"
+      - "Mintfile"
+      - ".periphery.yml"
+      - ".periphery-baseline.json"
       - ".github/workflows/pr_build_test.yml"
 
 permissions:
@@ -44,7 +50,9 @@ jobs:
   build-and-test:
     name: Build + unit tests
     runs-on: macos-26
-    timeout-minutes: 20
+    timeout-minutes: 25
+    env:
+      MINT_PATH: ${{ github.workspace }}/mint
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -58,6 +66,7 @@ jobs:
           xcodebuild test \
             -project Homebrew.xcodeproj \
             -scheme Brew-Unit \
+            -derivedDataPath DerivedData \
             -destination "platform=macOS" \
             -skipPackagePluginValidation \
             -skipMacroValidation \
@@ -96,6 +105,50 @@ jobs:
         run: |
           set -o pipefail
           xcrun swift test --package-path Tools/BrewUILint | tee swift-test-brewuilint.log
+
+      - name: Cache Mint packages
+        id: mint-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ github.workspace }}/mint
+          key: ${{ runner.os }}-mint-${{ hashFiles('**/Mintfile') }}
+          restore-keys: |
+            ${{ runner.os }}-mint-
+
+      - name: Install Mintfile packages
+        if: steps.mint-cache.outputs.cache-hit != 'true'
+        run: mint bootstrap --mintfile Mintfile
+
+      - name: Periphery dead-code scan
+        run: |
+          set -o pipefail
+          # Reuse the index store produced by the xcodebuild test step (no second build).
+          index="DerivedData/Index.noindex/DataStore"
+          if [ ! -d "$index" ]; then
+            index="$(find DerivedData -type d -name DataStore -path '*Index*' | head -n 1)"
+          fi
+          echo "Using index store: $index"
+          if [ -f .periphery-baseline.json ]; then
+            mint run periphery scan \
+              --index-store-path "$index" --skip-build \
+              --baseline .periphery-baseline.json --strict \
+              --relative-results --format github-actions
+          else
+            echo "::warning::No .periphery-baseline.json committed yet — writing a seed baseline (this run does NOT gate). Download the 'periphery-baseline' artifact from this run, commit it as .periphery-baseline.json, and subsequent PRs will fail only on newly introduced dead code."
+            mint run periphery scan \
+              --index-store-path "$index" --skip-build \
+              --write-baseline .periphery-baseline.json \
+              --relative-results
+          fi
+
+      - name: Upload periphery seed baseline
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: periphery-baseline
+          path: .periphery-baseline.json
+          if-no-files-found: ignore
+          retention-days: 7
 
       - name: Upload logs on failure
         if: failure() || cancelled()

--- a/.github/workflows/pr_build_test.yml
+++ b/.github/workflows/pr_build_test.yml
@@ -106,6 +106,13 @@ jobs:
           set -o pipefail
           xcrun swift test --package-path Tools/BrewUILint | tee swift-test-brewuilint.log
 
+      - name: Cache Homebrew prefix
+        uses: Homebrew/actions/cache-homebrew-prefix@18fcb8e3e06b4247c676c506750dc95ea7226479 # 2026.07.13.1
+        with:
+          brewfile: true
+          uninstall: true
+          workflow-key: pr-build-test
+
       - name: Cache Mint packages
         id: mint-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -118,7 +125,6 @@ jobs:
       - name: Install Mintfile packages
         if: steps.mint-cache.outputs.cache-hit != 'true'
         run: mint bootstrap --mintfile Mintfile
-
       - name: Periphery dead-code scan
         run: |
           set -o pipefail

--- a/.periphery.yml
+++ b/.periphery.yml
@@ -1,0 +1,16 @@
+# Periphery — dead-code (unused declaration) analysis.
+# Run in CI by .github/workflows/pr_build_test.yml; see AGENTS.md for the workflow.
+#
+# We scan the Xcode PROJECT (not the bare SwiftPM package) so the Homebrew app is included as a
+# consumer of the SwiftPM library modules. That means `retain_public` stays FALSE: public API that
+# not even the app uses is genuinely dead and should be reported. (Scanning the package alone would
+# force retain_public and blind us to dead public API, while also flagging the whole app-only UI tree
+# as a false positive.)
+project: Homebrew.xcodeproj
+schemes:
+  - Brew-Unit # host-app unit-test scheme — builds the app + every SPM module + unit tests
+
+# Retain the declaration classes that are used implicitly (Periphery can't see these as "reads"):
+retain_swift_ui_previews: true # `#Preview` bodies aren't indexed as usage
+retain_codable_properties: true # decoded/encoded stored properties on Codable types
+retain_assign_only_properties: true # e.g. Hashable/Equatable key structs read only via synthesis

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,15 @@ The pre-commit hook formats and lints **staged** Swift files (SwiftFormat/SwiftL
 
 If a test failure surfaces a real regression that's out of scope for the current turn, surface it to the user rather than silently skipping it — never paper over a red test with `.disabled` or `--filter` exclusions without flagging.
 
+### Dead-code analysis (Periphery)
+
+`.github/workflows/pr_build_test.yml` runs [Periphery](https://github.com/peripheryapp/periphery) (pinned in `Mintfile`) after the Xcode build, reusing that build's index store (`--index-store-path DerivedData/Index.noindex/DataStore --skip-build`) so it adds no second build. It scans the **Xcode project** (config in `.periphery.yml`) so the `Homebrew/` app counts as a consumer of the SwiftPM modules — this reports unused code across the whole program, including dead `public` API, which a package-only scan cannot.
+
+The check is **baseline-gated**: it fails a PR only on dead code **not** already recorded in `.periphery-baseline.json` (via `--strict --baseline`). This grandfathers the existing tail so only newly introduced dead code blocks a merge.
+
+- **Seeding / regenerating the baseline:** it can't be generated in the agent sandbox (needs a working `xcodebuild` app build). If `.periphery-baseline.json` is absent, the CI step writes one and uploads it as the `periphery-baseline` artifact without gating — download it, commit it, and the gate activates. To refresh it intentionally (after a deliberate change to the unused set), regenerate on a machine/CI where the app builds: build `Brew-Unit` with `-derivedDataPath DerivedData`, then `mint run periphery scan --index-store-path DerivedData/Index.noindex/DataStore --skip-build --write-baseline .periphery-baseline.json`.
+- **Known-implicit usage is already retained** via `.periphery.yml` (`retain_swift_ui_previews`, `retain_codable_properties`, `retain_assign_only_properties`). For a genuine one-off that Periphery still can't see, annotate the declaration with `// periphery:ignore` (or `// periphery:ignore:all` for a type and its members) rather than widening the baseline.
+
 ---
 
 ## What Lives Where

--- a/Mintfile
+++ b/Mintfile
@@ -1,2 +1,3 @@
 nicklockwood/SwiftFormat@0.61.0
 realm/SwiftLint@0.63.2
+peripheryapp/periphery@3.7.4

--- a/Sources/BrewAppEnvironment/UnimplementedRepositories.swift
+++ b/Sources/BrewAppEnvironment/UnimplementedRepositories.swift
@@ -137,23 +137,11 @@ actor UnimplementedBrewCommandCenter: BrewCommandCenter {
         unimplemented()
     }
 
-    func phaseByID() async -> [BrewOperationID: BrewOperationPhase] {
-        unimplemented()
-    }
-
-    func isActive(id _: BrewOperationID) async -> Bool {
-        unimplemented()
-    }
-
     func phaseChanges(for _: BrewOperationID) async -> AsyncStream<BrewOperationPhase> {
         unimplemented()
     }
 
     func allPhaseChanges() async -> AsyncStream<(BrewOperationID, BrewOperationPhase)> {
-        unimplemented()
-    }
-
-    func outputChanges(for _: BrewOperationID) async -> AsyncStream<BrewCommandOutputLine> {
         unimplemented()
     }
 

--- a/Sources/BrewCLI/JSON/BrewInfoJSON.swift
+++ b/Sources/BrewCLI/JSON/BrewInfoJSON.swift
@@ -31,9 +31,6 @@ struct BrewInfoFormula: Decodable {
     var license: String?
     var homepage: String?
     var dependencies: [String]
-    var buildDependencies: [String]
-    var recommendedDependencies: [String]
-    var optionalDependencies: [String]
     var rubySourcePath: String?
     var versions: BrewInfoFormulaVersions
     var installed: [BrewInfoFormulaInstalled]
@@ -52,9 +49,6 @@ struct BrewInfoFormula: Decodable {
         license = try? container.decode(String.self, forKey: .license)
         homepage = try? container.decode(String.self, forKey: .homepage)
         dependencies = container.decodeStringArray(forKey: .dependencies)
-        buildDependencies = container.decodeStringArray(forKey: .buildDependencies)
-        recommendedDependencies = container.decodeStringArray(forKey: .recommendedDependencies)
-        optionalDependencies = container.decodeStringArray(forKey: .optionalDependencies)
         rubySourcePath = try? container.decode(String.self, forKey: .rubySourcePath)
         versions = (try? container.decode(BrewInfoFormulaVersions.self, forKey: .versions))
             ?? BrewInfoFormulaVersions(stable: nil)
@@ -75,9 +69,6 @@ struct BrewInfoFormula: Decodable {
         case license
         case homepage
         case dependencies
-        case buildDependencies = "build_dependencies"
-        case recommendedDependencies = "recommended_dependencies"
-        case optionalDependencies = "optional_dependencies"
         case rubySourcePath = "ruby_source_path"
         case versions
         case installed

--- a/Sources/BrewCLI/NoopBrewCommandCenter.swift
+++ b/Sources/BrewCLI/NoopBrewCommandCenter.swift
@@ -24,15 +24,6 @@ public actor NoopBrewCommandCenter: BrewCommandCenter {
         return .idle
     }
 
-    public func phaseByID() async -> [BrewOperationID: BrewOperationPhase] {
-        [:]
-    }
-
-    public func isActive(id: BrewOperationID) async -> Bool {
-        _ = id
-        return false
-    }
-
     public func phaseChanges(for id: BrewOperationID) async -> AsyncStream<BrewOperationPhase> {
         _ = id
         return AsyncStream<BrewOperationPhase>(bufferingPolicy: .unbounded) { continuation in
@@ -43,13 +34,6 @@ public actor NoopBrewCommandCenter: BrewCommandCenter {
 
     public func allPhaseChanges() async -> AsyncStream<(BrewOperationID, BrewOperationPhase)> {
         AsyncStream<(BrewOperationID, BrewOperationPhase)>(bufferingPolicy: .unbounded) { continuation in
-            continuation.finish()
-        }
-    }
-
-    public func outputChanges(for id: BrewOperationID) async -> AsyncStream<BrewCommandOutputLine> {
-        _ = id
-        return AsyncStream<BrewCommandOutputLine>(bufferingPolicy: .unbounded) { continuation in
             continuation.finish()
         }
     }

--- a/Sources/BrewCLI/NoopBrewCommandCenter.swift
+++ b/Sources/BrewCLI/NoopBrewCommandCenter.swift
@@ -14,12 +14,7 @@ public actor NoopBrewCommandCenter: BrewCommandCenter {
         self.executionContext = executionContext
     }
 
-    /// Preconfigured noop center for SwiftUI previews (immediate execution, standard noop context).
-    public static func preview() -> NoopBrewCommandCenter {
-        NoopBrewCommandCenter(executionContext: .noopForTestingAndPreviews())
-    }
-
-    /// Preconfigured noop center for unit tests (same wiring as ``preview()``).
+    /// Preconfigured noop center for unit tests (immediate execution, standard noop context).
     public static func forTesting() -> NoopBrewCommandCenter {
         NoopBrewCommandCenter(executionContext: .noopForTestingAndPreviews())
     }

--- a/Sources/BrewCLI/PackageInstallCommand.swift
+++ b/Sources/BrewCLI/PackageInstallCommand.swift
@@ -13,11 +13,6 @@ struct PackageInstallCommand: BrewMutatingCommand {
     let packageName: String
     let kind: InstalledPackageKind
 
-    init(package: DiscoveryBrewPackage) {
-        packageName = package.name
-        kind = package.kind
-    }
-
     init(kind: InstalledPackageKind, name: String) {
         packageName = name
         self.kind = kind

--- a/Sources/BrewCLI/SerialBrewCommandCenter.swift
+++ b/Sources/BrewCLI/SerialBrewCommandCenter.swift
@@ -9,9 +9,6 @@ import Foundation
 private typealias AllPhaseStreamTermination =
     AsyncStream<(BrewOperationID, BrewOperationPhase)>.Continuation.Termination
 
-private typealias OutputStreamTermination =
-    AsyncStream<BrewCommandOutputLine>.Continuation.Termination
-
 private typealias AllOutputStreamTermination =
     AsyncStream<(BrewOperationID, BrewCommandOutputLine)>.Continuation.Termination
 
@@ -32,11 +29,6 @@ private struct AllPhaseStreamListener {
     let continuation: AsyncStream<(BrewOperationID, BrewOperationPhase)>.Continuation
 }
 
-private struct OutputStreamListener {
-    let token: UUID
-    let continuation: AsyncStream<BrewCommandOutputLine>.Continuation
-}
-
 private struct AllOutputStreamListener {
     let token: UUID
     let continuation: AsyncStream<(BrewOperationID, BrewCommandOutputLine)>.Continuation
@@ -51,7 +43,6 @@ public actor SerialBrewCommandCenter: BrewCommandCenter {
     private var inflightByID: [BrewOperationID: Task<Void, Error>] = [:]
     private var phaseListenersByID: [BrewOperationID: [PhaseStreamListener]] = [:]
     private var allPhaseListeners: [AllPhaseStreamListener] = []
-    private var outputListenersByID: [BrewOperationID: [OutputStreamListener]] = [:]
     private var allOutputListeners: [AllOutputStreamListener] = []
 
     public init(executionContext: BrewCommandExecutionContext) {
@@ -60,17 +51,6 @@ public actor SerialBrewCommandCenter: BrewCommandCenter {
 
     public func phase(for id: BrewOperationID) async -> BrewOperationPhase {
         trackedPhasesByID[id] ?? .idle
-    }
-
-    public func phaseByID() async -> [BrewOperationID: BrewOperationPhase] {
-        trackedPhasesByID
-    }
-
-    public func isActive(id: BrewOperationID) async -> Bool {
-        if case .running = trackedPhasesByID[id] ?? .idle {
-            return true
-        }
-        return false
     }
 
     public func phaseChanges(for id: BrewOperationID) async -> AsyncStream<BrewOperationPhase> {
@@ -94,18 +74,6 @@ public actor SerialBrewCommandCenter: BrewCommandCenter {
                 }
             }
             registerAllPhaseListener(token: token, continuation: continuation)
-        }
-    }
-
-    public func outputChanges(for id: BrewOperationID) async -> AsyncStream<BrewCommandOutputLine> {
-        AsyncStream<BrewCommandOutputLine>(bufferingPolicy: .unbounded) { continuation in
-            let token = UUID()
-            continuation.onTermination = { @Sendable (_: OutputStreamTermination) in
-                Task {
-                    await self.removeOutputListener(id: id, token: token)
-                }
-            }
-            registerOutputListener(id: id, token: token, continuation: continuation)
         }
     }
 
@@ -213,27 +181,6 @@ public actor SerialBrewCommandCenter: BrewCommandCenter {
         allPhaseListeners.removeAll { $0.token == token }
     }
 
-    private func registerOutputListener(
-        id: BrewOperationID,
-        token: UUID,
-        continuation: AsyncStream<BrewCommandOutputLine>.Continuation,
-    ) {
-        let listener = OutputStreamListener(token: token, continuation: continuation)
-        outputListenersByID[id, default: []].append(listener)
-    }
-
-    private func removeOutputListener(id: BrewOperationID, token: UUID) {
-        guard var listeners = outputListenersByID[id] else {
-            return
-        }
-        listeners.removeAll { $0.token == token }
-        if listeners.isEmpty {
-            outputListenersByID[id] = nil
-        } else {
-            outputListenersByID[id] = listeners
-        }
-    }
-
     private func registerAllOutputListener(
         token: UUID,
         continuation: AsyncStream<(BrewOperationID, BrewCommandOutputLine)>.Continuation,
@@ -259,11 +206,6 @@ public actor SerialBrewCommandCenter: BrewCommandCenter {
     }
 
     private func notifyOutputListeners(id: BrewOperationID, line: BrewCommandOutputLine) {
-        if let listeners = outputListenersByID[id] {
-            for listener in listeners {
-                listener.continuation.yield(line)
-            }
-        }
         for listener in allOutputListeners {
             listener.continuation.yield((id, line))
         }

--- a/Sources/BrewCore/Operations/BrewCommandCenter.swift
+++ b/Sources/BrewCore/Operations/BrewCommandCenter.swift
@@ -10,12 +10,6 @@ public protocol BrewCommandCenter: Actor {
     /// Snapshot for UI — ``BrewOperationPhase/idle`` when no state is tracked for `id`.
     func phase(for id: BrewOperationID) async -> BrewOperationPhase
 
-    /// All tracked phases keyed by ``BrewOperationID``. Missing keys are equivalent to ``BrewOperationPhase/idle``.
-    func phaseByID() async -> [BrewOperationID: BrewOperationPhase]
-
-    /// `true` while work for `id` is actively running (not failed-only).
-    func isActive(id: BrewOperationID) async -> Bool
-
     /// Push-based phase updates for `id` — yields the current phase once when subscribed, then each subsequent phase transition.
     /// Cancel the consuming task (e.g. end of a SwiftUI ``View/task``) and unregister via ``AsyncStream/Continuation/onTermination``.
     func phaseChanges(for id: BrewOperationID) async -> AsyncStream<BrewOperationPhase>
@@ -23,10 +17,6 @@ public protocol BrewCommandCenter: Actor {
     /// Push-based phase updates for **any** operation id — yields each phase transition `(id, phase)` with **no** initial replay.
     /// Cancel the consuming task and unregister via ``AsyncStream/Continuation/onTermination``.
     func allPhaseChanges() async -> AsyncStream<(BrewOperationID, BrewOperationPhase)>
-
-    /// Push-based subprocess output for `id` — yields buffered lines on subscribe, then each new line as the
-    /// underlying `Process` emits it. Cancel the consuming task and unregister via ``AsyncStream/Continuation/onTermination``.
-    func outputChanges(for id: BrewOperationID) async -> AsyncStream<BrewCommandOutputLine>
 
     /// Push-based subprocess output for **any** operation id — yields each line `(id, line)` with **no** initial replay.
     /// Cancel the consuming task and unregister via ``AsyncStream/Continuation/onTermination``.

--- a/Sources/BrewCrashReporting/CrashReportFormatter.swift
+++ b/Sources/BrewCrashReporting/CrashReportFormatter.swift
@@ -6,11 +6,11 @@
 import Foundation
 
 /// Builds the human-readable text of a crash report.
-public enum CrashReportFormatter {
+enum CrashReportFormatter {
     /// The header a signal handler writes before its raw `backtrace_symbols_fd`
     /// dump, so it ends with a `Call stack:` marker and newline. Must be built
     /// before the crash — string building is not async-signal-safe.
-    public static func signalReportHeader(
+    static func signalReportHeader(
         environment: CrashReportEnvironment,
         date: Date,
     ) -> String {
@@ -24,7 +24,7 @@ public enum CrashReportFormatter {
         """ + "\n"
     }
 
-    public static func makeReportText(
+    static func makeReportText(
         kind: String,
         detail: String?,
         callStack: [String],

--- a/Sources/BrewCrashReporting/CrashReportIssue.swift
+++ b/Sources/BrewCrashReporting/CrashReportIssue.swift
@@ -7,14 +7,14 @@ import Foundation
 
 /// Builds a pre-filled "new issue" URL on the app's GitHub repository from a
 /// crash report, so a user can file it with one click.
-public enum CrashReportIssue {
-    public static let repositoryURL = URL(string: "https://github.com/Homebrew/BrewUI")!
+enum CrashReportIssue {
+    static let repositoryURL = URL(string: "https://github.com/Homebrew/BrewUI")!
 
     /// Kept under GitHub's ~8k URL ceiling; longer logs are truncated.
     static let maxBodyLength = 6000
 
     /// A pre-filled new-issue URL. Nothing is sent until the user submits it on GitHub.
-    public static func url(for report: CrashReport) -> URL {
+    static func url(for report: CrashReport) -> URL {
         var components = URLComponents(
             url: repositoryURL.appendingPathComponent("issues/new"),
             resolvingAgainstBaseURL: false,

--- a/Sources/BrewCrashReporting/CrashReportStore.swift
+++ b/Sources/BrewCrashReporting/CrashReportStore.swift
@@ -17,10 +17,6 @@ public struct CrashReportStore: Sendable {
         self.directoryURL = directoryURL ?? Self.defaultDirectoryURL()
     }
 
-    public var directory: URL {
-        directoryURL
-    }
-
     public func reportFileURL(for date: Date) -> URL {
         let millis = Int((date.timeIntervalSince1970 * 1000).rounded())
         return directoryURL.appendingPathComponent("crash-\(millis).log")

--- a/Sources/BrewFeatureConfig/ViewModels/ConfigViewModel+Sections.swift
+++ b/Sources/BrewFeatureConfig/ViewModels/ConfigViewModel+Sections.swift
@@ -61,13 +61,6 @@ extension ConfigViewModel {
         return error is BrewLookupError
     }
 
-    var errorMessage: String {
-        guard case let .failed(error) = state else {
-            return ""
-        }
-        return userMessage(for: error)
-    }
-
     // MARK: - Grouping
 
     enum ConfigGroup {

--- a/Sources/BrewFeatureConsole/ViewModels/CommandJob+Presentation.swift
+++ b/Sources/BrewFeatureConsole/ViewModels/CommandJob+Presentation.swift
@@ -5,7 +5,6 @@
 
 import BrewCore
 import BrewRepositoryInterfaces
-import BrewUIComponents
 import Foundation
 
 extension CommandJob {

--- a/Sources/BrewFeatureConsole/ViewModels/ConsoleStatusPresentation.swift
+++ b/Sources/BrewFeatureConsole/ViewModels/ConsoleStatusPresentation.swift
@@ -4,8 +4,6 @@
 //
 
 import BrewCore
-import BrewRepositoryInterfaces
-import BrewUIComponents
 import Foundation
 
 /// View-facing snapshot of "what does the collapsed status bar render right now" — keeps the view passive.

--- a/Sources/BrewFeatureConsole/ViewModels/ConsoleViewModel.swift
+++ b/Sources/BrewFeatureConsole/ViewModels/ConsoleViewModel.swift
@@ -5,7 +5,6 @@
 
 import BrewCore
 import BrewRepositoryInterfaces
-import BrewUIComponents
 import Foundation
 import Observation
 

--- a/Sources/BrewFeatureConsole/Views/ConsoleCommands.swift
+++ b/Sources/BrewFeatureConsole/Views/ConsoleCommands.swift
@@ -3,9 +3,6 @@
 //  Brew
 //
 
-import BrewCore
-import BrewRepositoryInterfaces
-import BrewUIComponents
 import SwiftUI
 
 /// View menu commands for the command console. Currently a single `⌘\`` toggle matching Xcode / VS Code / Terminal.

--- a/Sources/BrewFeatureConsole/Views/ConsoleOutputExport.swift
+++ b/Sources/BrewFeatureConsole/Views/ConsoleOutputExport.swift
@@ -4,9 +4,7 @@
 //
 
 import AppKit
-import BrewCore
 import BrewRepositoryInterfaces
-import BrewUIComponents
 
 /// View-layer AppKit bridge for saving/copying a command job's output. Lives at the view layer so the
 /// console view model stays AppKit-free; views call these static methods with the data already shaped by

--- a/Sources/BrewFeatureConsole/Views/ConsolePanel.swift
+++ b/Sources/BrewFeatureConsole/Views/ConsolePanel.swift
@@ -3,7 +3,6 @@
 //  Brew
 //
 
-import BrewCore
 import BrewRepositoryInterfaces
 import BrewUIComponents
 import SwiftUI

--- a/Sources/BrewFeatureConsole/Views/ConsolePanelRoot.swift
+++ b/Sources/BrewFeatureConsole/Views/ConsolePanelRoot.swift
@@ -4,7 +4,6 @@
 //
 
 import BrewAppEnvironment
-import BrewCore
 import BrewRepositoryInterfaces
 import BrewUIComponents
 import SwiftUI

--- a/Sources/BrewFeatureConsole/Views/ConsoleStatusBar.swift
+++ b/Sources/BrewFeatureConsole/Views/ConsoleStatusBar.swift
@@ -3,8 +3,6 @@
 //  Brew
 //
 
-import BrewCore
-import BrewRepositoryInterfaces
 import BrewUIComponents
 import SwiftUI
 

--- a/Sources/BrewFeatureConsole/Views/ConsoleStatusDot.swift
+++ b/Sources/BrewFeatureConsole/Views/ConsoleStatusDot.swift
@@ -3,8 +3,6 @@
 //  Brew
 //
 
-import BrewCore
-import BrewRepositoryInterfaces
 import BrewUIComponents
 import SwiftUI
 

--- a/Sources/BrewFeatureConsole/Views/FocusedValues+Console.swift
+++ b/Sources/BrewFeatureConsole/Views/FocusedValues+Console.swift
@@ -3,8 +3,6 @@
 //  Brew
 //
 
-import BrewCore
-import BrewRepositoryInterfaces
 import BrewUIComponents
 import SwiftUI
 

--- a/Sources/BrewFeatureDiscover/ViewModels/DiscoverInstallBusyPresentation.swift
+++ b/Sources/BrewFeatureDiscover/ViewModels/DiscoverInstallBusyPresentation.swift
@@ -4,8 +4,6 @@
 //
 
 import BrewCore
-import BrewRepositoryInterfaces
-import BrewUIComponents
 import Foundation
 
 /// Derived presentation for "install in progress" chrome on a Discover row.

--- a/Sources/BrewFeatureDiscover/Views/DiscoverInstalledBadge.swift
+++ b/Sources/BrewFeatureDiscover/Views/DiscoverInstalledBadge.swift
@@ -1,5 +1,3 @@
-import BrewCore
-import BrewRepositoryInterfaces
 import BrewUIComponents
 import SwiftUI
 

--- a/Sources/BrewFeatureDiscover/Views/DiscoverPackagesView.swift
+++ b/Sources/BrewFeatureDiscover/Views/DiscoverPackagesView.swift
@@ -1,5 +1,4 @@
 import BrewCore
-import BrewRepositoryInterfaces
 import BrewUIComponents
 import SwiftUI
 

--- a/Sources/BrewFeatureDoctor/ViewModels/DoctorViewModel.swift
+++ b/Sources/BrewFeatureDoctor/ViewModels/DoctorViewModel.swift
@@ -88,13 +88,6 @@ final class DoctorViewModel {
         return report.rawOutput
     }
 
-    var issueItems: [DoctorIssueItem] {
-        guard case let .loaded(report) = state else {
-            return []
-        }
-        return report.issues.map { DoctorIssueItem(issue: $0) }
-    }
-
     /// Header chrome (Run Again button, re-check spinner) is only meaningful once a report — healthy or
     /// with issues — is on screen. Hidden during the initial load and on failure (the failure surface owns
     /// its own retry affordance via ``AsyncContentView``).

--- a/Sources/BrewFeatureInstalled/ViewModels/InstalledListRowViewModel.swift
+++ b/Sources/BrewFeatureInstalled/ViewModels/InstalledListRowViewModel.swift
@@ -4,7 +4,6 @@
 //
 
 import BrewCore
-import BrewRepositoryInterfaces
 import BrewUIComponents
 import Foundation
 import Observation
@@ -22,10 +21,6 @@ final class InstalledListRowViewModel {
     private(set) var showsUpgradeBusy: Bool = false
     private(set) var showsUninstallBusy: Bool = false
     private let brewCommandCenter: BrewCommandCenter
-
-    var id: HomebrewPackageID {
-        package.id
-    }
 
     var name: String {
         package.displayName

--- a/Sources/BrewFeatureInstalled/ViewModels/InstalledUninstallBusyPresentation.swift
+++ b/Sources/BrewFeatureInstalled/ViewModels/InstalledUninstallBusyPresentation.swift
@@ -4,8 +4,6 @@
 //
 
 import BrewCore
-import BrewRepositoryInterfaces
-import BrewUIComponents
 import Foundation
 
 /// Derived presentation for "uninstall in progress" chrome when observing ``BrewOperationPhase`` for an installed row.

--- a/Sources/BrewFeatureInstalled/ViewModels/InstalledUpgradeBusyPresentation.swift
+++ b/Sources/BrewFeatureInstalled/ViewModels/InstalledUpgradeBusyPresentation.swift
@@ -4,8 +4,6 @@
 //
 
 import BrewCore
-import BrewRepositoryInterfaces
-import BrewUIComponents
 import Foundation
 
 /// Derived presentation for "upgrade in progress" chrome when observing ``BrewOperationPhase`` for an installed row.

--- a/Sources/BrewFeatureInstalled/ViewModels/PackageDetailMetadataItem.swift
+++ b/Sources/BrewFeatureInstalled/ViewModels/PackageDetailMetadataItem.swift
@@ -21,11 +21,6 @@ struct PackageDetailMetadataItem {
         self.package = package
     }
 
-    /// User-facing command for package details transparency.
-    var infoCommand: String {
-        "brew info \(package.name)"
-    }
-
     var latestVersionValue: String {
         formattedValue(package.latestVersion)
     }

--- a/Sources/BrewFeatureInstalled/ViewModels/PackageDetailMetadataItem.swift
+++ b/Sources/BrewFeatureInstalled/ViewModels/PackageDetailMetadataItem.swift
@@ -4,8 +4,6 @@
 //
 
 import BrewCore
-import BrewRepositoryInterfaces
-import BrewUIComponents
 import Foundation
 
 /// Presentation mapping for Installed detail metadata content.

--- a/Sources/BrewFeatureInstalled/ViewModels/PackageRelationshipItem.swift
+++ b/Sources/BrewFeatureInstalled/ViewModels/PackageRelationshipItem.swift
@@ -4,7 +4,6 @@
 //
 
 import BrewCore
-import BrewRepositoryInterfaces
 import BrewUIComponents
 import Foundation
 

--- a/Sources/BrewFeatureInstalled/ViewModels/UninstallPackageItem.swift
+++ b/Sources/BrewFeatureInstalled/ViewModels/UninstallPackageItem.swift
@@ -4,7 +4,6 @@
 //
 
 import BrewCore
-import BrewRepositoryInterfaces
 import BrewUIComponents
 import Foundation
 

--- a/Sources/BrewFeatureInstalled/ViewModels/UpgradePackageItem.swift
+++ b/Sources/BrewFeatureInstalled/ViewModels/UpgradePackageItem.swift
@@ -4,7 +4,6 @@
 //
 
 import BrewCore
-import BrewRepositoryInterfaces
 import BrewUIComponents
 import Foundation
 

--- a/Sources/BrewFeatureInstalled/Views/InstalledListRowView.swift
+++ b/Sources/BrewFeatureInstalled/Views/InstalledListRowView.swift
@@ -163,20 +163,6 @@ struct InstalledListRowView: View {
     }
 }
 
-struct InstalledSectionHeader: View {
-    let title: String
-    let count: Int
-
-    var body: some View {
-        Text("\(title) (\(count))")
-            .font(.brewCaption2)
-            .foregroundStyle(Color.brewTextTertiary)
-            .textCase(.uppercase)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .accessibilityAddTraits(.isHeader)
-    }
-}
-
 #if DEBUG
 
     #Preview("Formula with upgrade") {

--- a/Sources/BrewFeatureInstalled/Views/InstalledPackageDetailSubviewSections.swift
+++ b/Sources/BrewFeatureInstalled/Views/InstalledPackageDetailSubviewSections.swift
@@ -5,7 +5,6 @@
 
 import AppKit
 import BrewCore
-import BrewRepositoryInterfaces
 import BrewUIComponents
 import SwiftUI
 

--- a/Sources/BrewRepositories/BrewCommandJobsRepository.swift
+++ b/Sources/BrewRepositories/BrewCommandJobsRepository.swift
@@ -3,7 +3,6 @@
 //  Brew
 //
 
-import BrewCLI
 import BrewCore
 import BrewRepositoryInterfaces
 import Foundation

--- a/Sources/BrewRepositoryInterfaces/Fakes/Stubs.swift
+++ b/Sources/BrewRepositoryInterfaces/Fakes/Stubs.swift
@@ -141,14 +141,6 @@ public actor StubBrewCommandCenter: BrewCommandCenter {
         .idle
     }
 
-    public func phaseByID() async -> [BrewOperationID: BrewOperationPhase] {
-        [:]
-    }
-
-    public func isActive(id _: BrewOperationID) async -> Bool {
-        false
-    }
-
     public func phaseChanges(for _: BrewOperationID) async -> AsyncStream<BrewOperationPhase> {
         AsyncStream<BrewOperationPhase>(bufferingPolicy: .unbounded) { continuation in
             continuation.yield(.idle)
@@ -158,12 +150,6 @@ public actor StubBrewCommandCenter: BrewCommandCenter {
 
     public func allPhaseChanges() async -> AsyncStream<(BrewOperationID, BrewOperationPhase)> {
         AsyncStream<(BrewOperationID, BrewOperationPhase)>(bufferingPolicy: .unbounded) { continuation in
-            continuation.finish()
-        }
-    }
-
-    public func outputChanges(for _: BrewOperationID) async -> AsyncStream<BrewCommandOutputLine> {
-        AsyncStream<BrewCommandOutputLine>(bufferingPolicy: .unbounded) { continuation in
             continuation.finish()
         }
     }

--- a/Sources/BrewRepositoryInterfaces/Protocols/InstalledPackagesRepository.swift
+++ b/Sources/BrewRepositoryInterfaces/Protocols/InstalledPackagesRepository.swift
@@ -3,7 +3,6 @@
 //  BrewRepositoryInterfaces
 //
 
-import BrewCore
 import Foundation
 
 /// App-scoped source of truth for installed/outdated package state: the observable inventory plus the

--- a/Sources/BrewServicesTestSupport/ControllableJobsCommandCenter.swift
+++ b/Sources/BrewServicesTestSupport/ControllableJobsCommandCenter.swift
@@ -36,14 +36,6 @@ public actor ControllableJobsCommandCenter: BrewCommandCenter {
         .idle
     }
 
-    public func phaseByID() async -> [BrewOperationID: BrewOperationPhase] {
-        [:]
-    }
-
-    public func isActive(id _: BrewOperationID) async -> Bool {
-        false
-    }
-
     public func phaseChanges(for _: BrewOperationID) async -> AsyncStream<BrewOperationPhase> {
         AsyncStream<BrewOperationPhase>(bufferingPolicy: .unbounded) { continuation in
             continuation.finish()
@@ -59,12 +51,6 @@ public actor ControllableJobsCommandCenter: BrewCommandCenter {
                 }
             }
             registerAllPhaseListener(token: token, continuation: continuation)
-        }
-    }
-
-    public func outputChanges(for _: BrewOperationID) async -> AsyncStream<BrewCommandOutputLine> {
-        AsyncStream<BrewCommandOutputLine>(bufferingPolicy: .unbounded) { continuation in
-            continuation.finish()
         }
     }
 

--- a/Sources/BrewServicesTestSupport/RecordingSerialBrewCommandCenter.swift
+++ b/Sources/BrewServicesTestSupport/RecordingSerialBrewCommandCenter.swift
@@ -21,24 +21,12 @@ public actor RecordingSerialBrewCommandCenter: BrewCommandCenter {
         await inner.phase(for: id)
     }
 
-    public func phaseByID() async -> [BrewOperationID: BrewOperationPhase] {
-        await inner.phaseByID()
-    }
-
-    public func isActive(id: BrewOperationID) async -> Bool {
-        await inner.isActive(id: id)
-    }
-
     public func phaseChanges(for id: BrewOperationID) async -> AsyncStream<BrewOperationPhase> {
         await inner.phaseChanges(for: id)
     }
 
     public func allPhaseChanges() async -> AsyncStream<(BrewOperationID, BrewOperationPhase)> {
         await inner.allPhaseChanges()
-    }
-
-    public func outputChanges(for id: BrewOperationID) async -> AsyncStream<BrewCommandOutputLine> {
-        await inner.outputChanges(for: id)
     }
 
     public func allOutputChanges() async -> AsyncStream<(BrewOperationID, BrewCommandOutputLine)> {

--- a/Tests/BrewCLITests/BrewCommandServiceStreamingTests.swift
+++ b/Tests/BrewCLITests/BrewCommandServiceStreamingTests.swift
@@ -5,8 +5,6 @@
 
 @testable import BrewCLI
 import BrewCore
-import BrewCoreTestSupport
-import BrewServicesTestSupport
 import Foundation
 import Testing
 

--- a/Tests/BrewCLITests/BrewCommandServiceTests.swift
+++ b/Tests/BrewCLITests/BrewCommandServiceTests.swift
@@ -5,8 +5,6 @@
 
 @testable import BrewCLI
 import BrewCore
-import BrewCoreTestSupport
-import BrewServicesTestSupport
 import Foundation
 import Testing
 

--- a/Tests/BrewCLITests/BrewExecutableLocatorTests.swift
+++ b/Tests/BrewCLITests/BrewExecutableLocatorTests.swift
@@ -1,7 +1,5 @@
 @testable import BrewCLI
 import BrewCore
-import BrewCoreTestSupport
-import BrewServicesTestSupport
 import Foundation
 import Testing
 

--- a/Tests/BrewCLITests/BulkUpgradeCommandTests.swift
+++ b/Tests/BrewCLITests/BulkUpgradeCommandTests.swift
@@ -5,7 +5,6 @@
 
 @testable import BrewCLI
 import BrewCore
-import BrewServicesTestSupport
 import Foundation
 import Testing
 

--- a/Tests/BrewCLITests/InstalledInventorySnapshotTests.swift
+++ b/Tests/BrewCLITests/InstalledInventorySnapshotTests.swift
@@ -6,7 +6,6 @@
 @testable import BrewCLI
 import BrewCore
 import BrewCoreTestSupport
-import BrewServicesTestSupport
 import Foundation
 import Testing
 

--- a/Tests/BrewCLITests/NoopBrewCommandCenterTests.swift
+++ b/Tests/BrewCLITests/NoopBrewCommandCenterTests.swift
@@ -5,8 +5,6 @@
 
 @testable import BrewCLI
 import BrewCore
-import BrewCoreTestSupport
-import BrewServicesTestSupport
 import Foundation
 import Testing
 

--- a/Tests/BrewCLITests/NoopBrewCommandCenterTests.swift
+++ b/Tests/BrewCLITests/NoopBrewCommandCenterTests.swift
@@ -9,13 +9,11 @@ import Foundation
 import Testing
 
 struct NoopBrewCommandCenterTests {
-    @Test func `phase and activity stay empty while idle`() async {
+    @Test func `phase stays idle while no work is submitted`() async {
         let center = NoopBrewCommandCenter.forTesting()
         let id = BrewOperationID(kind: .formula, name: "hello")
 
         #expect(await center.phase(for: id) == .idle)
-        #expect(await center.phaseByID().isEmpty)
-        #expect(await !center.isActive(id: id))
     }
 
     @Test func `submit runs command without tracking phase`() async throws {
@@ -27,8 +25,6 @@ struct NoopBrewCommandCenterTests {
 
         #expect(await counter.value == 1)
         #expect(await center.phase(for: id) == .idle)
-        #expect(await center.phaseByID().isEmpty)
-        #expect(await !center.isActive(id: id))
     }
 
     @Test func `submit propagates thrown errors`() async {

--- a/Tests/BrewCLITests/PackageInstallCommandTests.swift
+++ b/Tests/BrewCLITests/PackageInstallCommandTests.swift
@@ -5,8 +5,6 @@
 
 @testable import BrewCLI
 import BrewCore
-import BrewCoreTestSupport
-import BrewServicesTestSupport
 import Foundation
 import Testing
 

--- a/Tests/BrewCLITests/PackageUninstallCommandTests.swift
+++ b/Tests/BrewCLITests/PackageUninstallCommandTests.swift
@@ -6,7 +6,6 @@
 @testable import BrewCLI
 import BrewCore
 import BrewCoreTestSupport
-import BrewServicesTestSupport
 import Foundation
 import Testing
 

--- a/Tests/BrewCLITests/PackageUpgradeCommandTests.swift
+++ b/Tests/BrewCLITests/PackageUpgradeCommandTests.swift
@@ -6,7 +6,6 @@
 @testable import BrewCLI
 import BrewCore
 import BrewCoreTestSupport
-import BrewServicesTestSupport
 import Foundation
 import Testing
 

--- a/Tests/BrewCLITests/SerialBrewCommandCenterOutputTests.swift
+++ b/Tests/BrewCLITests/SerialBrewCommandCenterOutputTests.swift
@@ -5,7 +5,6 @@
 
 @testable import BrewCLI
 import BrewCore
-import BrewCoreTestSupport
 import BrewServicesTestSupport
 import Foundation
 import Testing

--- a/Tests/BrewCLITests/SerialBrewCommandCenterOutputTests.swift
+++ b/Tests/BrewCLITests/SerialBrewCommandCenterOutputTests.swift
@@ -9,14 +9,6 @@ import BrewServicesTestSupport
 import Foundation
 import Testing
 
-private actor OutputLineCollector {
-    private(set) var lines: [BrewCommandOutputLine] = []
-
-    func append(_ line: BrewCommandOutputLine) {
-        lines.append(line)
-    }
-}
-
 private actor AllOutputCollector {
     private(set) var events: [(BrewOperationID, BrewCommandOutputLine)] = []
 
@@ -52,14 +44,14 @@ private func makeOutputTestCenter() -> SerialBrewCommandCenter {
 }
 
 struct SerialBrewCommandCenterOutputTests {
-    @Test func `outputChanges for id delivers lines emitted via the sink in order`() async throws {
+    @Test func `output for an id delivers lines emitted via the sink in order`() async throws {
         let center = makeOutputTestCenter()
         let id = BrewOperationID(kind: .formula, name: "output-order")
-        let stream = await center.outputChanges(for: id)
-        let collector = OutputLineCollector()
+        let stream = await center.allOutputChanges()
+        let collector = AllOutputCollector()
         let collect = Task {
-            for await line in stream {
-                await collector.append(line)
+            for await pair in stream {
+                await collector.append(id: pair.0, line: pair.1)
             }
         }
         defer { collect.cancel() }
@@ -75,7 +67,7 @@ struct SerialBrewCommandCenterOutputTests {
         )
         try await Task.sleep(for: .milliseconds(80))
 
-        let lines = await collector.lines
+        let lines = await collector.events.filter { $0.0 == id }.map(\.1)
         #expect(lines.map(\.text) == ["one", "two", "warn", "three"])
         #expect(lines.map(\.stream) == [.stdout, .stdout, .stderr, .stdout])
     }
@@ -110,21 +102,21 @@ struct SerialBrewCommandCenterOutputTests {
         #expect(textsB == ["b1"])
     }
 
-    @Test func `outputChanges multicasts to multiple subscribers`() async throws {
+    @Test func `output multicasts to multiple subscribers`() async throws {
         let center = makeOutputTestCenter()
         let id = BrewOperationID(kind: .formula, name: "output-multi")
-        let streamA = await center.outputChanges(for: id)
-        let streamB = await center.outputChanges(for: id)
-        let collectorA = OutputLineCollector()
-        let collectorB = OutputLineCollector()
+        let streamA = await center.allOutputChanges()
+        let streamB = await center.allOutputChanges()
+        let collectorA = AllOutputCollector()
+        let collectorB = AllOutputCollector()
         let taskA = Task {
-            for await line in streamA {
-                await collectorA.append(line)
+            for await pair in streamA {
+                await collectorA.append(id: pair.0, line: pair.1)
             }
         }
         let taskB = Task {
-            for await line in streamB {
-                await collectorB.append(line)
+            for await pair in streamB {
+                await collectorB.append(id: pair.0, line: pair.1)
             }
         }
         defer {
@@ -138,8 +130,8 @@ struct SerialBrewCommandCenterOutputTests {
         )
         try await Task.sleep(for: .milliseconds(80))
 
-        let textsA = await collectorA.lines.map(\.text)
-        let textsB = await collectorB.lines.map(\.text)
+        let textsA = await collectorA.events.map(\.1.text)
+        let textsB = await collectorB.events.map(\.1.text)
         #expect(textsA == ["x", "y"])
         #expect(textsB == ["x", "y"])
     }
@@ -147,11 +139,11 @@ struct SerialBrewCommandCenterOutputTests {
     @Test func `output listener removed on stream termination`() async throws {
         let center = makeOutputTestCenter()
         let id = BrewOperationID(kind: .formula, name: "output-cleanup")
-        let stream = await center.outputChanges(for: id)
-        let collector = OutputLineCollector()
+        let stream = await center.allOutputChanges()
+        let collector = AllOutputCollector()
         let collect = Task {
-            for await line in stream {
-                await collector.append(line)
+            for await pair in stream {
+                await collector.append(id: pair.0, line: pair.1)
             }
         }
         collect.cancel()
@@ -163,7 +155,7 @@ struct SerialBrewCommandCenterOutputTests {
         )
         try await Task.sleep(for: .milliseconds(80))
 
-        let lines = await collector.lines
-        #expect(lines.isEmpty)
+        let events = await collector.events
+        #expect(events.isEmpty)
     }
 }

--- a/Tests/BrewCLITests/SerialBrewCommandCenterTests.swift
+++ b/Tests/BrewCLITests/SerialBrewCommandCenterTests.swift
@@ -90,7 +90,6 @@ struct SerialBrewCommandCenterTests {
         try await center.submit(id: id, command: EmptyMutatingCommand())
 
         #expect(await center.phase(for: id) == .idle)
-        #expect(await !center.isActive(id: id))
     }
 
     @Test func `records failure with OperationFailure and clears in flight slot`() async throws {
@@ -110,23 +109,6 @@ struct SerialBrewCommandCenterTests {
             return
         }
         #expect(!failure.userFacingMessage.isEmpty)
-        #expect(await !center.isActive(id: id))
-    }
-
-    @Test func `phaseByID exposes tracked entries`() async throws {
-        let center = makeCenter()
-        let id = BrewOperationID(kind: .formula, name: "snapshot")
-        #expect(await center.phaseByID().isEmpty)
-
-        do {
-            try await center.submit(id: id, command: ThrowingMutatingCommand())
-        } catch {
-            _ = error
-        }
-
-        let map = await center.phaseByID()
-        #expect(map[id] != nil)
-        #expect(await center.phase(for: id) == map[id])
     }
 
     @Test func `mutating command uses injected mock runner not real brew`() async throws {

--- a/Tests/BrewCLITests/SerialBrewCommandCenterTests.swift
+++ b/Tests/BrewCLITests/SerialBrewCommandCenterTests.swift
@@ -5,7 +5,6 @@
 
 @testable import BrewCLI
 import BrewCore
-import BrewCoreTestSupport
 import BrewServicesTestSupport
 import Foundation
 import Testing

--- a/Tests/BrewCoreTests/DiscoveryBrewPackagePlaceholderTests.swift
+++ b/Tests/BrewCoreTests/DiscoveryBrewPackagePlaceholderTests.swift
@@ -1,5 +1,4 @@
 @testable import BrewCore
-import BrewCoreTestSupport
 import Foundation
 import Testing
 

--- a/Tests/BrewCoreTests/OperationFailureTests.swift
+++ b/Tests/BrewCoreTests/OperationFailureTests.swift
@@ -1,5 +1,4 @@
 @testable import BrewCore
-import BrewCoreTestSupport
 import Foundation
 import Testing
 

--- a/Tests/BrewCrashReportingTests/CrashReportStoreTests.swift
+++ b/Tests/BrewCrashReportingTests/CrashReportStoreTests.swift
@@ -65,9 +65,11 @@ struct CrashReportStoreTests {
     }
 
     @Test func `unrelated files in the directory are ignored`() throws {
-        let store = makeTemporaryStore()
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CrashReportStoreTests-\(UUID().uuidString)", isDirectory: true)
+        let store = CrashReportStore(directoryURL: directory)
         try store.ensureDirectoryExists()
-        try Data("noise".utf8).write(to: store.directory.appendingPathComponent("notes.txt"))
+        try Data("noise".utf8).write(to: directory.appendingPathComponent("notes.txt"))
         let saved = try store.save(text: "boom", date: Date(timeIntervalSince1970: 1000))
 
         #expect(store.pendingReports() == [saved])

--- a/Tests/BrewFeatureConfigTests/ConfigViewModelTests.swift
+++ b/Tests/BrewFeatureConfigTests/ConfigViewModelTests.swift
@@ -91,7 +91,11 @@ struct ConfigViewModelTests {
         await viewModel.load()
 
         #expect(!viewModel.isBrewNotFound)
-        #expect(viewModel.errorMessage == "something broke")
+        guard case let .failed(message) = viewModel.pageState else {
+            Issue.record("expected a failed page state")
+            return
+        }
+        #expect(message == "something broke")
     }
 
     @Test @MainActor func `unknown errors map to a generic message`() async {
@@ -101,7 +105,11 @@ struct ConfigViewModelTests {
 
         await viewModel.load()
 
-        #expect(viewModel.errorMessage == "Couldn't read the Homebrew configuration.")
+        guard case let .failed(message) = viewModel.pageState else {
+            Issue.record("expected a failed page state")
+            return
+        }
+        #expect(message == "Couldn't read the Homebrew configuration.")
     }
 }
 

--- a/Tests/BrewFeatureConsoleTests/BrewCommandJobsRepositoryTests.swift
+++ b/Tests/BrewFeatureConsoleTests/BrewCommandJobsRepositoryTests.swift
@@ -3,14 +3,10 @@
 //  BrewTests
 //
 
-import BrewCLI
 import BrewCore
-import BrewCoreTestSupport
 @testable import BrewFeatureConsole
-import BrewNetworking
 @testable import BrewRepositories
 import BrewRepositoryInterfaces
-import BrewServicesTestSupport
 import Foundation
 import Testing
 

--- a/Tests/BrewFeatureConsoleTests/CommandJobExportTests.swift
+++ b/Tests/BrewFeatureConsoleTests/CommandJobExportTests.swift
@@ -4,11 +4,9 @@
 //
 
 import BrewCore
-import BrewCoreTestSupport
 @testable import BrewFeatureConsole
 import BrewRepositories
 import BrewRepositoryInterfaces
-import BrewServicesTestSupport
 import Foundation
 import Testing
 

--- a/Tests/BrewFeatureConsoleTests/CommandJobTests.swift
+++ b/Tests/BrewFeatureConsoleTests/CommandJobTests.swift
@@ -4,11 +4,9 @@
 //
 
 import BrewCore
-import BrewCoreTestSupport
 @testable import BrewFeatureConsole
 import BrewRepositories
 import BrewRepositoryInterfaces
-import BrewServicesTestSupport
 import Foundation
 import Testing
 

--- a/Tests/BrewFeatureConsoleTests/ConsoleStatusPresentationTests.swift
+++ b/Tests/BrewFeatureConsoleTests/ConsoleStatusPresentationTests.swift
@@ -4,11 +4,8 @@
 //
 
 import BrewCore
-import BrewCoreTestSupport
 @testable import BrewFeatureConsole
 import BrewRepositories
-import BrewRepositoryInterfaces
-import BrewServicesTestSupport
 import Foundation
 import Testing
 

--- a/Tests/BrewFeatureConsoleTests/ConsoleViewModelTests.swift
+++ b/Tests/BrewFeatureConsoleTests/ConsoleViewModelTests.swift
@@ -4,11 +4,9 @@
 //
 
 import BrewCore
-import BrewCoreTestSupport
 @testable import BrewFeatureConsole
 import BrewRepositories
 import BrewRepositoryInterfaces
-import BrewServicesTestSupport
 import Foundation
 import Testing
 

--- a/Tests/BrewFeatureDiscoverTests/DiscoverInstallBusyPresentationTests.swift
+++ b/Tests/BrewFeatureDiscoverTests/DiscoverInstallBusyPresentationTests.swift
@@ -3,12 +3,8 @@
 //  BrewTests
 //
 
-import BrewCLI
 import BrewCore
-import BrewCoreTestSupport
 @testable import BrewFeatureDiscover
-import BrewRepositoryInterfaces
-import BrewServicesTestSupport
 import Foundation
 import Testing
 

--- a/Tests/BrewFeatureDiscoverTests/DiscoverListRowViewModelTests.swift
+++ b/Tests/BrewFeatureDiscoverTests/DiscoverListRowViewModelTests.swift
@@ -3,7 +3,6 @@ import BrewCore
 import BrewCoreTestSupport
 @testable import BrewFeatureDiscover
 import BrewRepositoryInterfaces
-import BrewServicesTestSupport
 import Testing
 
 struct DiscoverListRowViewModelTests {

--- a/Tests/BrewFeatureDiscoverTests/DiscoverPackageDetailViewModelTests.swift
+++ b/Tests/BrewFeatureDiscoverTests/DiscoverPackageDetailViewModelTests.swift
@@ -3,7 +3,6 @@ import BrewCore
 import BrewCoreTestSupport
 @testable import BrewFeatureDiscover
 import BrewRepositoryInterfaces
-import BrewServicesTestSupport
 import Foundation
 import Testing
 

--- a/Tests/BrewFeatureDiscoverTests/DiscoverViewModelTests.swift
+++ b/Tests/BrewFeatureDiscoverTests/DiscoverViewModelTests.swift
@@ -1,9 +1,7 @@
-import BrewCLI
 import BrewCore
 import BrewCoreTestSupport
 @testable import BrewFeatureDiscover
 import BrewRepositoryInterfaces
-import BrewServicesTestSupport
 import Foundation
 import Testing
 

--- a/Tests/BrewFeatureDoctorTests/DoctorViewModelTests.swift
+++ b/Tests/BrewFeatureDoctorTests/DoctorViewModelTests.swift
@@ -83,22 +83,31 @@ struct DoctorViewModelTests {
         )
     }
 
+    /// The issue items in the order the view renders them — grouped by descending severity — mirroring
+    /// `DoctorView`'s `DoctorIssueGroup.grouped(from:)` call. Tests assert against this production
+    /// projection rather than a raw `report.issues` mapping.
+    private static func displayedItems(_ report: DoctorReport) -> [DoctorIssueItem] {
+        DoctorIssueGroup.grouped(from: report).flatMap(\.items)
+    }
+
     @Test func `projects loaded issues and selects the first`() async {
-        let viewModel = Self.viewModel(repository: StubDoctorRepository(report: Self.issuesReport()))
+        let report = Self.issuesReport()
+        let viewModel = Self.viewModel(repository: StubDoctorRepository(report: report))
         await viewModel.load()
+        let items = Self.displayedItems(report)
 
         #expect(viewModel.presentation == .issues)
-        #expect(viewModel.issueItems.count == 2)
-        #expect(viewModel.issueItems.first?.title == "You have unlinked kegs in your Cellar.")
-        #expect(viewModel.issueItems.first?.hasRunnableFix == true)
-        #expect(viewModel.issueItems.last?.hasRunnableFix == false)
-        #expect(viewModel.selectedIssueID == viewModel.issueItems.first?.id)
+        #expect(items.count == 2)
+        #expect(items.first?.title == "You have unlinked kegs in your Cellar.")
+        #expect(items.first?.hasRunnableFix == true)
+        #expect(items.last?.hasRunnableFix == false)
+        #expect(viewModel.selectedIssueID == items.first?.id)
     }
 
     @Test func `projects healthy report`() {
         let viewModel = Self.viewModel(repository: StubDoctorRepository(report: DoctorReport(issues: [])))
         #expect(viewModel.presentation == .healthy)
-        #expect(viewModel.issueItems.isEmpty)
+        #expect(viewModel.orderedIssueIDs.isEmpty)
     }
 
     @Test func `projects a failure into a user-facing message`() {
@@ -111,22 +120,24 @@ struct DoctorViewModelTests {
     }
 
     @Test func `setSelection changes the selected issue`() {
-        let viewModel = Self.viewModel(repository: StubDoctorRepository(report: Self.issuesReport()))
-        let secondID = viewModel.issueItems[1].id
+        let report = Self.issuesReport()
+        let viewModel = Self.viewModel(repository: StubDoctorRepository(report: report))
+        let secondID = Self.displayedItems(report)[1].id
         viewModel.setSelection(secondID)
         #expect(viewModel.selectedIssueID == secondID)
         #expect(viewModel.selectedIssue?.title == "Some installed formulae are deprecated.")
     }
 
     @Test func `runFix submits a doctorFix maintenance operation`() async {
+        let report = Self.cleanupReport()
         let center = Self.recordingCenter(cleanupExitCode: 0)
         let viewModel = Self.viewModel(
-            repository: StubDoctorRepository(report: Self.cleanupReport()),
+            repository: StubDoctorRepository(report: report),
             commandCenter: center,
             commandFactory: LiveBrewMutatingCommandFactory(),
         )
 
-        viewModel.runFix(for: viewModel.issueItems[0])
+        viewModel.runFix(for: Self.displayedItems(report)[0])
         let entries = await waitForSubmitEntries(on: center)
 
         #expect(entries.count == 1)
@@ -135,26 +146,29 @@ struct DoctorViewModelTests {
     }
 
     @Test func `isFixRunning is false for an item without a runnable fix`() {
-        let viewModel = Self.viewModel(repository: StubDoctorRepository(report: Self.issuesReport()))
+        let report = Self.issuesReport()
+        let viewModel = Self.viewModel(repository: StubDoctorRepository(report: report))
         // The deprecated-formulae issue (index 1) has no runnable block, so no fix token to track.
-        let nonRunnable = viewModel.issueItems[1]
+        let nonRunnable = Self.displayedItems(report)[1]
         #expect(nonRunnable.fixToken == nil)
         #expect(viewModel.isFixRunning(nonRunnable) == false)
     }
 
     @Test func `fixError is nil for an item without a runnable fix`() {
-        let viewModel = Self.viewModel(repository: StubDoctorRepository(report: Self.issuesReport()))
-        #expect(viewModel.fixError(viewModel.issueItems[1]) == nil)
+        let report = Self.issuesReport()
+        let viewModel = Self.viewModel(repository: StubDoctorRepository(report: report))
+        #expect(viewModel.fixError(Self.displayedItems(report)[1]) == nil)
     }
 
     @Test func `runFix surfaces an inline error when the fix fails`() async {
+        let report = Self.cleanupReport()
         let center = Self.recordingCenter(cleanupExitCode: 1, stderr: "could not clean")
         let viewModel = Self.viewModel(
-            repository: StubDoctorRepository(report: Self.cleanupReport()),
+            repository: StubDoctorRepository(report: report),
             commandCenter: center,
             commandFactory: LiveBrewMutatingCommandFactory(),
         )
-        let item = viewModel.issueItems[0]
+        let item = Self.displayedItems(report)[0]
 
         viewModel.runFix(for: item)
         await waitUntil({ viewModel.fixError(item) != nil }, "fix error surfaced")
@@ -227,7 +241,7 @@ struct DoctorViewModelTests {
         let viewModel = Self.viewModel(repository: repository)
 
         await viewModel.load()
-        let thirdID = viewModel.issueItems[2].id
+        let thirdID = Self.displayedItems(initial)[2].id
         viewModel.setSelection(thirdID)
         #expect(viewModel.selectedIssueID == thirdID)
 
@@ -247,7 +261,7 @@ struct DoctorViewModelTests {
         let viewModel = Self.viewModel(repository: repository)
 
         await viewModel.load()
-        let secondID = viewModel.issueItems[1].id
+        let secondID = Self.displayedItems(report)[1].id
         viewModel.setSelection(secondID)
 
         await viewModel.load()

--- a/Tests/BrewFeatureInstalledTests/BrewTests.swift
+++ b/Tests/BrewFeatureInstalledTests/BrewTests.swift
@@ -5,13 +5,10 @@
 //  Created by Graeme Arthur on 6/3/2026.
 //
 
-import BrewCLI
 import BrewCore
 import BrewCoreTestSupport
 @testable import BrewFeatureInstalled
 import BrewRepositories
-import BrewRepositoryInterfaces
-import BrewServicesTestSupport
 import Testing
 
 struct BrewTests {

--- a/Tests/BrewFeatureInstalledTests/InstalledDetailMutationParityTests.swift
+++ b/Tests/BrewFeatureInstalledTests/InstalledDetailMutationParityTests.swift
@@ -9,7 +9,6 @@ import BrewCoreTestSupport
 @testable import BrewFeatureInstalled
 import BrewRepositories
 @testable import BrewRepositoryInterfaces
-import BrewServicesTestSupport
 import Testing
 
 @MainActor

--- a/Tests/BrewFeatureInstalledTests/InstalledDetailsViewModelTests.swift
+++ b/Tests/BrewFeatureInstalledTests/InstalledDetailsViewModelTests.swift
@@ -9,7 +9,6 @@ import BrewCoreTestSupport
 @testable import BrewFeatureInstalled
 import BrewRepositories
 @testable import BrewRepositoryInterfaces
-import BrewServicesTestSupport
 import Foundation
 import Testing
 

--- a/Tests/BrewFeatureInstalledTests/InstalledDetailsViewModelTestsSupport.swift
+++ b/Tests/BrewFeatureInstalledTests/InstalledDetailsViewModelTestsSupport.swift
@@ -18,15 +18,6 @@ actor ConstantPhaseCommandCenter: BrewCommandCenter {
         fixedPhase
     }
 
-    func phaseByID() async -> [BrewOperationID: BrewOperationPhase] {
-        [:]
-    }
-
-    func isActive(id _: BrewOperationID) async -> Bool {
-        if case .running = fixedPhase { return true }
-        return false
-    }
-
     func submit(id _: BrewOperationID, command _: any BrewMutatingCommand) async throws {}
     func phaseChanges(for _: BrewOperationID) async -> AsyncStream<BrewOperationPhase> {
         AsyncStream<BrewOperationPhase>(bufferingPolicy: .unbounded) { continuation in
@@ -37,12 +28,6 @@ actor ConstantPhaseCommandCenter: BrewCommandCenter {
 
     func allPhaseChanges() async -> AsyncStream<(BrewOperationID, BrewOperationPhase)> {
         AsyncStream<(BrewOperationID, BrewOperationPhase)>(bufferingPolicy: .unbounded) { continuation in
-            continuation.finish()
-        }
-    }
-
-    func outputChanges(for _: BrewOperationID) async -> AsyncStream<BrewCommandOutputLine> {
-        AsyncStream<BrewCommandOutputLine>(bufferingPolicy: .unbounded) { continuation in
             continuation.finish()
         }
     }
@@ -64,14 +49,6 @@ actor ThrowingSubmitCommandCenter: BrewCommandCenter {
         .idle
     }
 
-    func phaseByID() async -> [BrewOperationID: BrewOperationPhase] {
-        [:]
-    }
-
-    func isActive(id _: BrewOperationID) async -> Bool {
-        false
-    }
-
     func submit(id _: BrewOperationID, command _: any BrewMutatingCommand) async throws {
         throw error
     }
@@ -84,12 +61,6 @@ actor ThrowingSubmitCommandCenter: BrewCommandCenter {
 
     func allPhaseChanges() async -> AsyncStream<(BrewOperationID, BrewOperationPhase)> {
         AsyncStream<(BrewOperationID, BrewOperationPhase)>(bufferingPolicy: .unbounded) { continuation in
-            continuation.finish()
-        }
-    }
-
-    func outputChanges(for _: BrewOperationID) async -> AsyncStream<BrewCommandOutputLine> {
-        AsyncStream<BrewCommandOutputLine>(bufferingPolicy: .unbounded) { continuation in
             continuation.finish()
         }
     }
@@ -113,14 +84,6 @@ actor RunningSubmitCountingCommandCenter: BrewCommandCenter {
         runningPhase
     }
 
-    func phaseByID() async -> [BrewOperationID: BrewOperationPhase] {
-        [:]
-    }
-
-    func isActive(id _: BrewOperationID) async -> Bool {
-        true
-    }
-
     func submit(id _: BrewOperationID, command _: any BrewMutatingCommand) async throws {
         submitCallCount += 1
     }
@@ -137,12 +100,6 @@ actor RunningSubmitCountingCommandCenter: BrewCommandCenter {
         }
     }
 
-    func outputChanges(for _: BrewOperationID) async -> AsyncStream<BrewCommandOutputLine> {
-        AsyncStream<BrewCommandOutputLine>(bufferingPolicy: .unbounded) { continuation in
-            continuation.finish()
-        }
-    }
-
     func allOutputChanges() async -> AsyncStream<(BrewOperationID, BrewCommandOutputLine)> {
         AsyncStream<(BrewOperationID, BrewCommandOutputLine)>(bufferingPolicy: .unbounded) { continuation in
             continuation.finish()
@@ -155,14 +112,6 @@ actor SubmitRecordingCommandCenter: BrewCommandCenter {
 
     func phase(for _: BrewOperationID) async -> BrewOperationPhase {
         .idle
-    }
-
-    func phaseByID() async -> [BrewOperationID: BrewOperationPhase] {
-        [:]
-    }
-
-    func isActive(id _: BrewOperationID) async -> Bool {
-        false
     }
 
     func submit(id: BrewOperationID, command: any BrewMutatingCommand) async throws {
@@ -188,12 +137,6 @@ actor SubmitRecordingCommandCenter: BrewCommandCenter {
         }
     }
 
-    func outputChanges(for _: BrewOperationID) async -> AsyncStream<BrewCommandOutputLine> {
-        AsyncStream<BrewCommandOutputLine>(bufferingPolicy: .unbounded) { continuation in
-            continuation.finish()
-        }
-    }
-
     func allOutputChanges() async -> AsyncStream<(BrewOperationID, BrewCommandOutputLine)> {
         AsyncStream<(BrewOperationID, BrewCommandOutputLine)>(bufferingPolicy: .unbounded) { continuation in
             continuation.finish()
@@ -206,14 +149,6 @@ actor DeferredSubmitCommandCenter: BrewCommandCenter {
     private var continuation: CheckedContinuation<Void, Never>?
     func phase(for _: BrewOperationID) async -> BrewOperationPhase {
         .idle
-    }
-
-    func phaseByID() async -> [BrewOperationID: BrewOperationPhase] {
-        [:]
-    }
-
-    func isActive(id _: BrewOperationID) async -> Bool {
-        submitCallCount > 0
     }
 
     func submit(id _: BrewOperationID, command _: any BrewMutatingCommand) async throws {
@@ -239,12 +174,6 @@ actor DeferredSubmitCommandCenter: BrewCommandCenter {
 
     func allPhaseChanges() async -> AsyncStream<(BrewOperationID, BrewOperationPhase)> {
         AsyncStream<(BrewOperationID, BrewOperationPhase)>(bufferingPolicy: .unbounded) { continuation in
-            continuation.finish()
-        }
-    }
-
-    func outputChanges(for _: BrewOperationID) async -> AsyncStream<BrewCommandOutputLine> {
-        AsyncStream<BrewCommandOutputLine>(bufferingPolicy: .unbounded) { continuation in
             continuation.finish()
         }
     }

--- a/Tests/BrewFeatureInstalledTests/InstalledDetailsViewModelTestsSupport.swift
+++ b/Tests/BrewFeatureInstalledTests/InstalledDetailsViewModelTestsSupport.swift
@@ -4,7 +4,6 @@ import BrewCoreTestSupport
 @testable import BrewFeatureInstalled
 import BrewRepositories
 @testable import BrewRepositoryInterfaces
-import BrewServicesTestSupport
 import Foundation
 import Testing
 

--- a/Tests/BrewFeatureInstalledTests/InstalledListRowViewModelTests.swift
+++ b/Tests/BrewFeatureInstalledTests/InstalledListRowViewModelTests.swift
@@ -175,20 +175,6 @@ private actor PhaseSequenceCommandCenter: BrewCommandCenter {
         return phases.last ?? .idle
     }
 
-    func phaseByID() async -> [BrewOperationID: BrewOperationPhase] {
-        [:]
-    }
-
-    func isActive(id: BrewOperationID) async -> Bool {
-        _ = id
-        return phases.contains { phase in
-            if case .running = phase {
-                return true
-            }
-            return false
-        }
-    }
-
     func submit(id: BrewOperationID, command: any BrewMutatingCommand) async throws {
         _ = id
         _ = command
@@ -206,12 +192,6 @@ private actor PhaseSequenceCommandCenter: BrewCommandCenter {
 
     func allPhaseChanges() async -> AsyncStream<(BrewOperationID, BrewOperationPhase)> {
         AsyncStream<(BrewOperationID, BrewOperationPhase)>(bufferingPolicy: .unbounded) { continuation in
-            continuation.finish()
-        }
-    }
-
-    func outputChanges(for _: BrewOperationID) async -> AsyncStream<BrewCommandOutputLine> {
-        AsyncStream<BrewCommandOutputLine>(bufferingPolicy: .unbounded) { continuation in
             continuation.finish()
         }
     }

--- a/Tests/BrewFeatureInstalledTests/InstalledListRowViewModelTests.swift
+++ b/Tests/BrewFeatureInstalledTests/InstalledListRowViewModelTests.swift
@@ -8,8 +8,6 @@ import BrewCore
 import BrewCoreTestSupport
 @testable import BrewFeatureInstalled
 import BrewRepositories
-import BrewRepositoryInterfaces
-import BrewServicesTestSupport
 import Foundation
 import Testing
 

--- a/Tests/BrewFeatureInstalledTests/InstalledPackageRowPresentationTests.swift
+++ b/Tests/BrewFeatureInstalledTests/InstalledPackageRowPresentationTests.swift
@@ -8,8 +8,6 @@ import BrewCore
 import BrewCoreTestSupport
 @testable import BrewFeatureInstalled
 import BrewRepositories
-import BrewRepositoryInterfaces
-import BrewServicesTestSupport
 import BrewUIComponents
 import Testing
 

--- a/Tests/BrewFeatureInstalledTests/InstalledUninstallBusyPresentationTests.swift
+++ b/Tests/BrewFeatureInstalledTests/InstalledUninstallBusyPresentationTests.swift
@@ -3,13 +3,8 @@
 //  BrewTests
 //
 
-import BrewCLI
 import BrewCore
-import BrewCoreTestSupport
 @testable import BrewFeatureInstalled
-import BrewRepositories
-import BrewRepositoryInterfaces
-import BrewServicesTestSupport
 import Foundation
 import Testing
 

--- a/Tests/BrewFeatureInstalledTests/InstalledUpgradeBusyPresentationTests.swift
+++ b/Tests/BrewFeatureInstalledTests/InstalledUpgradeBusyPresentationTests.swift
@@ -3,13 +3,8 @@
 //  BrewTests
 //
 
-import BrewCLI
 import BrewCore
-import BrewCoreTestSupport
 @testable import BrewFeatureInstalled
-import BrewRepositories
-import BrewRepositoryInterfaces
-import BrewServicesTestSupport
 import Foundation
 import Testing
 

--- a/Tests/BrewFeatureInstalledTests/InstalledViewModelPresentationTests.swift
+++ b/Tests/BrewFeatureInstalledTests/InstalledViewModelPresentationTests.swift
@@ -3,13 +3,10 @@
 //  BrewTests
 //
 
-import BrewCLI
 import BrewCore
 import BrewCoreTestSupport
 @testable import BrewFeatureInstalled
 import BrewRepositories
-import BrewRepositoryInterfaces
-import BrewServicesTestSupport
 import Foundation
 import Testing
 

--- a/Tests/BrewFeatureInstalledTests/InstalledViewModelScopeTests.swift
+++ b/Tests/BrewFeatureInstalledTests/InstalledViewModelScopeTests.swift
@@ -3,13 +3,10 @@
 //  BrewTests
 //
 
-import BrewCLI
 import BrewCore
 import BrewCoreTestSupport
 @testable import BrewFeatureInstalled
 import BrewRepositories
-import BrewRepositoryInterfaces
-import BrewServicesTestSupport
 import Foundation
 import Testing
 

--- a/Tests/BrewFeatureInstalledTests/InstalledViewModelSearchTests.swift
+++ b/Tests/BrewFeatureInstalledTests/InstalledViewModelSearchTests.swift
@@ -3,13 +3,10 @@
 //  BrewTests
 //
 
-import BrewCLI
 import BrewCore
 import BrewCoreTestSupport
 @testable import BrewFeatureInstalled
 import BrewRepositories
-import BrewRepositoryInterfaces
-import BrewServicesTestSupport
 import Foundation
 import Testing
 

--- a/Tests/BrewFeatureInstalledTests/InstalledViewModelTestsSupport.swift
+++ b/Tests/BrewFeatureInstalledTests/InstalledViewModelTestsSupport.swift
@@ -13,38 +13,6 @@ import BrewServicesTestSupport
 import Foundation
 import Testing
 
-// MARK: - Snapshots (one logical assertion per load test)
-
-struct VMStateSnapshot: Equatable {
-    var state: LoadState<InstalledPackagesContent, String>
-    var formulaPackages: [InstalledBrewPackage]
-    var caskPackages: [InstalledBrewPackage]
-    var selectedPackageID: InstalledBrewPackage.ID?
-    var totalPackageCount: Int
-
-    /// Rows cleared, load finished, after a failed `load()`.
-    static func emptyAfterLoad(userFacingError: String) -> VMStateSnapshot {
-        VMStateSnapshot(
-            state: .failed(userFacingError),
-            formulaPackages: [],
-            caskPackages: [],
-            selectedPackageID: nil,
-            totalPackageCount: 0,
-        )
-    }
-}
-
-@MainActor
-func snapshot(_ vm: InstalledViewModel) -> VMStateSnapshot {
-    VMStateSnapshot(
-        state: vm.state,
-        formulaPackages: vm.loadedFormulaPackages,
-        caskPackages: vm.loadedCaskPackages,
-        selectedPackageID: vm.selectedPackage?.id,
-        totalPackageCount: vm.totalPackageCount,
-    )
-}
-
 @MainActor
 func makeInstalledViewModel(repository: BrewInstalledPackagesRepository) -> InstalledViewModel {
     InstalledViewModel(repository: repository)

--- a/Tests/BrewFeatureInstalledTests/PackageDetailMetadataItemTests.swift
+++ b/Tests/BrewFeatureInstalledTests/PackageDetailMetadataItemTests.swift
@@ -3,13 +3,10 @@
 //  BrewTests
 //
 
-import BrewCLI
 import BrewCore
 import BrewCoreTestSupport
 @testable import BrewFeatureInstalled
 import BrewRepositories
-import BrewRepositoryInterfaces
-import BrewServicesTestSupport
 import Foundation
 import Testing
 

--- a/Tests/BrewFeatureInstalledTests/PackageDetailMetadataItemTests.swift
+++ b/Tests/BrewFeatureInstalledTests/PackageDetailMetadataItemTests.swift
@@ -11,11 +11,6 @@ import Foundation
 import Testing
 
 struct PackageDetailMetadataItemTests {
-    @Test func `info command uses package name`() {
-        let item = PackageDetailMetadataItem(package: InstalledBrewPackage.fixture(name: "wget", kind: .formula))
-        #expect(item.infoCommand == "brew info wget")
-    }
-
     @Test func `metadata values normalize missing versions to em dash`() {
         let item = PackageDetailMetadataItem(
             package: .fixture(name: "wget", latestVersion: " ", installedVersions: []),

--- a/Tests/BrewFeatureInstalledTests/PackageRelationshipItemTests.swift
+++ b/Tests/BrewFeatureInstalledTests/PackageRelationshipItemTests.swift
@@ -3,13 +3,10 @@
 //  BrewTests
 //
 
-import BrewCLI
 import BrewCore
 import BrewCoreTestSupport
 @testable import BrewFeatureInstalled
 import BrewRepositories
-import BrewRepositoryInterfaces
-import BrewServicesTestSupport
 import Testing
 
 struct PackageRelationshipItemTests {

--- a/Tests/BrewFeatureInstalledTests/UninstallPackageItemTests.swift
+++ b/Tests/BrewFeatureInstalledTests/UninstallPackageItemTests.swift
@@ -3,13 +3,10 @@
 //  BrewTests
 //
 
-import BrewCLI
 import BrewCore
 import BrewCoreTestSupport
 @testable import BrewFeatureInstalled
 import BrewRepositories
-import BrewRepositoryInterfaces
-import BrewServicesTestSupport
 import Testing
 
 struct UninstallPackageItemTests {

--- a/Tests/BrewFeatureInstalledTests/UpgradePackageItemTests.swift
+++ b/Tests/BrewFeatureInstalledTests/UpgradePackageItemTests.swift
@@ -3,13 +3,10 @@
 //  BrewTests
 //
 
-import BrewCLI
 import BrewCore
 import BrewCoreTestSupport
 @testable import BrewFeatureInstalled
 import BrewRepositories
-import BrewRepositoryInterfaces
-import BrewServicesTestSupport
 import Testing
 
 struct UpgradePackageItemTests {

--- a/Tests/BrewFeatureInstalledTests/UpgradesViewModelScopeTests.swift
+++ b/Tests/BrewFeatureInstalledTests/UpgradesViewModelScopeTests.swift
@@ -298,14 +298,6 @@ private actor PhaseStreamingScopeCommandCenter: BrewCommandCenter {
         .idle
     }
 
-    func phaseByID() async -> [BrewOperationID: BrewOperationPhase] {
-        [:]
-    }
-
-    func isActive(id _: BrewOperationID) async -> Bool {
-        false
-    }
-
     func submit(id _: BrewOperationID, command _: any BrewMutatingCommand) async throws {}
 
     func phaseChanges(for _: BrewOperationID) async -> AsyncStream<BrewOperationPhase> {
@@ -319,10 +311,6 @@ private actor PhaseStreamingScopeCommandCenter: BrewCommandCenter {
         }
         subscriberWaiters.removeAll()
         return phaseStream
-    }
-
-    func outputChanges(for _: BrewOperationID) async -> AsyncStream<BrewCommandOutputLine> {
-        AsyncStream { $0.finish() }
     }
 
     func allOutputChanges() async -> AsyncStream<(BrewOperationID, BrewCommandOutputLine)> {

--- a/Tests/BrewFeatureInstalledTests/UpgradesViewModelTests.swift
+++ b/Tests/BrewFeatureInstalledTests/UpgradesViewModelTests.swift
@@ -444,14 +444,6 @@ private actor PhaseStreamingCommandCenter: BrewCommandCenter {
         .idle
     }
 
-    func phaseByID() async -> [BrewOperationID: BrewOperationPhase] {
-        [:]
-    }
-
-    func isActive(id _: BrewOperationID) async -> Bool {
-        false
-    }
-
     func submit(id _: BrewOperationID, command _: any BrewMutatingCommand) async throws {}
 
     func phaseChanges(for _: BrewOperationID) async -> AsyncStream<BrewOperationPhase> {
@@ -465,10 +457,6 @@ private actor PhaseStreamingCommandCenter: BrewCommandCenter {
         }
         subscriberWaiters.removeAll()
         return phaseStream
-    }
-
-    func outputChanges(for _: BrewOperationID) async -> AsyncStream<BrewCommandOutputLine> {
-        AsyncStream { $0.finish() }
     }
 
     func allOutputChanges() async -> AsyncStream<(BrewOperationID, BrewCommandOutputLine)> {

--- a/Tests/BrewNetworkingTests/BrewAPIClientCatalogueURLSessionIntegrationTests.swift
+++ b/Tests/BrewNetworkingTests/BrewAPIClientCatalogueURLSessionIntegrationTests.swift
@@ -3,7 +3,6 @@
 //  BrewTests
 //
 
-import BrewCore
 import BrewCoreTestSupport
 @testable import BrewNetworking
 import Foundation

--- a/Tests/BrewNetworkingTests/CatalogueCacheTests.swift
+++ b/Tests/BrewNetworkingTests/CatalogueCacheTests.swift
@@ -3,7 +3,6 @@
 //  BrewTests
 //
 
-import BrewCore
 import BrewCoreTestSupport
 @testable import BrewNetworking
 import Foundation

--- a/Tests/BrewNetworkingTests/CatalogueJSONTests.swift
+++ b/Tests/BrewNetworkingTests/CatalogueJSONTests.swift
@@ -4,7 +4,6 @@
 //
 
 import BrewCore
-import BrewCoreTestSupport
 @testable import BrewNetworking
 import Foundation
 import Testing

--- a/Tests/BrewRepositoriesTests/BrewAPIClientConcurrentIntegrationTests.swift
+++ b/Tests/BrewRepositoriesTests/BrewAPIClientConcurrentIntegrationTests.swift
@@ -3,7 +3,6 @@
 //  BrewTests
 //
 
-import BrewCLI
 import BrewCore
 import BrewCoreTestSupport
 @testable import BrewNetworking

--- a/Tests/BrewRepositoriesTests/BrewCatalogueRepositoryTests.swift
+++ b/Tests/BrewRepositoriesTests/BrewCatalogueRepositoryTests.swift
@@ -3,13 +3,10 @@
 //  BrewTests
 //
 
-import BrewCLI
 import BrewCore
 import BrewCoreTestSupport
 import BrewNetworking
 @testable import BrewRepositories
-import BrewRepositoryInterfaces
-import BrewServicesTestSupport
 import Foundation
 import Testing
 

--- a/Tests/BrewRepositoriesTests/BrewDiscoverPackagesRepositoryTests.swift
+++ b/Tests/BrewRepositoriesTests/BrewDiscoverPackagesRepositoryTests.swift
@@ -3,7 +3,6 @@
 //  BrewTests
 //
 
-import BrewCLI
 import BrewCore
 import BrewCoreTestSupport
 import BrewNetworking

--- a/Tests/BrewRepositoriesTests/BrewInstalledDependentsRepositoryTests.swift
+++ b/Tests/BrewRepositoriesTests/BrewInstalledDependentsRepositoryTests.swift
@@ -6,10 +6,7 @@
 import BrewCLI
 import BrewCore
 import BrewCoreTestSupport
-import BrewNetworking
 @testable import BrewRepositories
-import BrewRepositoryInterfaces
-import BrewServicesTestSupport
 import Foundation
 import Testing
 

--- a/Tests/BrewRepositoriesTests/BrewInstalledPackagesCacheTests.swift
+++ b/Tests/BrewRepositoriesTests/BrewInstalledPackagesCacheTests.swift
@@ -6,7 +6,6 @@
 import BrewCLI
 import BrewCore
 import BrewCoreTestSupport
-import BrewNetworking
 @testable import BrewRepositories
 import BrewRepositoryInterfaces
 import BrewServicesTestSupport

--- a/Tests/BrewRepositoriesTests/BrewInstalledPackagesRepositoryTests.swift
+++ b/Tests/BrewRepositoriesTests/BrewInstalledPackagesRepositoryTests.swift
@@ -427,14 +427,6 @@ private actor ControllableAllPhasesCommandCenter: BrewCommandCenter {
         .idle
     }
 
-    func phaseByID() async -> [BrewOperationID: BrewOperationPhase] {
-        [:]
-    }
-
-    func isActive(id _: BrewOperationID) async -> Bool {
-        false
-    }
-
     func phaseChanges(for _: BrewOperationID) async -> AsyncStream<BrewOperationPhase> {
         AsyncStream<BrewOperationPhase>(bufferingPolicy: .unbounded) { continuation in
             continuation.finish()
@@ -450,12 +442,6 @@ private actor ControllableAllPhasesCommandCenter: BrewCommandCenter {
                 }
             }
             registerAllPhaseListener(token: token, continuation: continuation)
-        }
-    }
-
-    func outputChanges(for _: BrewOperationID) async -> AsyncStream<BrewCommandOutputLine> {
-        AsyncStream<BrewCommandOutputLine>(bufferingPolicy: .unbounded) { continuation in
-            continuation.finish()
         }
     }
 

--- a/Tests/BrewRepositoriesTests/BrewInstalledPackagesRepositoryTests.swift
+++ b/Tests/BrewRepositoriesTests/BrewInstalledPackagesRepositoryTests.swift
@@ -6,7 +6,6 @@
 import BrewCLI
 import BrewCore
 import BrewCoreTestSupport
-import BrewNetworking
 @testable import BrewRepositories
 import BrewRepositoryInterfaces
 import BrewServicesTestSupport

--- a/Tests/BrewUIComponentsTests/AnimatedSplitTests.swift
+++ b/Tests/BrewUIComponentsTests/AnimatedSplitTests.swift
@@ -3,7 +3,6 @@
 //  BrewTests
 //
 
-import BrewCore
 @testable import BrewUIComponents
 import Foundation
 import Testing


### PR DESCRIPTION
# PR: Remove dead code and add a baseline-gated Periphery check

## Summary

Deletes unused declarations, imports, and codepaths across the app and its SwiftPM modules, then wires up [Periphery](https://github.com/peripheryapp/periphery) in CI so newly introduced dead code fails a PR going forward.

## Changes

- **Dead-code removal:** Dropped unused declarations and imports flagged by Periphery, removed dead `NoopBrewCommandCenter`/`SerialBrewCommandCenter` and repository stub codepaths, and stopped decoding unused `brew info` dependency fields. Remaining behaviour is now exercised through production interfaces rather than the deleted internal seams.
- **Visibility tightening:** Internalized test-only `BrewCrashReporting` namespaces (`CrashReportFormatter`, `CrashReportIssue`, `CrashReportStore`) so they're no longer spuriously public.
- **Test cleanup:** Pruned now-unused test support helpers and imports; reworked affected suites (e.g. `DoctorViewModel`, `ConfigViewModel`, `SerialBrewCommandCenterOutput`) to cover the retained behaviour directly.
- **CI + tooling:** Pinned `peripheryapp/periphery` in the `Mintfile`, added `.periphery.yml` (scans the Xcode project so the app counts as a consumer of the SPM modules ‚ — dead `public` API is reported too), and added a `pr_build_test.yml` step that reuses the Xcode test build's index store (`--skip-build`) so it adds no second build. Documented the workflow in `AGENTS.md`.

## Why this split

The check is **baseline-gated**: it fails only on dead code not already in `.periphery-baseline.json`, grandfathering the existing tail so only *new* dead code blocks a merge. The baseline can't be generated in the agent sandbox (needs a working `xcodebuild` app build), so on the first run CI writes and uploads a seed baseline as an artifact without gating‚ download, commit it, and the gate activates.

## Testing

- [x] `scripts/test` (full unit suite) passes locally
- [x] `swift test --package-path Tools/BrewUILint`

## PR checklist

- [x] Followed the repository's contribution and workflow guidance
- [x] Explained what changed and why this should land now
- [x] Ran relevant local checks for the changed scope
- [x] Changes scoped and free of unrelated modifications

-----

- [x] AI was used to generate or assist with generating this PR.
- [x] Periphery flagged the candidates; each deletion was reviewed and verified by running the full test suite locally before commit.