### PR TITLE
Interleave casks and formulae in Installed and Upgrades lists

### DIFF
--- a/Sources/BrewFeatureInstalled/ViewModels/InstalledPackagesContent+Placeholdable.swift
+++ b/Sources/BrewFeatureInstalled/ViewModels/InstalledPackagesContent+Placeholdable.swift
@@ -6,8 +6,8 @@
 import BrewCore
 
 extension InstalledPackagesContent: Placeholdable {
-    /// A small mixed-kind stub so the redacted skeleton renders both the Formulae and Casks
-    /// sections at plausible heights. Distinct ids keep `ForEach` happy under `.redacted`.
+    /// A small mixed-kind stub so the redacted skeleton renders a plausible interleaved list of
+    /// formula and cask rows. Distinct ids keep `ForEach` happy under `.redacted`.
     static var placeholder: InstalledPackagesContent {
         let formulae = (0 ..< 3).map { index in
             InstalledBrewPackage(

--- a/Sources/BrewFeatureInstalled/ViewModels/InstalledViewModel.swift
+++ b/Sources/BrewFeatureInstalled/ViewModels/InstalledViewModel.swift
@@ -10,15 +10,9 @@ import Foundation
 import Observation
 
 struct InstalledPackagesContent: Equatable {
+    /// Formulae and casks interleaved into a single list, ordered as the repository sorted them
+    /// (by name across both kinds). The per-row kind badge keeps casks and formulae distinguishable.
     var packages: [InstalledBrewPackage]
-
-    var shouldShowFormulaeSection: Bool {
-        !formulaPackages.isEmpty
-    }
-
-    var shouldShowCasksSection: Bool {
-        !caskPackages.isEmpty
-    }
 
     var formulaPackages: [InstalledBrewPackage] {
         packages.filter { $0.kind == .formula }
@@ -29,7 +23,7 @@ struct InstalledPackagesContent: Equatable {
     }
 
     var orderedPackageIDs: [InstalledBrewPackage.ID] {
-        formulaPackages.map(\.id) + caskPackages.map(\.id)
+        packages.map(\.id)
     }
 
     /// Narrows the content to a single package kind for the scope picker. `.all` is the identity —
@@ -268,15 +262,10 @@ final class InstalledViewModel {
             return scoped
         }
 
-        let filteredFormulaRows = scoped.formulaPackages.filter {
+        let filteredRows = scoped.packages.filter {
             $0.name.localizedCaseInsensitiveContains(normalizedQuery)
         }
-        let filteredCaskRows = scoped.caskPackages.filter {
-            $0.name.localizedCaseInsensitiveContains(normalizedQuery)
-        }
-        return InstalledPackagesContent(
-            packages: filteredFormulaRows + filteredCaskRows,
-        )
+        return InstalledPackagesContent(packages: filteredRows)
     }
 
     private static func normalizedSearchQuery(_ query: String) -> String {

--- a/Sources/BrewFeatureInstalled/ViewModels/UpgradesViewModel.swift
+++ b/Sources/BrewFeatureInstalled/ViewModels/UpgradesViewModel.swift
@@ -205,16 +205,13 @@ final class UpgradesViewModel {
         isSearchActive || scope != .all
     }
 
-    /// Rows in the order the list renders them (formulae section, then casks).
-    /// `content.packages` is name-sorted across kinds, which would make
-    /// `firstVisibleRowID` pick the alphabetically-first row regardless of
-    /// section — surfacing a cask as the default selection even though the
-    /// Formulae section appears first on screen.
+    /// Rows in the order the list renders them: casks and formulae interleaved, name-sorted across
+    /// kinds. `firstVisibleRowID` picks the first of these as the default selection.
     private var allRows: [InstalledBrewPackage] {
         guard case let .loaded(content) = state else {
             return []
         }
-        return content.formulaPackages + content.caskPackages
+        return content.packages
     }
 
     private func updateSelectionForSearchQueryChange(from oldQuery: String, to newQuery: String) {
@@ -294,15 +291,10 @@ final class UpgradesViewModel {
             return scoped
         }
 
-        let filteredFormulaRows = scoped.formulaPackages.filter {
+        let filteredRows = scoped.packages.filter {
             $0.name.localizedCaseInsensitiveContains(normalizedQuery)
         }
-        let filteredCaskRows = scoped.caskPackages.filter {
-            $0.name.localizedCaseInsensitiveContains(normalizedQuery)
-        }
-        return InstalledPackagesContent(
-            packages: filteredFormulaRows + filteredCaskRows,
-        )
+        return InstalledPackagesContent(packages: filteredRows)
     }
 
     private static func normalizedSearchQuery(_ query: String) -> String {

--- a/Sources/BrewFeatureInstalled/Views/InstalledPackagesView.swift
+++ b/Sources/BrewFeatureInstalled/Views/InstalledPackagesView.swift
@@ -61,16 +61,8 @@ struct InstalledPackagesView: View {
     private func installedList(_ content: InstalledPackagesContent) -> some View {
         ScrollViewReader { proxy in
             List {
-                if content.shouldShowFormulaeSection {
-                    Section("Formulae") {
-                        sectionContent(for: content.formulaPackages)
-                    }
-                }
-
-                if content.shouldShowCasksSection {
-                    Section("Casks") {
-                        sectionContent(for: content.caskPackages)
-                    }
+                ForEach(content.packages) { package in
+                    row(for: package)
                 }
             }
             .listStyle(.inset)
@@ -102,30 +94,24 @@ struct InstalledPackagesView: View {
         }
     }
 
-    private func sectionContent(for packages: [InstalledBrewPackage]) -> some View {
-        ForEach(packages) { package in
-            listRow(for: package)
-                .id(package.id)
-                .contentShape(Rectangle())
-                .listRowBackground(
-                    RoundedRectangle(
-                        cornerRadius: BrewRadius.lg,
-                        style: .continuous,
-                    )
-                    .fill(
-                        viewModel.activeSelectedPackageID == package.id ? Color.brewBrandTint : Color.clear,
-                    )
-                    .padding(.horizontal, BrewSpacing.sm),
-                )
-                .onTapGesture {
-                    // Needed to suppress the default ugly blue macOS highlight state
-                    viewModel.setSelection(package.id)
-                }
-        }
-    }
-
-    private func listRow(for package: InstalledBrewPackage) -> some View {
+    private func row(for package: InstalledBrewPackage) -> some View {
         InstalledListRowRoot(package: package)
+            .id(package.id)
+            .contentShape(Rectangle())
+            .listRowBackground(
+                RoundedRectangle(
+                    cornerRadius: BrewRadius.lg,
+                    style: .continuous,
+                )
+                .fill(
+                    viewModel.activeSelectedPackageID == package.id ? Color.brewBrandTint : Color.clear,
+                )
+                .padding(.horizontal, BrewSpacing.sm),
+            )
+            .onTapGesture {
+                // Needed to suppress the default ugly blue macOS highlight state
+                viewModel.setSelection(package.id)
+            }
     }
 
     private func scrollToSelection(

--- a/Sources/BrewFeatureInstalled/Views/UpgradesPackagesView.swift
+++ b/Sources/BrewFeatureInstalled/Views/UpgradesPackagesView.swift
@@ -95,16 +95,8 @@ struct UpgradesPackagesView: View {
     private func upgradesList(_ content: InstalledPackagesContent) -> some View {
         ScrollViewReader { proxy in
             List {
-                if content.shouldShowFormulaeSection {
-                    Section("Formulae") {
-                        sectionContent(for: content.formulaPackages)
-                    }
-                }
-
-                if content.shouldShowCasksSection {
-                    Section("Casks") {
-                        sectionContent(for: content.caskPackages)
-                    }
+                ForEach(content.packages) { package in
+                    row(for: package)
                 }
             }
             .listStyle(.inset)
@@ -136,30 +128,24 @@ struct UpgradesPackagesView: View {
         }
     }
 
-    private func sectionContent(for packages: [InstalledBrewPackage]) -> some View {
-        ForEach(packages) { package in
-            listRow(for: package)
-                .id(package.id)
-                .contentShape(Rectangle())
-                .listRowBackground(
-                    RoundedRectangle(
-                        cornerRadius: BrewRadius.lg,
-                        style: .continuous,
-                    )
-                    .fill(
-                        viewModel.activeSelectedPackageID == package.id ? Color.brewBrandTint : Color.clear,
-                    )
-                    .padding(.horizontal, BrewSpacing.sm),
-                )
-                .onTapGesture {
-                    // Needed to suppress the default ugly blue macOS highlight state
-                    viewModel.setSelection(package.id)
-                }
-        }
-    }
-
-    private func listRow(for package: InstalledBrewPackage) -> some View {
+    private func row(for package: InstalledBrewPackage) -> some View {
         InstalledListRowRoot(package: package)
+            .id(package.id)
+            .contentShape(Rectangle())
+            .listRowBackground(
+                RoundedRectangle(
+                    cornerRadius: BrewRadius.lg,
+                    style: .continuous,
+                )
+                .fill(
+                    viewModel.activeSelectedPackageID == package.id ? Color.brewBrandTint : Color.clear,
+                )
+                .padding(.horizontal, BrewSpacing.sm),
+            )
+            .onTapGesture {
+                // Needed to suppress the default ugly blue macOS highlight state
+                viewModel.setSelection(package.id)
+            }
     }
 
     private func scrollToSelection(

--- a/Tests/BrewCLITests/BrewInfoJSONMappingTests.swift
+++ b/Tests/BrewCLITests/BrewInfoJSONMappingTests.swift
@@ -1,0 +1,48 @@
+//
+//  BrewInfoJSONMappingTests.swift
+//  BrewTests
+//
+
+@testable import BrewCLI
+import BrewCore
+import Foundation
+import Testing
+
+struct BrewInfoJSONMappingTests {
+    @Test func `installedPackages interleaves formulae and casks name-sorted across both kinds`() throws {
+        // Both arrays arrive out of order, and the sorted result must weave the two kinds together:
+        // alfred (cask) < git (formula) < ripgrep (formula) < slack (cask).
+        let json = """
+        {
+          "formulae": [
+            { "name": "ripgrep" },
+            { "name": "git" }
+          ],
+          "casks": [
+            { "token": "slack" },
+            { "token": "alfred" }
+          ]
+        }
+        """
+
+        let payload = try JSONDecoder().decode(BrewInfoJSON.self, from: Data(json.utf8))
+        let packages = payload.installedPackages()
+
+        #expect(packages.map(\.name) == ["alfred", "git", "ripgrep", "slack"])
+        // Casks and formulae are genuinely interleaved, not grouped by kind.
+        #expect(packages.map(\.kind) == [.cask, .formula, .formula, .cask])
+    }
+
+    @Test func `installedPackages sorts case-insensitively`() throws {
+        let json = """
+        {
+          "formulae": [{ "name": "Zsh" }, { "name": "aria2" }],
+          "casks": [{ "token": "Firefox" }]
+        }
+        """
+
+        let payload = try JSONDecoder().decode(BrewInfoJSON.self, from: Data(json.utf8))
+
+        #expect(payload.installedPackages().map(\.name) == ["aria2", "Firefox", "Zsh"])
+    }
+}

--- a/Tests/BrewFeatureInstalledTests/InstalledViewModelPresentationTests.swift
+++ b/Tests/BrewFeatureInstalledTests/InstalledViewModelPresentationTests.swift
@@ -10,22 +10,6 @@ import BrewRepositories
 import Foundation
 import Testing
 
-private struct SectionVisibilitySnapshot: Equatable {
-    var formulae: Bool
-    var casks: Bool
-}
-
-@MainActor
-private func sectionVisibility(_ vm: InstalledViewModel) -> SectionVisibilitySnapshot {
-    guard case let .loaded(content) = vm.state else {
-        return SectionVisibilitySnapshot(formulae: false, casks: false)
-    }
-    return SectionVisibilitySnapshot(
-        formulae: content.shouldShowFormulaeSection,
-        casks: content.shouldShowCasksSection,
-    )
-}
-
 struct InstalledViewModelPresentationTests {
     @Test @MainActor func `selectedPackage is nil for initial loading state`() {
         let vm = makeInstalledViewModel(
@@ -52,26 +36,6 @@ struct InstalledViewModelPresentationTests {
         let vm = makeInstalledViewModel(repository: missingBrewInstalledRepository())
         await vm.load()
         #expect(!vm.shouldShowInitialLoadingIndicator)
-    }
-
-    @Test @MainActor func `section visibility shows both sections when formulae and casks present`() async {
-        let vm = await InstalledFeatureTestSupport.loadedViewModel(
-            formulae: [.fixture(name: "f", kind: .formula)],
-            casks: [.fixture(name: "c", kind: .cask)],
-        )
-        #expect(sectionVisibility(vm) == SectionVisibilitySnapshot(formulae: true, casks: true))
-    }
-
-    @Test @MainActor func `section visibility shows only formulae when no casks`() async {
-        let vm = await InstalledFeatureTestSupport.loadedViewModel(
-            formulae: [.fixture(name: "f", kind: .formula)],
-        )
-        #expect(sectionVisibility(vm) == SectionVisibilitySnapshot(formulae: true, casks: false))
-    }
-
-    @Test @MainActor func `section visibility hides all sections when empty loaded snapshot`() async {
-        let vm = await InstalledFeatureTestSupport.loadedViewModel()
-        #expect(sectionVisibility(vm) == SectionVisibilitySnapshot(formulae: false, casks: false))
     }
 
     @Test @MainActor func `totalPackageCount sums formula and cask rows`() async {

--- a/Tests/BrewFeatureInstalledTests/InstalledViewModelTests.swift
+++ b/Tests/BrewFeatureInstalledTests/InstalledViewModelTests.swift
@@ -14,7 +14,7 @@ import Foundation
 import Testing
 
 struct InstalledViewModelTests {
-    @Test @MainActor func `load produces expected package sections`() async {
+    @Test @MainActor func `load exposes formula and cask rows in one list`() async {
         let vm = await InstalledFeatureTestSupport.loadedViewModel(
             formulae: [.fixture(name: "git", kind: .formula)],
             casks: [.fixture(name: "slack", kind: .cask)],
@@ -73,7 +73,7 @@ struct InstalledViewModelTests {
         vm.setSelection(ordered[0])
         vm.selectNext()
         #expect(vm.selectedPackage?.id == ordered[1])
-        // Crosses the formulae → casks section boundary.
+        // Steps from a formula to a cask within the single interleaved list.
         vm.selectNext()
         #expect(vm.selectedPackage?.id == ordered[2])
         // Clamps at the final row.

--- a/Tests/BrewFeatureInstalledTests/UpgradesViewModelTests.swift
+++ b/Tests/BrewFeatureInstalledTests/UpgradesViewModelTests.swift
@@ -57,19 +57,19 @@ struct UpgradesViewModelTests {
         #expect(vm.totalOutdatedCount == 2)
     }
 
-    @Test @MainActor func `default selection prefers the first formula over an alphabetically earlier cask`() {
-        // Repository sorts by name across kinds, so "alfred" (cask) comes
-        // before "git" (formula). The list shows Formulae first though, so
-        // the default selection should still land on git.
+    @Test @MainActor func `default selection lands on the first row of the interleaved list`() {
+        // Casks and formulae share one list ordered as the repository sorted them (by name across
+        // kinds), so the alphabetically-first row wins the default selection regardless of kind — here
+        // the "alfred" cask, even though a formula follows it.
         let vm = Self.makeViewModel(packages: [
             .fixture(name: "alfred", kind: .cask, outdated: true),
             .fixture(name: "git", kind: .formula, outdated: true),
         ])
 
-        #expect(vm.selectedPackage?.name == "git")
+        #expect(vm.selectedPackage?.name == "alfred")
     }
 
-    @Test @MainActor func `default selection falls back to first cask when no formulae are outdated`() {
+    @Test @MainActor func `default selection is the first row when every outdated package is a cask`() {
         let vm = Self.makeViewModel(packages: [
             .fixture(name: "alfred", kind: .cask, outdated: true),
             .fixture(name: "slack", kind: .cask, outdated: true),


### PR DESCRIPTION
# PR: Interleave casks and formulae in Installed and Upgrades lists

## Summary

The Installed and Upgrades package lists previously split formulae and casks into two separate sections. This PR renders each as a single list ordered by name across both kinds. The per-row FORMULA/CASK badge already tells the two apart, so the section split was redundant, and removing it deletes noticeably more code than it adds.

## Changes

- InstalledPackagesContent: drop shouldShowFormulaeSection / shouldShowCasksSection and expose one name-ordered list of packages.
- InstalledViewModel and UpgradesViewModel: collapse the two-section rendering and the formulae-then-casks search filter into a single ordered pass.
- InstalledPackagesView and UpgradesPackagesView: replace the two Section blocks with one ForEach over the interleaved rows.
- Remove the now-unused InstalledSectionHeader.
- Behaviour note: default and keyboard selection now follow the interleaved order, so the first row wins regardless of kind (previously formulae were preferred). Tests updated to match.

## Why this split

Discover was originally part of this work but has been intentionally left out. Its Trending list is fed by two independent analytics calls (top formulae and top casks) whose rankings are not comparable, so interleaving there is misleading. This PR is scoped to the two lists where a single name-ordered list is clearly correct.

## Testing

- [x] xcrun swift buil
- [x] xcrun swift test
- [x] swiftformat and swiftlint (strict) clean on the changed files.

## PR checklist

- [x] Have you followed this repository's contribution and workflow guidance?
- [x] Have you explained what changed and why this should land now?
- [x] Have you run relevant local checks for the changed scope?
- [x] Are changes scoped and free of unrelated modifications?

-----

- [x] AI was used to generate or assist with generating this PR.
- [x] If yes, describe exactly how AI was used and what manual verification was performed: Claude Code made the edits and updated the tests; changes were reviewed locally and verified with a clean build, the full test suite, and lint.