### PR TITLE
Preload Discover Trending list

### DIFF
--- a/Homebrew/BrewApp.swift
+++ b/Homebrew/BrewApp.swift
@@ -85,9 +85,6 @@ struct BrewApp: App {
                 .environment(\.doctorRepository, doctorRepository)
                 .environment(\.configRepository, configRepository)
                 .task {
-                    // Warm the on-disk caches before preloading Discover so enrichment reads them rather
-                    // than racing into a needless fetch (correctness holds either way — an empty cache
-                    // just triggers a fetch).
                     async let catalogue: Void = catalogueCache.prepare()
                     async let analytics: Void = discoverAnalyticsCache.prepare()
                     _ = await (catalogue, analytics)

--- a/Homebrew/BrewApp.swift
+++ b/Homebrew/BrewApp.swift
@@ -84,8 +84,17 @@ struct BrewApp: App {
                 .environment(\.discoverPackagesRepository, discoverPackagesRepository)
                 .environment(\.doctorRepository, doctorRepository)
                 .environment(\.configRepository, configRepository)
-                .task { await catalogueCache.prepare() }
-                .task { await discoverAnalyticsCache.prepare() }
+                .task {
+                    // Warm the on-disk caches, then preload Discover's trending list so the tab is
+                    // snappy on first open. Ordered so enrichment reads the just-prepared caches rather
+                    // than racing them into a needless network fetch (correctness holds either way — the
+                    // repositories fetch when a cache is empty). The list survives tab switches and only
+                    // revalidates on return once the analytics cache goes stale.
+                    async let catalogue: Void = catalogueCache.prepare()
+                    async let analytics: Void = discoverAnalyticsCache.prepare()
+                    _ = await (catalogue, analytics)
+                    await discoverPackagesRepository.load()
+                }
                 .task { await installedPackagesRepository.load() }
                 .onChange(of: scenePhase) { oldPhase, newPhase in
                     // Mark the config + brew.env caches stale on return-to-foreground so the next visit

--- a/Homebrew/BrewApp.swift
+++ b/Homebrew/BrewApp.swift
@@ -85,11 +85,9 @@ struct BrewApp: App {
                 .environment(\.doctorRepository, doctorRepository)
                 .environment(\.configRepository, configRepository)
                 .task {
-                    // Warm the on-disk caches, then preload Discover's trending list so the tab is
-                    // snappy on first open. Ordered so enrichment reads the just-prepared caches rather
-                    // than racing them into a needless network fetch (correctness holds either way — the
-                    // repositories fetch when a cache is empty). The list survives tab switches and only
-                    // revalidates on return once the analytics cache goes stale.
+                    // Warm the on-disk caches before preloading Discover so enrichment reads them rather
+                    // than racing into a needless fetch (correctness holds either way — an empty cache
+                    // just triggers a fetch).
                     async let catalogue: Void = catalogueCache.prepare()
                     async let analytics: Void = discoverAnalyticsCache.prepare()
                     _ = await (catalogue, analytics)

--- a/Package.swift
+++ b/Package.swift
@@ -258,6 +258,10 @@ let package = Package(
                 "BrewCLI",
                 "BrewCore",
                 "BrewRepositoryInterfaces",
+                // Concrete repository + API-client types, so the trending integration test can wire the
+                // real BrewDiscoverPackagesRepository into the view model end-to-end.
+                "BrewRepositories",
+                "BrewNetworking",
                 "BrewCoreTestSupport",
                 "BrewServicesTestSupport",
             ],

--- a/Package.swift
+++ b/Package.swift
@@ -258,8 +258,6 @@ let package = Package(
                 "BrewCLI",
                 "BrewCore",
                 "BrewRepositoryInterfaces",
-                // Concrete repository + API-client types, so the trending integration test can wire the
-                // real BrewDiscoverPackagesRepository into the view model end-to-end.
                 "BrewRepositories",
                 "BrewNetworking",
                 "BrewCoreTestSupport",

--- a/Sources/BrewAppEnvironment/UnimplementedRepositories.swift
+++ b/Sources/BrewAppEnvironment/UnimplementedRepositories.swift
@@ -36,8 +36,14 @@ final class UnimplementedInstalledPackagesRepository: InstalledPackagesRepositor
     }
 }
 
-struct UnimplementedDiscoverPackagesRepository: DiscoverPackagesRepository {
-    func loadTopPackages(limit _: Int, window _: BrewAnalyticsWindow) async throws -> DiscoverTopPackagesSnapshot {
+@Observable
+@MainActor
+final class UnimplementedDiscoverPackagesRepository: DiscoverPackagesRepository {
+    var state: LoadState<[DiscoveryBrewPackage], any Error> {
+        unimplemented()
+    }
+
+    func load(forceRefresh _: Bool) async {
         unimplemented()
     }
 }

--- a/Sources/BrewCore/Models/BrewAnalyticsJSON.swift
+++ b/Sources/BrewCore/Models/BrewAnalyticsJSON.swift
@@ -27,9 +27,9 @@ public struct BrewAnalyticsJSON: Decodable, Sendable {
     let casks: [String: [Entry]]?
 
     /// A single analytics row. Mirrors the wire verbatim: `count` is the comma-grouped string Homebrew
-    /// sends ("1,234,567"), parsed to an `Int` only during mapping.
+    /// sends ("1,234,567"), parsed to an `Int` only during mapping. The API carries no rank field, so
+    /// ranking is derived from `count` during mapping.
     struct Entry: Decodable {
-        let number: Int
         let formula: String?
         let cask: String?
         let count: String
@@ -57,9 +57,9 @@ public enum BrewAnalyticsMappingError: Error, Equatable {
 }
 
 public extension BrewAnalyticsJSON {
-    /// Flattens the keyed buckets into package counts in the backend's published rank order (`number`).
-    /// The client never re-ranks by install count — it defers to the server's ordering, including the
-    /// server's own tie-breaking.
+    /// Flattens the keyed buckets into package counts ranked by install count (descending), with a
+    /// name tie-break for a stable order. The API keys entries alphabetically and carries no rank
+    /// field, so `count` is the only ranking signal — the ranking is reconstructed here.
     func rankedPackageCounts() throws -> [BrewAnalyticsPackageCount] {
         guard let bucket = formulae ?? casks else {
             throw BrewAnalyticsMappingError.missingPackageBucket
@@ -67,30 +67,37 @@ public extension BrewAnalyticsJSON {
         return try bucket.values
             .compactMap(\.first)
             .map { try $0.packageCount() }
-            .sorted { $0.rank < $1.rank }
+            .sorted(by: BrewAnalyticsPackageCount.byInstallCountDescendingThenName)
     }
 }
 
 public struct BrewAnalyticsPackageCount: Hashable, Sendable {
     public let reference: HomebrewPackageID
     public let count: Int
-    /// The backend's `number` field — the authoritative rank used to order counts.
-    public let rank: Int
 
     public var name: String {
         reference.name
     }
 
-    public init(reference: HomebrewPackageID, count: Int, rank: Int) {
+    public init(reference: HomebrewPackageID, count: Int) {
         self.reference = reference
         self.count = count
-        self.rank = rank
+    }
+
+    static func byInstallCountDescendingThenName(
+        _ lhs: BrewAnalyticsPackageCount,
+        _ rhs: BrewAnalyticsPackageCount,
+    ) -> Bool {
+        if lhs.count == rhs.count {
+            return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+        }
+        return lhs.count > rhs.count
     }
 }
 
 private extension BrewAnalyticsJSON.Entry {
     func packageCount() throws -> BrewAnalyticsPackageCount {
-        try BrewAnalyticsPackageCount(reference: reference(), count: parsedCount(), rank: number)
+        try BrewAnalyticsPackageCount(reference: reference(), count: parsedCount())
     }
 
     func reference() throws -> HomebrewPackageID {

--- a/Sources/BrewCore/Models/BrewAnalyticsJSON.swift
+++ b/Sources/BrewCore/Models/BrewAnalyticsJSON.swift
@@ -20,11 +20,9 @@ public struct BrewAnalyticsJSON: Decodable, Sendable {
     public let startDate: String
     public let endDate: String
 
-    // The cask-install endpoint reuses the `formulae` key, so kind is read from each entry, not the bucket.
     let formulae: [String: [Entry]]?
     let casks: [String: [Entry]]?
 
-    /// `count` is the comma-grouped string Homebrew sends ("1,234,567"); the API carries no rank field.
     struct Entry: Decodable {
         let formula: String?
         let cask: String?
@@ -55,8 +53,7 @@ public enum BrewAnalyticsMappingError: Error, Equatable {
 
 public extension BrewAnalyticsJSON {
     /// Package counts ranked by install count (descending, name tie-break). The API carries no rank
-    /// field, so `count` is the only ranking signal. Every key must carry an entry: an empty array
-    /// throws rather than being dropped, so a malformed payload can't silently shrink the ranking.
+    /// field, so `count` is the only ranking signal; a key with an empty entry array throws.
     func rankedPackageCounts() throws -> [BrewAnalyticsPackageCount] {
         guard let bucket = formulae ?? casks else {
             throw BrewAnalyticsMappingError.missingPackageBucket
@@ -117,7 +114,6 @@ private extension BrewAnalyticsJSON.Entry {
         }
     }
 
-    /// Strip the wire's group separators ("1,234" → 1234) before parsing.
     func parsedCount() throws -> Int {
         let digitsOnly = count.filter(\.isNumber)
         guard !digitsOnly.isEmpty, let value = Int(digitsOnly) else {

--- a/Sources/BrewCore/Models/BrewAnalyticsJSON.swift
+++ b/Sources/BrewCore/Models/BrewAnalyticsJSON.swift
@@ -47,6 +47,7 @@ public struct BrewAnalyticsJSON: Decodable, Sendable {
 /// Raised while mapping a decoded analytics response into domain package counts.
 public enum BrewAnalyticsMappingError: Error, Equatable {
     case missingPackageBucket
+    case emptyPackageEntries(key: String)
     case missingPackageIdentity
     case conflictingPackageIdentity
     case malformedCount(String)
@@ -54,14 +55,19 @@ public enum BrewAnalyticsMappingError: Error, Equatable {
 
 public extension BrewAnalyticsJSON {
     /// Package counts ranked by install count (descending, name tie-break). The API carries no rank
-    /// field, so `count` is the only ranking signal.
+    /// field, so `count` is the only ranking signal. Every key must carry an entry: an empty array
+    /// throws rather than being dropped, so a malformed payload can't silently shrink the ranking.
     func rankedPackageCounts() throws -> [BrewAnalyticsPackageCount] {
         guard let bucket = formulae ?? casks else {
             throw BrewAnalyticsMappingError.missingPackageBucket
         }
-        return try bucket.values
-            .compactMap(\.first)
-            .map { try $0.packageCount() }
+        return try bucket
+            .map { key, entries in
+                guard let entry = entries.first else {
+                    throw BrewAnalyticsMappingError.emptyPackageEntries(key: key)
+                }
+                return try entry.packageCount()
+            }
             .sorted(by: BrewAnalyticsPackageCount.byInstallCountDescendingThenName)
     }
 }

--- a/Sources/BrewCore/Models/BrewAnalyticsJSON.swift
+++ b/Sources/BrewCore/Models/BrewAnalyticsJSON.swift
@@ -11,55 +11,28 @@ public enum BrewAnalyticsWindow: String, CaseIterable, Sendable {
     case days90 = "90d"
 }
 
-/// Strict schema for Homebrew analytics API responses.
+/// Thin, faithful mirror of a Homebrew analytics API response. Decoding stays dumb — field-for-field
+/// with the wire shape (synthesized `Decodable`, snake_case keys only) — and the flatten/validate/rank
+/// transformation lives in ``rankedPackageCounts()`` rather than in `init(from:)`.
 public struct BrewAnalyticsJSON: Decodable, Sendable {
     public let category: String
     public let totalItems: Int
     public let totalCount: Int
     public let startDate: String
     public let endDate: String
-    private let parsedPackageCounts: [BrewAnalyticsPackageCount]
 
-    public var packageCounts: [BrewAnalyticsPackageCount] {
-        parsedPackageCounts
-    }
+    /// Homebrew keys the ranking under a package-name → single-entry-array map. The cask-install
+    /// endpoint reuses the `formulae` key, so kind is taken from each entry, not the bucket name.
+    let formulae: [String: [Entry]]?
+    let casks: [String: [Entry]]?
 
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        category = try container.decodeNonEmptyString(forKey: .category)
-        totalItems = try container.decodeRequiredIntLossy(forKey: .totalItems)
-        totalCount = try container.decodeRequiredIntLossy(forKey: .totalCount)
-        startDate = try container.decodeNonEmptyString(forKey: .startDate)
-        endDate = try container.decodeNonEmptyString(forKey: .endDate)
-
-        let packageBuckets: [String: [BrewAnalyticsEntry]]
-        if container.contains(.formulae) {
-            packageBuckets = try container.decode([String: [BrewAnalyticsEntry]].self, forKey: .formulae)
-        } else if container.contains(.casks) {
-            packageBuckets = try container.decode([String: [BrewAnalyticsEntry]].self, forKey: .casks)
-        } else {
-            throw DecodingError.keyNotFound(
-                CodingKeys.formulae,
-                DecodingError.Context(
-                    codingPath: container.codingPath,
-                    debugDescription: "Expected formulae or casks analytics buckets.",
-                ),
-            )
-        }
-
-        parsedPackageCounts = try packageBuckets.map { bucketName, entries in
-            let normalizedBucket = bucketName.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard let firstEntry = entries.first else {
-                throw DecodingError.dataCorrupted(
-                    DecodingError.Context(
-                        codingPath: container.codingPath,
-                        debugDescription: "Analytics bucket '\(normalizedBucket)' has no entries.",
-                    ),
-                )
-            }
-            let reference = try firstEntry.requiredReference(codingPath: container.codingPath)
-            return BrewAnalyticsPackageCount(reference: reference, count: firstEntry.count)
-        }
+    /// A single analytics row. Mirrors the wire verbatim: `count` is the comma-grouped string Homebrew
+    /// sends ("1,234,567"), parsed to an `Int` only during mapping.
+    struct Entry: Decodable {
+        let number: Int
+        let formula: String?
+        let cask: String?
+        let count: String
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -73,33 +46,54 @@ public struct BrewAnalyticsJSON: Decodable, Sendable {
     }
 }
 
+// MARK: - Mapping
+
+/// Raised while mapping a decoded analytics response into domain package counts.
+public enum BrewAnalyticsMappingError: Error, Equatable {
+    case missingPackageBucket
+    case missingPackageIdentity
+    case conflictingPackageIdentity
+    case malformedCount(String)
+}
+
+public extension BrewAnalyticsJSON {
+    /// Flattens the keyed buckets into package counts in the backend's published rank order (`number`).
+    /// The client never re-ranks by install count — it defers to the server's ordering, including the
+    /// server's own tie-breaking.
+    func rankedPackageCounts() throws -> [BrewAnalyticsPackageCount] {
+        guard let bucket = formulae ?? casks else {
+            throw BrewAnalyticsMappingError.missingPackageBucket
+        }
+        return try bucket.values
+            .compactMap(\.first)
+            .map { try $0.packageCount() }
+            .sorted { $0.rank < $1.rank }
+    }
+}
+
 public struct BrewAnalyticsPackageCount: Hashable, Sendable {
     public let reference: HomebrewPackageID
     public let count: Int
+    /// The backend's `number` field — the authoritative rank used to order counts.
+    public let rank: Int
 
     public var name: String {
         reference.name
     }
 
-    public init(reference: HomebrewPackageID, count: Int) {
+    public init(reference: HomebrewPackageID, count: Int, rank: Int) {
         self.reference = reference
         self.count = count
+        self.rank = rank
     }
 }
 
-private struct BrewAnalyticsEntry: Decodable {
-    let formula: String?
-    let cask: String?
-    let count: Int
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        formula = try container.decodeIfPresent(String.self, forKey: .formula)
-        cask = try container.decodeIfPresent(String.self, forKey: .cask)
-        count = try container.decodeRequiredIntLossy(forKey: .count)
+private extension BrewAnalyticsJSON.Entry {
+    func packageCount() throws -> BrewAnalyticsPackageCount {
+        try BrewAnalyticsPackageCount(reference: reference(), count: parsedCount(), rank: number)
     }
 
-    func requiredReference(codingPath: [CodingKey]) throws -> HomebrewPackageID {
+    func reference() throws -> HomebrewPackageID {
         let formulaName = Self.trimmedOrNil(formula)
         let caskToken = Self.trimmedOrNil(cask)
 
@@ -109,63 +103,24 @@ private struct BrewAnalyticsEntry: Decodable {
         case let (nil, .some(token)):
             return .cask(token: token)
         case (.none, .none):
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
-                    codingPath: codingPath,
-                    debugDescription: "Analytics entry must include formula or cask.",
-                ),
-            )
+            throw BrewAnalyticsMappingError.missingPackageIdentity
         case (.some, .some):
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
-                    codingPath: codingPath,
-                    debugDescription: "Analytics entry cannot include both formula and cask.",
-                ),
-            )
+            throw BrewAnalyticsMappingError.conflictingPackageIdentity
         }
     }
 
-    private enum CodingKeys: String, CodingKey {
-        case formula
-        case cask
-        case count
+    /// Strips the wire's group separators ("1,234" → 1234); mirrors the old lossy count decode.
+    func parsedCount() throws -> Int {
+        let digitsOnly = count.filter(\.isNumber)
+        guard !digitsOnly.isEmpty, let value = Int(digitsOnly) else {
+            throw BrewAnalyticsMappingError.malformedCount(count)
+        }
+        return value
     }
 
-    private static func trimmedOrNil(_ value: String?) -> String? {
+    static func trimmedOrNil(_ value: String?) -> String? {
         guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
             return nil
-        }
-        return trimmed
-    }
-}
-
-private extension KeyedDecodingContainer {
-    func decodeRequiredIntLossy(forKey key: Key) throws -> Int {
-        if let value = try? decode(Int.self, forKey: key) {
-            return value
-        }
-        if let stringValue = try? decode(String.self, forKey: key) {
-            let digitsOnly = stringValue.filter(\.isNumber)
-            if let parsedValue = Int(digitsOnly) {
-                return parsedValue
-            }
-        }
-        throw DecodingError.dataCorruptedError(
-            forKey: key,
-            in: self,
-            debugDescription: "Expected an integer-compatible analytics count.",
-        )
-    }
-
-    func decodeNonEmptyString(forKey key: Key) throws -> String {
-        let value = try decode(String.self, forKey: key)
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
-            throw DecodingError.dataCorruptedError(
-                forKey: key,
-                in: self,
-                debugDescription: "Expected non-empty string.",
-            )
         }
         return trimmed
     }

--- a/Sources/BrewCore/Models/BrewAnalyticsJSON.swift
+++ b/Sources/BrewCore/Models/BrewAnalyticsJSON.swift
@@ -11,9 +11,8 @@ public enum BrewAnalyticsWindow: String, CaseIterable, Sendable {
     case days90 = "90d"
 }
 
-/// Thin, faithful mirror of a Homebrew analytics API response. Decoding stays dumb — field-for-field
-/// with the wire shape (synthesized `Decodable`, snake_case keys only) — and the flatten/validate/rank
-/// transformation lives in ``rankedPackageCounts()`` rather than in `init(from:)`.
+/// Faithful mirror of a Homebrew analytics API response. Decoding is field-for-field with the wire
+/// shape; the flatten/validate/rank transformation lives in ``rankedPackageCounts()``.
 public struct BrewAnalyticsJSON: Decodable, Sendable {
     public let category: String
     public let totalItems: Int
@@ -21,14 +20,11 @@ public struct BrewAnalyticsJSON: Decodable, Sendable {
     public let startDate: String
     public let endDate: String
 
-    /// Homebrew keys the ranking under a package-name → single-entry-array map. The cask-install
-    /// endpoint reuses the `formulae` key, so kind is taken from each entry, not the bucket name.
+    // The cask-install endpoint reuses the `formulae` key, so kind is read from each entry, not the bucket.
     let formulae: [String: [Entry]]?
     let casks: [String: [Entry]]?
 
-    /// A single analytics row. Mirrors the wire verbatim: `count` is the comma-grouped string Homebrew
-    /// sends ("1,234,567"), parsed to an `Int` only during mapping. The API carries no rank field, so
-    /// ranking is derived from `count` during mapping.
+    /// `count` is the comma-grouped string Homebrew sends ("1,234,567"); the API carries no rank field.
     struct Entry: Decodable {
         let formula: String?
         let cask: String?
@@ -57,9 +53,8 @@ public enum BrewAnalyticsMappingError: Error, Equatable {
 }
 
 public extension BrewAnalyticsJSON {
-    /// Flattens the keyed buckets into package counts ranked by install count (descending), with a
-    /// name tie-break for a stable order. The API keys entries alphabetically and carries no rank
-    /// field, so `count` is the only ranking signal — the ranking is reconstructed here.
+    /// Package counts ranked by install count (descending, name tie-break). The API carries no rank
+    /// field, so `count` is the only ranking signal.
     func rankedPackageCounts() throws -> [BrewAnalyticsPackageCount] {
         guard let bucket = formulae ?? casks else {
             throw BrewAnalyticsMappingError.missingPackageBucket
@@ -116,7 +111,7 @@ private extension BrewAnalyticsJSON.Entry {
         }
     }
 
-    /// Strips the wire's group separators ("1,234" → 1234); mirrors the old lossy count decode.
+    /// Strip the wire's group separators ("1,234" → 1234) before parsing.
     func parsedCount() throws -> Int {
         let digitsOnly = count.filter(\.isNumber)
         guard !digitsOnly.isEmpty, let value = Int(digitsOnly) else {

--- a/Sources/BrewFeatureDiscover/ViewModels/DiscoverViewModel.swift
+++ b/Sources/BrewFeatureDiscover/ViewModels/DiscoverViewModel.swift
@@ -36,8 +36,6 @@ final class DiscoverViewModel {
         }
     }
 
-    /// Projected from the app-scoped repository so preload and tab switches share one fetch; its `Error`
-    /// is mapped to user-facing copy here.
     var trending: LoadState<[DiscoveryBrewPackage], String> {
         switch discoverPackagesRepository.state {
         case .loading:
@@ -78,8 +76,6 @@ final class DiscoverViewModel {
         isSearching ? results : trending
     }
 
-    /// The list only owns keyboard focus on the trending landing once loaded; during a search, focus
-    /// belongs to the catalogue search field.
     var shouldFocusList: Bool {
         trending.isLoaded && !isSearching
     }
@@ -201,8 +197,6 @@ final class DiscoverViewModel {
 
     // MARK: - Helpers
 
-    // Filter-only: ranking is the source's job (trending by install count, search by match order), so
-    // this never re-sorts.
     static func section(
         _ packages: [DiscoveryBrewPackage],
         kind: HomebrewPackageKind,

--- a/Sources/BrewFeatureDiscover/ViewModels/DiscoverViewModel.swift
+++ b/Sources/BrewFeatureDiscover/ViewModels/DiscoverViewModel.swift
@@ -4,7 +4,6 @@ import BrewUIComponents
 import Foundation
 import Observation
 
-/// Package-kind filter for the Discover search field's scope picker.
 enum DiscoverSearchScope: CaseIterable, Equatable {
     case all
     case formulae
@@ -37,9 +36,8 @@ final class DiscoverViewModel {
         }
     }
 
-    /// Catalogue top packages shown on the landing (empty-query) state. Projected from the app-scoped
-    /// ``DiscoverPackagesRepository`` so cold-start preloading and tab switches share one fetch; the
-    /// repository's `Error` is mapped to user-facing copy here.
+    /// Projected from the app-scoped repository so preload and tab switches share one fetch; its `Error`
+    /// is mapped to user-facing copy here.
     var trending: LoadState<[DiscoveryBrewPackage], String> {
         switch discoverPackagesRepository.state {
         case .loading:
@@ -51,7 +49,6 @@ final class DiscoverViewModel {
         }
     }
 
-    /// Catalogue search results shown while the query is non-empty.
     private(set) var results: LoadState<[DiscoveryBrewPackage], String> = .loaded([])
     private(set) var selectedPackageID: BrewPackage.ID?
 
@@ -73,18 +70,16 @@ final class DiscoverViewModel {
         query.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    /// Empty query → trending landing; non-empty → search results.
     var isSearching: Bool {
         !normalizedQuery.isEmpty
     }
 
-    /// The load state the view renders for the current mode.
     var activeState: LoadState<[DiscoveryBrewPackage], String> {
         isSearching ? results : trending
     }
 
-    /// Drives the list view's `@FocusState`. The list only owns keyboard focus on the trending landing
-    /// once it has loaded — while a search is active focus belongs to the catalogue search field.
+    /// The list only owns keyboard focus on the trending landing once loaded; during a search, focus
+    /// belongs to the catalogue search field.
     var shouldFocusList: Bool {
         trending.isLoaded && !isSearching
     }
@@ -96,7 +91,6 @@ final class DiscoverViewModel {
 
     // MARK: - Heading
 
-    /// Editorial heading for the list pane, driven by the display mode and result count.
     var paneHeading: String {
         guard isSearching else {
             return String(localized: "Trending", comment: "Discover list heading, trending landing")
@@ -148,7 +142,6 @@ final class DiscoverViewModel {
         )
     }
 
-    /// The trending landing decorates its subhead with an upward-trend glyph once data is loaded.
     var showsSubtitleTrendIcon: Bool {
         if case .loaded = activeState, !isSearching {
             return true
@@ -173,7 +166,6 @@ final class DiscoverViewModel {
         scope != .formulae
     }
 
-    /// Trending mode frames sections editorially ("Popular"); search mode drops the framing.
     var formulaeSectionTitle: String {
         isSearching
             ? String(localized: "Formulae", comment: "Discover formulae section header while searching")
@@ -186,7 +178,6 @@ final class DiscoverViewModel {
             : String(localized: "Popular Casks", comment: "Discover trending casks section header")
     }
 
-    /// Loaded packages of the active mode, scope-filtered, in display order. Drives selection.
     var visiblePackages: [DiscoveryBrewPackage] {
         guard case let .loaded(packages) = activeState else {
             return []
@@ -210,9 +201,8 @@ final class DiscoverViewModel {
 
     // MARK: - Helpers
 
-    /// Packages of one kind, in the order the source handed them down. Ranking is the source's job:
-    /// trending arrives in the backend's install-rank order, search in the catalogue's match order — the
-    /// view model never re-sorts, it only partitions by kind.
+    // Filter-only: ranking is the source's job (trending by install count, search by match order), so
+    // this never re-sorts.
     static func section(
         _ packages: [DiscoveryBrewPackage],
         kind: HomebrewPackageKind,
@@ -287,15 +277,11 @@ extension DiscoverViewModel {
 // MARK: - Loading
 
 extension DiscoverViewModel {
-    /// Delegates to the app-scoped repository (cache-first; `forceRefresh` for the retry affordance),
-    /// then re-anchors selection against whatever rows are now visible.
     func load(forceRefresh: Bool = false) async {
         await discoverPackagesRepository.load(forceRefresh: forceRefresh)
         synchronizeSelectionWithVisibleRows()
     }
 
-    /// Issues a catalogue search for the current query. Empty queries skip the call and clear results so
-    /// the view falls back to the trending landing.
     func search() async {
         guard isSearching else {
             results = .loaded([])
@@ -316,7 +302,6 @@ extension DiscoverViewModel {
         synchronizeSelectionWithVisibleRows()
     }
 
-    /// Re-runs whichever load backs the active mode — wired to the error state's Retry affordance.
     func reloadActive() async {
         if isSearching {
             await search()

--- a/Sources/BrewFeatureDiscover/ViewModels/DiscoverViewModel.swift
+++ b/Sources/BrewFeatureDiscover/ViewModels/DiscoverViewModel.swift
@@ -180,17 +180,17 @@ final class DiscoverViewModel {
             : String(localized: "Popular Casks", comment: "Discover trending casks section header")
     }
 
-    /// Loaded packages of the active mode, scope-filtered and sorted, in display order. Drives selection.
+    /// Loaded packages of the active mode, scope-filtered, in display order. Drives selection.
     var visiblePackages: [DiscoveryBrewPackage] {
         guard case let .loaded(packages) = activeState else {
             return []
         }
         var visible: [DiscoveryBrewPackage] = []
         if showsFormulaeSection {
-            visible += Self.sortedSection(packages, kind: .formula)
+            visible += Self.section(packages, kind: .formula)
         }
         if showsCasksSection {
-            visible += Self.sortedSection(packages, kind: .cask)
+            visible += Self.section(packages, kind: .cask)
         }
         return visible
     }
@@ -204,23 +204,14 @@ final class DiscoverViewModel {
 
     // MARK: - Helpers
 
-    static func sortedSection(
+    /// Packages of one kind, in the order the source handed them down. Ranking is the source's job:
+    /// trending arrives in the backend's install-rank order, search in the catalogue's match order — the
+    /// view model never re-sorts, it only partitions by kind.
+    static func section(
         _ packages: [DiscoveryBrewPackage],
         kind: HomebrewPackageKind,
     ) -> [DiscoveryBrewPackage] {
-        packages
-            .filter { $0.kind == kind }
-            .sorted(by: sortByPopularityThenName)
-    }
-
-    private static func sortByPopularityThenName(
-        _ lhs: DiscoveryBrewPackage,
-        _ rhs: DiscoveryBrewPackage,
-    ) -> Bool {
-        if lhs.thirtyDayInstallCount == rhs.thirtyDayInstallCount {
-            return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
-        }
-        return lhs.thirtyDayInstallCount > rhs.thirtyDayInstallCount
+        packages.filter { $0.kind == kind }
     }
 
     private static func userMessage(for error: Error, searching: Bool) -> String {

--- a/Sources/BrewFeatureDiscover/ViewModels/DiscoverViewModel.swift
+++ b/Sources/BrewFeatureDiscover/ViewModels/DiscoverViewModel.swift
@@ -17,8 +17,6 @@ final class DiscoverViewModel {
     @ObservationIgnored private let discoverPackagesRepository: any DiscoverPackagesRepository
     @ObservationIgnored private let catalogueRepository: any CatalogueRepository
     @ObservationIgnored private let installedRepository: any InstalledPackageStatusReading
-    @ObservationIgnored private let topPackagesLimit: Int
-    @ObservationIgnored private let analyticsWindow: BrewAnalyticsWindow
     @ObservationIgnored private let searchResultsLimit: Int
 
     var query: String = "" {
@@ -39,8 +37,20 @@ final class DiscoverViewModel {
         }
     }
 
-    /// Catalogue top packages shown on the landing (empty-query) state.
-    private(set) var trending: LoadState<[DiscoveryBrewPackage], String> = .loading
+    /// Catalogue top packages shown on the landing (empty-query) state. Projected from the app-scoped
+    /// ``DiscoverPackagesRepository`` so cold-start preloading and tab switches share one fetch; the
+    /// repository's `Error` is mapped to user-facing copy here.
+    var trending: LoadState<[DiscoveryBrewPackage], String> {
+        switch discoverPackagesRepository.state {
+        case .loading:
+            .loading
+        case let .loaded(packages):
+            .loaded(packages)
+        case let .failed(error):
+            .failed(Self.userMessage(for: error, searching: false))
+        }
+    }
+
     /// Catalogue search results shown while the query is non-empty.
     private(set) var results: LoadState<[DiscoveryBrewPackage], String> = .loaded([])
     private(set) var selectedPackageID: BrewPackage.ID?
@@ -49,15 +59,11 @@ final class DiscoverViewModel {
         discoverPackagesRepository: any DiscoverPackagesRepository,
         catalogueRepository: any CatalogueRepository,
         installedRepository: any InstalledPackageStatusReading,
-        topPackagesLimit: Int = 10,
-        analyticsWindow: BrewAnalyticsWindow = .days30,
         searchResultsLimit: Int = 50,
     ) {
         self.discoverPackagesRepository = discoverPackagesRepository
         self.catalogueRepository = catalogueRepository
         self.installedRepository = installedRepository
-        self.topPackagesLimit = topPackagesLimit
-        self.analyticsWindow = analyticsWindow
         self.searchResultsLimit = searchResultsLimit
     }
 
@@ -281,17 +287,10 @@ extension DiscoverViewModel {
 // MARK: - Loading
 
 extension DiscoverViewModel {
-    func load() async {
-        trending = .loading
-        do {
-            let snapshot = try await discoverPackagesRepository.loadTopPackages(
-                limit: topPackagesLimit,
-                window: analyticsWindow,
-            )
-            trending = .loaded(snapshot.topFormulae + snapshot.topCasks)
-        } catch {
-            trending = .failed(Self.userMessage(for: error, searching: false))
-        }
+    /// Delegates to the app-scoped repository (cache-first; `forceRefresh` for the retry affordance),
+    /// then re-anchors selection against whatever rows are now visible.
+    func load(forceRefresh: Bool = false) async {
+        await discoverPackagesRepository.load(forceRefresh: forceRefresh)
         synchronizeSelectionWithVisibleRows()
     }
 
@@ -322,7 +321,7 @@ extension DiscoverViewModel {
         if isSearching {
             await search()
         } else {
-            await load()
+            await load(forceRefresh: true)
         }
     }
 }

--- a/Sources/BrewFeatureDiscover/Views/DiscoverPackagesView.swift
+++ b/Sources/BrewFeatureDiscover/Views/DiscoverPackagesView.swift
@@ -85,11 +85,11 @@ private struct DiscoverPackageSections: View {
     let packages: [DiscoveryBrewPackage]
 
     private var formulae: [DiscoveryBrewPackage] {
-        viewModel.showsFormulaeSection ? DiscoverViewModel.sortedSection(packages, kind: .formula) : []
+        viewModel.showsFormulaeSection ? DiscoverViewModel.section(packages, kind: .formula) : []
     }
 
     private var casks: [DiscoveryBrewPackage] {
-        viewModel.showsCasksSection ? DiscoverViewModel.sortedSection(packages, kind: .cask) : []
+        viewModel.showsCasksSection ? DiscoverViewModel.section(packages, kind: .cask) : []
     }
 
     var body: some View {

--- a/Sources/BrewRepositories/BrewDiscoverPackagesRepository.swift
+++ b/Sources/BrewRepositories/BrewDiscoverPackagesRepository.swift
@@ -19,20 +19,17 @@ enum DiscoverPackagesRepositoryError: Error, Equatable {
     case cacheMissingAfterRefresh(window: BrewAnalyticsWindow)
 }
 
-/// App-scoped observable source of truth for Discover's trending list.
-///
-/// Long-lived `@Observable` injected into the SwiftUI environment and preloaded at launch, so the tab
-/// renders instantly on first open. Homebrew publishes install analytics once per day, so the raw
-/// analytics responses are cached to disk (via ``DiscoverAnalyticsCaching``) and only refetched when
-/// older than `ttl`; the enriched trending list is held in ``state`` for the session. Mirrors
-/// ``BrewInstalledPackagesRepository``: IO/persistence lives in the cache actor, UI state lives here.
+/// App-scoped observable source of truth for Discover's trending list, injected into the environment
+/// and preloaded at launch. Homebrew publishes install analytics once a day, so raw responses are
+/// cached to disk (via ``DiscoverAnalyticsCaching``) and only refetched past `ttl`; the enriched list
+/// lives in ``state`` for the session. Mirrors ``BrewInstalledPackagesRepository``.
 @Observable
 @MainActor
 public final class BrewDiscoverPackagesRepository: DiscoverPackagesRepository {
     public static let defaultTTL: TimeInterval = 86400
 
-    /// Drives loading/loaded/error chrome. Carries the underlying `Error` on failure — presentation
-    /// layers map it to user-facing copy. Prior loaded data stays put when a revalidation fails.
+    /// Carries the underlying `Error` on failure; presentation maps it to copy. Prior loaded data stays
+    /// put when a revalidation fails.
     public private(set) var state: LoadState<[DiscoveryBrewPackage], any Error> = .loading
 
     @ObservationIgnored private let apiClient: any BrewAPIClient
@@ -45,8 +42,7 @@ public final class BrewDiscoverPackagesRepository: DiscoverPackagesRepository {
     @ObservationIgnored private let analyticsWindow: BrewAnalyticsWindow
     @ObservationIgnored private var loadTask: Task<Void, Never>?
 
-    /// `defaultsKeyPrefix` is the test seam for `UserDefaults.standard`; tests pass a unique prefix to
-    /// isolate their lastRefresh timestamps from each other and from production data.
+    /// `defaultsKeyPrefix` namespaces lastRefresh timestamps in `UserDefaults.standard` so tests isolate.
     public init(
         apiClient: any BrewAPIClient,
         catalogueRepository: any CatalogueRepository,
@@ -74,7 +70,7 @@ public final class BrewDiscoverPackagesRepository: DiscoverPackagesRepository {
     // MARK: - Lifecycle
 
     /// Cache-first: fresh in-memory data returns instantly; stale/empty/failed state fetches. A single
-    /// `loadTask` coalesces the launch preload with the tab's on-appear load into one fetch.
+    /// `loadTask` coalesces concurrent callers (e.g. launch preload and tab on-appear) into one fetch.
     public func load(forceRefresh: Bool) async {
         if !forceRefresh, case .loaded = state, !isStale(window: analyticsWindow) {
             return
@@ -119,8 +115,6 @@ public final class BrewDiscoverPackagesRepository: DiscoverPackagesRepository {
         return formulae + casks
     }
 
-    /// Returns the cached analytics bytes for `window`, refetching over the network only when the cache
-    /// is stale or the bytes are unexpectedly absent.
     private func freshAnalyticsData(window: BrewAnalyticsWindow) async throws -> (Data, Data) {
         if !isStale(window: window),
            let formulaData = await cache.formulaAnalyticsData(window: window),
@@ -182,7 +176,7 @@ public final class BrewDiscoverPackagesRepository: DiscoverPackagesRepository {
         var results: [DiscoveryBrewPackage] = []
         results.reserveCapacity(validatedLimit)
 
-        // Derive rank from `count` (see `BrewAnalyticsJSON.rankedPackageCounts()`), then enrich in that order.
+        // Already ranked; enrich in order and stop once we hit the limit.
         for entry in try analytics.rankedPackageCounts() {
             guard let package = try await catalogueRepository.package(for: entry.reference) else {
                 continue

--- a/Sources/BrewRepositories/BrewDiscoverPackagesRepository.swift
+++ b/Sources/BrewRepositories/BrewDiscoverPackagesRepository.swift
@@ -42,7 +42,6 @@ public final class BrewDiscoverPackagesRepository: DiscoverPackagesRepository {
     @ObservationIgnored private let analyticsWindow: BrewAnalyticsWindow
     @ObservationIgnored private var loadTask: Task<Void, Never>?
 
-    /// `defaultsKeyPrefix` namespaces lastRefresh timestamps in `UserDefaults.standard` so tests isolate.
     public init(
         apiClient: any BrewAPIClient,
         catalogueRepository: any CatalogueRepository,
@@ -86,7 +85,6 @@ public final class BrewDiscoverPackagesRepository: DiscoverPackagesRepository {
     }
 
     private func refresh() async {
-        // Keep any existing list on screen while revalidating; only show loading with nothing to show.
         if case .loaded = state {} else {
             state = .loading
         }
@@ -95,7 +93,6 @@ public final class BrewDiscoverPackagesRepository: DiscoverPackagesRepository {
         } catch is CancellationError {
             return
         } catch {
-            // Keep showing cached data if we have any; only surface an error with nothing to show.
             if case .loaded = state {
                 discoverRepositoryLogger.error(
                     "Discover trending revalidation failed: \(error.localizedDescription, privacy: .public)",
@@ -176,7 +173,6 @@ public final class BrewDiscoverPackagesRepository: DiscoverPackagesRepository {
         var results: [DiscoveryBrewPackage] = []
         results.reserveCapacity(validatedLimit)
 
-        // Already ranked; enrich in order and stop once we hit the limit.
         for entry in try analytics.rankedPackageCounts() {
             guard let package = try await catalogueRepository.package(for: entry.reference) else {
                 continue

--- a/Sources/BrewRepositories/BrewDiscoverPackagesRepository.swift
+++ b/Sources/BrewRepositories/BrewDiscoverPackagesRepository.swift
@@ -7,32 +7,46 @@ import BrewCore
 import BrewNetworking
 import BrewRepositoryInterfaces
 import Foundation
+import Observation
+import OSLog
+
+private let discoverRepositoryLogger = Logger(
+    subsystem: "Homebrew.BrewUI",
+    category: "BrewDiscoverPackagesRepository",
+)
 
 enum DiscoverPackagesRepositoryError: Error, Equatable {
     case cacheMissingAfterRefresh(window: BrewAnalyticsWindow)
 }
 
-/// Discover top-package repository with a 24-hour analytics cache.
+/// App-scoped observable source of truth for Discover's trending list.
 ///
-/// Homebrew publishes install analytics once per day, so the raw analytics responses are cached to
-/// disk (via ``DiscoverAnalyticsCaching``) and only refetched when older than `ttl`. Staleness is
-/// tracked with a per-window `lastRefresh` timestamp in `UserDefaults`, mirroring
-/// `BrewCatalogueRepository`. Catalogue enrichment (name/description/version lookups) is re-run on
-/// every call from the cached analytics — that path is already cached by the catalogue repository.
-public actor BrewDiscoverPackagesRepository: DiscoverPackagesRepository {
+/// Long-lived `@Observable` injected into the SwiftUI environment and preloaded at launch, so the tab
+/// renders instantly on first open. Homebrew publishes install analytics once per day, so the raw
+/// analytics responses are cached to disk (via ``DiscoverAnalyticsCaching``) and only refetched when
+/// older than `ttl`; the enriched trending list is held in ``state`` for the session. Mirrors
+/// ``BrewInstalledPackagesRepository``: IO/persistence lives in the cache actor, UI state lives here.
+@Observable
+@MainActor
+public final class BrewDiscoverPackagesRepository: DiscoverPackagesRepository {
     public static let defaultTTL: TimeInterval = 86400
 
-    private let apiClient: any BrewAPIClient
-    private let catalogueRepository: any CatalogueRepository
-    private let cache: any DiscoverAnalyticsCaching
-    private let defaultsKeyPrefix: String
-    private let now: @Sendable () -> Date
-    private let ttl: TimeInterval
+    /// Drives loading/loaded/error chrome. Carries the underlying `Error` on failure — presentation
+    /// layers map it to user-facing copy. Prior loaded data stays put when a revalidation fails.
+    public private(set) var state: LoadState<[DiscoveryBrewPackage], any Error> = .loading
 
-    private var refreshTasks: [BrewAnalyticsWindow: Task<(Data, Data), Error>] = [:]
+    @ObservationIgnored private let apiClient: any BrewAPIClient
+    @ObservationIgnored private let catalogueRepository: any CatalogueRepository
+    @ObservationIgnored private let cache: any DiscoverAnalyticsCaching
+    @ObservationIgnored private let defaultsKeyPrefix: String
+    @ObservationIgnored private let now: @Sendable () -> Date
+    @ObservationIgnored private let ttl: TimeInterval
+    @ObservationIgnored private let topPackagesLimit: Int
+    @ObservationIgnored private let analyticsWindow: BrewAnalyticsWindow
+    @ObservationIgnored private var loadTask: Task<Void, Never>?
 
-    /// `defaultsKeyPrefix` is the test seam for `UserDefaults.standard`; tests pass a unique prefix
-    /// to isolate their lastRefresh timestamps from each other and from production data.
+    /// `defaultsKeyPrefix` is the test seam for `UserDefaults.standard`; tests pass a unique prefix to
+    /// isolate their lastRefresh timestamps from each other and from production data.
     public init(
         apiClient: any BrewAPIClient,
         catalogueRepository: any CatalogueRepository,
@@ -40,6 +54,8 @@ public actor BrewDiscoverPackagesRepository: DiscoverPackagesRepository {
         defaultsKeyPrefix: String = "DiscoverAnalytics",
         now: @escaping @Sendable () -> Date = Date.init,
         ttl: TimeInterval = BrewDiscoverPackagesRepository.defaultTTL,
+        topPackagesLimit: Int = 10,
+        analyticsWindow: BrewAnalyticsWindow = .days30,
     ) {
         self.apiClient = apiClient
         self.catalogueRepository = catalogueRepository
@@ -47,22 +63,64 @@ public actor BrewDiscoverPackagesRepository: DiscoverPackagesRepository {
         self.defaultsKeyPrefix = defaultsKeyPrefix
         self.now = now
         self.ttl = ttl
+        self.topPackagesLimit = topPackagesLimit
+        self.analyticsWindow = analyticsWindow
     }
 
     nonisolated func lastRefreshKey(for window: BrewAnalyticsWindow) -> String {
         "\(defaultsKeyPrefix).analytics.\(window.rawValue).lastRefresh"
     }
 
-    public func loadTopPackages(
-        limit: Int = 10,
-        window: BrewAnalyticsWindow = .days30,
-    ) async throws -> DiscoverTopPackagesSnapshot {
-        let (formulaData, caskData) = try await freshAnalyticsData(window: window)
-        return try await enrichedSnapshot(formulaData: formulaData, caskData: caskData, limit: limit)
+    // MARK: - Lifecycle
+
+    /// Cache-first: fresh in-memory data returns instantly; stale/empty/failed state fetches. A single
+    /// `loadTask` coalesces the launch preload with the tab's on-appear load into one fetch.
+    public func load(forceRefresh: Bool) async {
+        if !forceRefresh, case .loaded = state, !isStale(window: analyticsWindow) {
+            return
+        }
+        if let loadTask {
+            await loadTask.value
+            return
+        }
+        let task = Task { await self.refresh() }
+        loadTask = task
+        await task.value
+        loadTask = nil
     }
 
-    /// Returns the cached analytics bytes for `window`, refetching over the network only when the
-    /// cache is stale or the bytes are unexpectedly absent.
+    private func refresh() async {
+        // Keep any existing list on screen while revalidating; only show loading with nothing to show.
+        if case .loaded = state {} else {
+            state = .loading
+        }
+        do {
+            state = try await .loaded(fetchTopPackages())
+        } catch is CancellationError {
+            return
+        } catch {
+            // Keep showing cached data if we have any; only surface an error with nothing to show.
+            if case .loaded = state {
+                discoverRepositoryLogger.error(
+                    "Discover trending revalidation failed: \(error.localizedDescription, privacy: .public)",
+                )
+            } else {
+                state = .failed(error)
+            }
+        }
+    }
+
+    // MARK: - Fetch / enrichment
+
+    private func fetchTopPackages() async throws -> [DiscoveryBrewPackage] {
+        let (formulaData, caskData) = try await freshAnalyticsData(window: analyticsWindow)
+        let formulae = try await topPackages(from: Self.decodeAnalytics(formulaData), limit: topPackagesLimit)
+        let casks = try await topPackages(from: Self.decodeAnalytics(caskData), limit: topPackagesLimit)
+        return formulae + casks
+    }
+
+    /// Returns the cached analytics bytes for `window`, refetching over the network only when the cache
+    /// is stale or the bytes are unexpectedly absent.
     private func freshAnalyticsData(window: BrewAnalyticsWindow) async throws -> (Data, Data) {
         if !isStale(window: window),
            let formulaData = await cache.formulaAnalyticsData(window: window),
@@ -70,25 +128,7 @@ public actor BrewDiscoverPackagesRepository: DiscoverPackagesRepository {
         {
             return (formulaData, caskData)
         }
-        return try await refreshAwaitingSharedTask(for: window)
-    }
-
-    /// Coalesces concurrent refreshes for the same window so simultaneous view appearances trigger a
-    /// single network round-trip (mirrors `BrewCatalogueRepository.refreshAwaitingSharedTask`).
-    private func refreshAwaitingSharedTask(for window: BrewAnalyticsWindow) async throws -> (Data, Data) {
-        if let existing = refreshTasks[window] {
-            return try await existing.value
-        }
-        let task = Task { try await self.performRefresh(for: window) }
-        refreshTasks[window] = task
-        do {
-            let value = try await task.value
-            refreshTasks[window] = nil
-            return value
-        } catch {
-            refreshTasks[window] = nil
-            throw error
-        }
+        return try await performRefresh(for: window)
     }
 
     private func performRefresh(for window: BrewAnalyticsWindow) async throws -> (Data, Data) {
@@ -128,20 +168,6 @@ public actor BrewDiscoverPackagesRepository: DiscoverPackagesRepository {
         // failure leaves the window stale and the next call retries.
         updateLastRefresh(window: window)
         return (formulaData, caskData)
-    }
-
-    private func enrichedSnapshot(
-        formulaData: Data,
-        caskData: Data,
-        limit: Int,
-    ) async throws -> DiscoverTopPackagesSnapshot {
-        let formulaAnalytics = try Self.decodeAnalytics(formulaData)
-        let caskAnalytics = try Self.decodeAnalytics(caskData)
-
-        let formulae = try await topPackages(from: formulaAnalytics, limit: limit)
-        let casks = try await topPackages(from: caskAnalytics, limit: limit)
-
-        return DiscoverTopPackagesSnapshot(topFormulae: formulae, topCasks: casks)
     }
 
     private func topPackages(

--- a/Sources/BrewRepositories/BrewDiscoverPackagesRepository.swift
+++ b/Sources/BrewRepositories/BrewDiscoverPackagesRepository.swift
@@ -156,8 +156,8 @@ public actor BrewDiscoverPackagesRepository: DiscoverPackagesRepository {
         var results: [DiscoveryBrewPackage] = []
         results.reserveCapacity(validatedLimit)
 
-        let sortedCounts = analytics.packageCounts.sorted(by: sortByInstallCountDescendingThenNameAscending)
-        for entry in sortedCounts {
+        // Counts arrive in the backend's published rank order; we never re-rank, just enrich in order.
+        for entry in try analytics.rankedPackageCounts() {
             guard let package = try await catalogueRepository.package(for: entry.reference) else {
                 continue
             }
@@ -172,16 +172,6 @@ public actor BrewDiscoverPackagesRepository: DiscoverPackagesRepository {
             }
         }
         return results
-    }
-
-    private func sortByInstallCountDescendingThenNameAscending(
-        _ lhs: BrewAnalyticsPackageCount,
-        _ rhs: BrewAnalyticsPackageCount,
-    ) -> Bool {
-        if lhs.count == rhs.count {
-            return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
-        }
-        return lhs.count > rhs.count
     }
 
     private func updateLastRefresh(window: BrewAnalyticsWindow) {

--- a/Sources/BrewRepositories/BrewDiscoverPackagesRepository.swift
+++ b/Sources/BrewRepositories/BrewDiscoverPackagesRepository.swift
@@ -182,7 +182,7 @@ public final class BrewDiscoverPackagesRepository: DiscoverPackagesRepository {
         var results: [DiscoveryBrewPackage] = []
         results.reserveCapacity(validatedLimit)
 
-        // Counts arrive in the backend's published rank order; we never re-rank, just enrich in order.
+        // Derive rank from `count` (see `BrewAnalyticsJSON.rankedPackageCounts()`), then enrich in that order.
         for entry in try analytics.rankedPackageCounts() {
             guard let package = try await catalogueRepository.package(for: entry.reference) else {
                 continue

--- a/Sources/BrewRepositoryInterfaces/Fakes/Stubs.swift
+++ b/Sources/BrewRepositoryInterfaces/Fakes/Stubs.swift
@@ -39,19 +39,22 @@ public final class StubInstalledPackagesRepository: InstalledPackagesRepository 
     }
 }
 
-public struct StubDiscoverPackagesRepository: DiscoverPackagesRepository {
-    private let snapshot: DiscoverTopPackagesSnapshot
+/// Loaded-state trending list backed by a fixed snapshot (or an explicit state). `load` is a no-op so
+/// the preset state stays put — mirrors ``StubInstalledPackagesRepository``.
+@Observable
+@MainActor
+public final class StubDiscoverPackagesRepository: DiscoverPackagesRepository {
+    public private(set) var state: LoadState<[DiscoveryBrewPackage], any Error>
 
     public init(snapshot: DiscoverTopPackagesSnapshot) {
-        self.snapshot = snapshot
+        state = .loaded(snapshot.topFormulae + snapshot.topCasks)
     }
 
-    public func loadTopPackages(
-        limit _: Int,
-        window _: BrewAnalyticsWindow,
-    ) async throws -> DiscoverTopPackagesSnapshot {
-        snapshot
+    public init(state: LoadState<[DiscoveryBrewPackage], any Error>) {
+        self.state = state
     }
+
+    public func load(forceRefresh _: Bool) async {}
 }
 
 @Observable

--- a/Sources/BrewRepositoryInterfaces/Fakes/Stubs.swift
+++ b/Sources/BrewRepositoryInterfaces/Fakes/Stubs.swift
@@ -39,8 +39,7 @@ public final class StubInstalledPackagesRepository: InstalledPackagesRepository 
     }
 }
 
-/// Loaded-state trending list backed by a fixed snapshot (or an explicit state). `load` is a no-op so
-/// the preset state stays put — mirrors ``StubInstalledPackagesRepository``.
+/// Trending list backed by a fixed snapshot (or explicit state); `load` is a no-op.
 @Observable
 @MainActor
 public final class StubDiscoverPackagesRepository: DiscoverPackagesRepository {

--- a/Sources/BrewRepositoryInterfaces/Protocols/DiscoverPackagesRepository.swift
+++ b/Sources/BrewRepositoryInterfaces/Protocols/DiscoverPackagesRepository.swift
@@ -7,12 +7,11 @@ import BrewCore
 import Foundation
 import Observation
 
-/// App-scoped source of truth for Discover's trending list: an observable load state plus a cache-first
-/// load. A single observable so any surface renders from one fetch and the composition root can preload
-/// it at launch. The default traps — the composition root must inject a live instance.
+/// App-scoped source of truth for Discover's trending list: one observable load state plus a cache-first
+/// load, so any surface renders from a single fetch and the composition root can preload it at launch.
 @MainActor
 public protocol DiscoverPackagesRepository: Observable, Sendable {
-    /// Trending packages — top formulae followed by top casks — in the backend's install-rank order.
+    /// Trending packages: top formulae followed by top casks, each ranked by install count.
     var state: LoadState<[DiscoveryBrewPackage], any Error> { get }
 
     /// Cache-first by default: fresh in-memory data returns instantly; stale data revalidates while the

--- a/Sources/BrewRepositoryInterfaces/Protocols/DiscoverPackagesRepository.swift
+++ b/Sources/BrewRepositoryInterfaces/Protocols/DiscoverPackagesRepository.swift
@@ -5,19 +5,24 @@
 
 import BrewCore
 import Foundation
+import Observation
 
-public protocol DiscoverPackagesRepository: Sendable {
-    func loadTopPackages(
-        limit: Int,
-        window: BrewAnalyticsWindow,
-    ) async throws -> DiscoverTopPackagesSnapshot
+/// App-scoped source of truth for Discover's trending list: an observable load state plus a cache-first
+/// load. A single observable so any surface renders from one fetch and the composition root can preload
+/// it at launch. The default traps — the composition root must inject a live instance.
+@MainActor
+public protocol DiscoverPackagesRepository: Observable, Sendable {
+    /// Trending packages — top formulae followed by top casks — in the backend's install-rank order.
+    var state: LoadState<[DiscoveryBrewPackage], any Error> { get }
+
+    /// Cache-first by default: fresh in-memory data returns instantly; stale data revalidates while the
+    /// prior list stays on screen; an empty/failed state fetches. `forceRefresh` always fetches.
+    func load(forceRefresh: Bool) async
 }
 
+@MainActor
 public extension DiscoverPackagesRepository {
-    func loadTopPackages(
-        limit: Int = 10,
-        window: BrewAnalyticsWindow = .days30,
-    ) async throws -> DiscoverTopPackagesSnapshot {
-        try await loadTopPackages(limit: limit, window: window)
+    func load() async {
+        await load(forceRefresh: false)
     }
 }

--- a/Tests/BrewCoreTests/BrewAnalyticsJSONTests.swift
+++ b/Tests/BrewCoreTests/BrewAnalyticsJSONTests.swift
@@ -7,10 +7,6 @@ import BrewCore
 import Foundation
 import Testing
 
-/// Coverage for the analytics DTO. `BrewAnalyticsJSON` is a thin wire mirror (synthesized decode), so
-/// these fixtures split into two groups: decode-time failures (missing/mistyped required fields) and
-/// mapping-time failures raised by ``BrewAnalyticsJSON/rankedPackageCounts()`` (bad buckets/entries).
-/// The live API keys entries by name with no rank field, so ranking is derived from `count`.
 struct BrewAnalyticsJSONTests {
     @Test func `decodes formula counts and flattens buckets`() throws {
         let json = Data(
@@ -39,8 +35,6 @@ struct BrewAnalyticsJSONTests {
     }
 
     @Test func `ranks package counts by install count with a name tie-break`() throws {
-        // Keys are alphabetical (like the live API) and unrelated to rank; ordering comes from `count`,
-        // with equal counts broken by name so the order is stable.
         let json = Data(
             """
             {
@@ -84,7 +78,6 @@ struct BrewAnalyticsJSONTests {
     }
 
     @Test func `throws when required fields are missing`() throws {
-        // `total_count` is absent, so the synthesized decode fails before any mapping is attempted.
         let json = Data(
             """
             {
@@ -105,7 +98,6 @@ struct BrewAnalyticsJSONTests {
     }
 
     @Test func `throws when entry count is malformed`() throws {
-        // `count` mirrors the wire as a String, so this decodes fine and fails during mapping.
         let json = Data(
             """
             {
@@ -128,8 +120,6 @@ struct BrewAnalyticsJSONTests {
     }
 
     @Test func `throws when a package key carries an empty entry array`() throws {
-        // An empty array (rather than the usual single-entry one) must surface as an error instead of
-        // being silently dropped, which would shrink the ranking without any signal.
         let json = Data(
             """
             {

--- a/Tests/BrewCoreTests/BrewAnalyticsJSONTests.swift
+++ b/Tests/BrewCoreTests/BrewAnalyticsJSONTests.swift
@@ -7,9 +7,9 @@ import BrewCore
 import Foundation
 import Testing
 
-/// Decoding coverage for the analytics DTO. The API client now returns the raw response bytes and the
-/// repository decodes them through this type, so these fixtures exercise the flatten/validation logic
-/// directly rather than through a URLSession stub.
+/// Coverage for the analytics DTO. `BrewAnalyticsJSON` is a thin wire mirror (synthesized decode), so
+/// these fixtures split into two groups: decode-time failures (missing/mistyped required fields) and
+/// mapping-time failures raised by ``BrewAnalyticsJSON/rankedPackageCounts()`` (bad buckets/entries).
 struct BrewAnalyticsJSONTests {
     @Test func `decodes formula ranking and flattens buckets`() throws {
         let json = Data(
@@ -21,8 +21,8 @@ struct BrewAnalyticsJSONTests {
               "start_date": "2026-04-17",
               "end_date": "2026-05-17",
               "formulae": {
-                "wget": [{ "formula": "wget", "count": "1,000" }],
-                "bat": [{ "formula": "bat", "count": "200" }]
+                "wget": [{ "number": 1, "formula": "wget", "count": "1,000" }],
+                "bat": [{ "number": 2, "formula": "bat", "count": "200" }]
               }
             }
             """.utf8,
@@ -32,9 +32,33 @@ struct BrewAnalyticsJSONTests {
 
         #expect(decoded.category == "formula_install_on_request")
         #expect(decoded.totalCount == 1200)
-        let countsByName = Dictionary(uniqueKeysWithValues: decoded.packageCounts.map { ($0.name, $0.count) })
+        let countsByName = try Dictionary(uniqueKeysWithValues: decoded.rankedPackageCounts().map { ($0.name, $0.count) })
         #expect(countsByName["wget"] == 1000)
         #expect(countsByName["bat"] == 200)
+    }
+
+    @Test func `orders package counts by backend rank regardless of key order`() throws {
+        // Keys are deliberately out of rank order; the backend's `number` is the sole ordering signal.
+        let json = Data(
+            """
+            {
+              "category": "formula_install_on_request",
+              "total_items": 3,
+              "total_count": 3300,
+              "start_date": "2026-04-17",
+              "end_date": "2026-05-17",
+              "formulae": {
+                "bat": [{ "number": 2, "formula": "bat", "count": "1,500" }],
+                "fd": [{ "number": 3, "formula": "fd", "count": "300" }],
+                "wget": [{ "number": 1, "formula": "wget", "count": "1,500" }]
+              }
+            }
+            """.utf8,
+        )
+
+        let decoded = try JSONDecoder().decode(BrewAnalyticsJSON.self, from: json)
+
+        #expect(try decoded.rankedPackageCounts().map(\.name) == ["wget", "bat", "fd"])
     }
 
     @Test func `decodes cask ranking into cask references`() throws {
@@ -47,17 +71,18 @@ struct BrewAnalyticsJSONTests {
               "start_date": "2026-02-17",
               "end_date": "2026-05-17",
               "formulae": {
-                "iterm2": [{ "cask": "iterm2", "count": "50" }]
+                "iterm2": [{ "number": 1, "cask": "iterm2", "count": "50" }]
               }
             }
             """.utf8,
         )
 
         let decoded = try JSONDecoder().decode(BrewAnalyticsJSON.self, from: json)
-        #expect(decoded.packageCounts.first?.reference == .cask(token: "iterm2"))
+        #expect(try decoded.rankedPackageCounts().first?.reference == .cask(token: "iterm2"))
     }
 
     @Test func `throws when required fields are missing`() throws {
+        // `total_count` is absent, so the synthesized decode fails before any mapping is attempted.
         let json = Data(
             """
             {
@@ -66,7 +91,7 @@ struct BrewAnalyticsJSONTests {
               "start_date": "2026-04-17",
               "end_date": "2026-05-17",
               "formulae": {
-                "wget": [{ "formula": "wget", "count": "1000" }]
+                "wget": [{ "number": 1, "formula": "wget", "count": "1000" }]
               }
             }
             """.utf8,
@@ -78,6 +103,7 @@ struct BrewAnalyticsJSONTests {
     }
 
     @Test func `throws when entry count is malformed`() throws {
+        // `count` mirrors the wire as a String, so this decodes fine and fails during mapping.
         let json = Data(
             """
             {
@@ -87,14 +113,15 @@ struct BrewAnalyticsJSONTests {
               "start_date": "2026-04-17",
               "end_date": "2026-05-17",
               "formulae": {
-                "wget": [{ "formula": "wget", "count": "not-a-number" }]
+                "wget": [{ "number": 1, "formula": "wget", "count": "not-a-number" }]
               }
             }
             """.utf8,
         )
 
-        #expect(throws: DecodingError.self) {
-            _ = try JSONDecoder().decode(BrewAnalyticsJSON.self, from: json)
+        let decoded = try JSONDecoder().decode(BrewAnalyticsJSON.self, from: json)
+        #expect(throws: BrewAnalyticsMappingError.self) {
+            _ = try decoded.rankedPackageCounts()
         }
     }
 
@@ -108,14 +135,15 @@ struct BrewAnalyticsJSONTests {
               "start_date": "2026-04-17",
               "end_date": "2026-05-17",
               "formulae": {
-                "wget": [{ "count": "1000" }]
+                "wget": [{ "number": 1, "count": "1000" }]
               }
             }
             """.utf8,
         )
 
-        #expect(throws: DecodingError.self) {
-            _ = try JSONDecoder().decode(BrewAnalyticsJSON.self, from: json)
+        let decoded = try JSONDecoder().decode(BrewAnalyticsJSON.self, from: json)
+        #expect(throws: BrewAnalyticsMappingError.self) {
+            _ = try decoded.rankedPackageCounts()
         }
     }
 
@@ -132,8 +160,9 @@ struct BrewAnalyticsJSONTests {
             """.utf8,
         )
 
-        #expect(throws: DecodingError.self) {
-            _ = try JSONDecoder().decode(BrewAnalyticsJSON.self, from: json)
+        let decoded = try JSONDecoder().decode(BrewAnalyticsJSON.self, from: json)
+        #expect(throws: BrewAnalyticsMappingError.missingPackageBucket) {
+            _ = try decoded.rankedPackageCounts()
         }
     }
 }

--- a/Tests/BrewCoreTests/BrewAnalyticsJSONTests.swift
+++ b/Tests/BrewCoreTests/BrewAnalyticsJSONTests.swift
@@ -127,6 +127,31 @@ struct BrewAnalyticsJSONTests {
         }
     }
 
+    @Test func `throws when a package key carries an empty entry array`() throws {
+        // An empty array (rather than the usual single-entry one) must surface as an error instead of
+        // being silently dropped, which would shrink the ranking without any signal.
+        let json = Data(
+            """
+            {
+              "category": "install-on-request",
+              "total_items": 2,
+              "total_count": 1200,
+              "start_date": "2026-04-17",
+              "end_date": "2026-05-17",
+              "formulae": {
+                "wget": [{ "formula": "wget", "count": "1000" }],
+                "bat": []
+              }
+            }
+            """.utf8,
+        )
+
+        let decoded = try JSONDecoder().decode(BrewAnalyticsJSON.self, from: json)
+        #expect(throws: BrewAnalyticsMappingError.emptyPackageEntries(key: "bat")) {
+            _ = try decoded.rankedPackageCounts()
+        }
+    }
+
     @Test func `throws when entry package identity is missing`() throws {
         let json = Data(
             """

--- a/Tests/BrewCoreTests/BrewAnalyticsJSONTests.swift
+++ b/Tests/BrewCoreTests/BrewAnalyticsJSONTests.swift
@@ -10,19 +10,20 @@ import Testing
 /// Coverage for the analytics DTO. `BrewAnalyticsJSON` is a thin wire mirror (synthesized decode), so
 /// these fixtures split into two groups: decode-time failures (missing/mistyped required fields) and
 /// mapping-time failures raised by ``BrewAnalyticsJSON/rankedPackageCounts()`` (bad buckets/entries).
+/// The live API keys entries by name with no rank field, so ranking is derived from `count`.
 struct BrewAnalyticsJSONTests {
-    @Test func `decodes formula ranking and flattens buckets`() throws {
+    @Test func `decodes formula counts and flattens buckets`() throws {
         let json = Data(
             """
             {
-              "category": "formula_install_on_request",
+              "category": "install-on-request",
               "total_items": 2,
               "total_count": 1200,
               "start_date": "2026-04-17",
               "end_date": "2026-05-17",
               "formulae": {
-                "wget": [{ "number": 1, "formula": "wget", "count": "1,000" }],
-                "bat": [{ "number": 2, "formula": "bat", "count": "200" }]
+                "wget": [{ "formula": "wget", "count": "1,000" }],
+                "bat": [{ "formula": "bat", "count": "200" }]
               }
             }
             """.utf8,
@@ -30,27 +31,28 @@ struct BrewAnalyticsJSONTests {
 
         let decoded = try JSONDecoder().decode(BrewAnalyticsJSON.self, from: json)
 
-        #expect(decoded.category == "formula_install_on_request")
+        #expect(decoded.category == "install-on-request")
         #expect(decoded.totalCount == 1200)
         let countsByName = try Dictionary(uniqueKeysWithValues: decoded.rankedPackageCounts().map { ($0.name, $0.count) })
         #expect(countsByName["wget"] == 1000)
         #expect(countsByName["bat"] == 200)
     }
 
-    @Test func `orders package counts by backend rank regardless of key order`() throws {
-        // Keys are deliberately out of rank order; the backend's `number` is the sole ordering signal.
+    @Test func `ranks package counts by install count with a name tie-break`() throws {
+        // Keys are alphabetical (like the live API) and unrelated to rank; ordering comes from `count`,
+        // with equal counts broken by name so the order is stable.
         let json = Data(
             """
             {
-              "category": "formula_install_on_request",
+              "category": "install-on-request",
               "total_items": 3,
               "total_count": 3300,
               "start_date": "2026-04-17",
               "end_date": "2026-05-17",
               "formulae": {
-                "bat": [{ "number": 2, "formula": "bat", "count": "1,500" }],
-                "fd": [{ "number": 3, "formula": "fd", "count": "300" }],
-                "wget": [{ "number": 1, "formula": "wget", "count": "1,500" }]
+                "bat": [{ "formula": "bat", "count": "1,500" }],
+                "fd": [{ "formula": "fd", "count": "300" }],
+                "wget": [{ "formula": "wget", "count": "1,500" }]
               }
             }
             """.utf8,
@@ -58,20 +60,20 @@ struct BrewAnalyticsJSONTests {
 
         let decoded = try JSONDecoder().decode(BrewAnalyticsJSON.self, from: json)
 
-        #expect(try decoded.rankedPackageCounts().map(\.name) == ["wget", "bat", "fd"])
+        #expect(try decoded.rankedPackageCounts().map(\.name) == ["bat", "wget", "fd"])
     }
 
-    @Test func `decodes cask ranking into cask references`() throws {
+    @Test func `decodes cask entries into cask references`() throws {
         let json = Data(
             """
             {
-              "category": "cask_install",
+              "category": "cask-install",
               "total_items": 1,
               "total_count": 50,
               "start_date": "2026-02-17",
               "end_date": "2026-05-17",
               "formulae": {
-                "iterm2": [{ "number": 1, "cask": "iterm2", "count": "50" }]
+                "iterm2": [{ "cask": "iterm2", "count": "50" }]
               }
             }
             """.utf8,
@@ -86,12 +88,12 @@ struct BrewAnalyticsJSONTests {
         let json = Data(
             """
             {
-              "category": "formula_install_on_request",
+              "category": "install-on-request",
               "total_items": 2,
               "start_date": "2026-04-17",
               "end_date": "2026-05-17",
               "formulae": {
-                "wget": [{ "number": 1, "formula": "wget", "count": "1000" }]
+                "wget": [{ "formula": "wget", "count": "1000" }]
               }
             }
             """.utf8,
@@ -107,13 +109,13 @@ struct BrewAnalyticsJSONTests {
         let json = Data(
             """
             {
-              "category": "formula_install_on_request",
+              "category": "install-on-request",
               "total_items": 2,
               "total_count": 1200,
               "start_date": "2026-04-17",
               "end_date": "2026-05-17",
               "formulae": {
-                "wget": [{ "number": 1, "formula": "wget", "count": "not-a-number" }]
+                "wget": [{ "formula": "wget", "count": "not-a-number" }]
               }
             }
             """.utf8,
@@ -129,13 +131,13 @@ struct BrewAnalyticsJSONTests {
         let json = Data(
             """
             {
-              "category": "formula_install_on_request",
+              "category": "install-on-request",
               "total_items": 2,
               "total_count": 1200,
               "start_date": "2026-04-17",
               "end_date": "2026-05-17",
               "formulae": {
-                "wget": [{ "number": 1, "count": "1000" }]
+                "wget": [{ "count": "1000" }]
               }
             }
             """.utf8,
@@ -151,7 +153,7 @@ struct BrewAnalyticsJSONTests {
         let json = Data(
             """
             {
-              "category": "formula_install_on_request",
+              "category": "install-on-request",
               "total_items": 0,
               "total_count": 0,
               "start_date": "2026-04-17",

--- a/Tests/BrewFeatureDiscoverTests/DiscoverTrendingIntegrationTests.swift
+++ b/Tests/BrewFeatureDiscoverTests/DiscoverTrendingIntegrationTests.swift
@@ -13,10 +13,6 @@ import BrewServicesTestSupport
 import Foundation
 import Testing
 
-/// End-to-end coverage from `DiscoverViewModel` down through the real `BrewDiscoverPackagesRepository`,
-/// decoding a payload shaped like the live Homebrew analytics API. This guards the seam that broke once:
-/// the API keys entries by package name (alphabetically), the objects carry only `formula`/`cask` +
-/// `count` (a comma-grouped string, and **no** rank field), so ranking must be derived from `count`.
 struct DiscoverTrendingIntegrationTests {
     @Test func `trending loads and ranks live-shaped analytics by install count`() async {
         let viewModel = makeViewModel(
@@ -32,8 +28,6 @@ struct DiscoverTrendingIntegrationTests {
             Issue.record("expected trending to load; got \(viewModel.trending)")
             return
         }
-        // Ranked by count descending within each kind (formulae then casks), regardless of the
-        // alphabetical key order in the payload.
         #expect(viewModel.visiblePackages.map(\.name) == ["wget", "bat", "a2ps", "raycast", "iterm2"])
         #expect(viewModel.selectedPackage?.id == .formula(name: "wget"))
     }
@@ -56,8 +50,6 @@ struct DiscoverTrendingIntegrationTests {
 
     // MARK: - Fixtures
 
-    /// Mirrors the live `install-on-request` response: name-keyed objects (alphabetical), string counts,
-    /// no rank field. Counts intentionally do not follow key order.
     private static let liveShapedFormulaAnalytics = Data(
         """
         {
@@ -141,8 +133,6 @@ private func catalogueCask(named name: String) -> BrewPackage {
     )
 }
 
-/// Returns fixed analytics bytes for both windows; catalogue endpoints are never exercised by the
-/// discover repository (enrichment goes through the injected catalogue repository).
 private struct StubAnalyticsAPIClient: BrewAPIClient {
     let formula: Data
     let cask: Data

--- a/Tests/BrewFeatureDiscoverTests/DiscoverTrendingIntegrationTests.swift
+++ b/Tests/BrewFeatureDiscoverTests/DiscoverTrendingIntegrationTests.swift
@@ -1,0 +1,171 @@
+//
+//  DiscoverTrendingIntegrationTests.swift
+//  BrewTests
+//
+
+import BrewCore
+import BrewCoreTestSupport
+@testable import BrewFeatureDiscover
+import BrewNetworking
+@testable import BrewRepositories
+import BrewRepositoryInterfaces
+import BrewServicesTestSupport
+import Foundation
+import Testing
+
+/// End-to-end coverage from `DiscoverViewModel` down through the real `BrewDiscoverPackagesRepository`,
+/// decoding a payload shaped like the live Homebrew analytics API. This guards the seam that broke once:
+/// the API keys entries by package name (alphabetically), the objects carry only `formula`/`cask` +
+/// `count` (a comma-grouped string, and **no** rank field), so ranking must be derived from `count`.
+struct DiscoverTrendingIntegrationTests {
+    @Test func `trending loads and ranks live-shaped analytics by install count`() async {
+        let viewModel = makeViewModel(
+            formulaAnalytics: Self.liveShapedFormulaAnalytics,
+            caskAnalytics: Self.liveShapedCaskAnalytics,
+            formulaCatalogueNames: ["a2ps", "wget", "bat"],
+            caskCatalogueNames: ["iterm2", "raycast"],
+        )
+
+        await viewModel.load()
+
+        guard case .loaded = viewModel.trending else {
+            Issue.record("expected trending to load; got \(viewModel.trending)")
+            return
+        }
+        // Ranked by count descending within each kind (formulae then casks), regardless of the
+        // alphabetical key order in the payload.
+        #expect(viewModel.visiblePackages.map(\.name) == ["wget", "bat", "a2ps", "raycast", "iterm2"])
+        #expect(viewModel.selectedPackage?.id == .formula(name: "wget"))
+    }
+
+    @Test func `trending surfaces a failure when analytics cannot be decoded`() async {
+        let viewModel = makeViewModel(
+            formulaAnalytics: Data("not json".utf8),
+            caskAnalytics: Data("not json".utf8),
+            formulaCatalogueNames: [],
+            caskCatalogueNames: [],
+        )
+
+        await viewModel.load()
+
+        guard case .failed = viewModel.trending else {
+            Issue.record("expected trending to fail on undecodable analytics; got \(viewModel.trending)")
+            return
+        }
+    }
+
+    // MARK: - Fixtures
+
+    /// Mirrors the live `install-on-request` response: name-keyed objects (alphabetical), string counts,
+    /// no rank field. Counts intentionally do not follow key order.
+    private static let liveShapedFormulaAnalytics = Data(
+        """
+        {
+          "category": "install-on-request",
+          "total_items": 3,
+          "total_count": 1281,
+          "start_date": "2026-04-17",
+          "end_date": "2026-05-17",
+          "formulae": {
+            "a2ps": [{ "formula": "a2ps", "count": "81" }],
+            "bat": [{ "formula": "bat", "count": "200" }],
+            "wget": [{ "formula": "wget", "count": "1,000" }]
+          }
+        }
+        """.utf8,
+    )
+
+    private static let liveShapedCaskAnalytics = Data(
+        """
+        {
+          "category": "cask-install",
+          "total_items": 2,
+          "total_count": 850,
+          "start_date": "2026-04-17",
+          "end_date": "2026-05-17",
+          "formulae": {
+            "iterm2": [{ "cask": "iterm2", "count": "400" }],
+            "raycast": [{ "cask": "raycast", "count": "450" }]
+          }
+        }
+        """.utf8,
+    )
+}
+
+// MARK: - Wiring
+
+private func makeViewModel(
+    formulaAnalytics: Data,
+    caskAnalytics: Data,
+    formulaCatalogueNames: [String],
+    caskCatalogueNames: [String],
+) -> DiscoverViewModel {
+    let catalogueRepository = StubCatalogueRepository(
+        formulaCatalogue: formulaCatalogueNames.map { catalogueFormula(named: $0) },
+        caskCatalogue: caskCatalogueNames.map { catalogueCask(named: $0) },
+    )
+    let repository = BrewDiscoverPackagesRepository(
+        apiClient: StubAnalyticsAPIClient(formula: formulaAnalytics, cask: caskAnalytics),
+        catalogueRepository: catalogueRepository,
+        cache: InMemoryDiscoverAnalyticsCache(),
+        defaultsKeyPrefix: "DiscoverTrendingIntegration.\(UUID().uuidString)",
+    )
+    return DiscoverViewModel(
+        discoverPackagesRepository: repository,
+        catalogueRepository: catalogueRepository,
+        installedRepository: StubInstalledPackagesRepository(packages: []),
+    )
+}
+
+private func catalogueFormula(named name: String) -> BrewPackage {
+    BrewPackage(
+        name: name,
+        displayName: name,
+        kind: .formula,
+        description: "Formula \(name)",
+        homepage: "https://example.com/\(name)",
+        latestVersion: "1.0.0",
+        dependencies: [],
+    )
+}
+
+private func catalogueCask(named name: String) -> BrewPackage {
+    BrewPackage(
+        name: name,
+        displayName: name,
+        kind: .cask,
+        description: "Cask \(name)",
+        homepage: "https://example.com/\(name)",
+        latestVersion: "2.0.0",
+        dependencies: [],
+    )
+}
+
+/// Returns fixed analytics bytes for both windows; catalogue endpoints are never exercised by the
+/// discover repository (enrichment goes through the injected catalogue repository).
+private struct StubAnalyticsAPIClient: BrewAPIClient {
+    let formula: Data
+    let cask: Data
+
+    func fetchFormulaInstallOnRequestAnalytics(
+        window _: BrewAnalyticsWindow,
+        etag _: String?,
+    ) async throws -> CatalogueResponse<Data> {
+        .updated(data: formula, etag: nil)
+    }
+
+    func fetchCaskInstallAnalytics(
+        window _: BrewAnalyticsWindow,
+        etag _: String?,
+    ) async throws -> CatalogueResponse<Data> {
+        .updated(data: cask, etag: nil)
+    }
+
+    func fetchFormulaCatalogue(etag _: String?) async throws -> CatalogueResponse<FormulaCatalogueJSON> {
+        .notModified
+    }
+
+    func fetchCaskCatalogue(etag _: String?) async throws -> CatalogueResponse<CaskCatalogueJSON> {
+        .notModified
+    }
+}

--- a/Tests/BrewFeatureDiscoverTests/DiscoverViewModelTests.swift
+++ b/Tests/BrewFeatureDiscoverTests/DiscoverViewModelTests.swift
@@ -105,7 +105,7 @@ struct DiscoverViewModelTests {
         #expect(viewModel.selectedPackage?.id == .formula(name: "git"))
     }
 
-    @Test @MainActor func `load selects first visible row by popularity`() async {
+    @Test @MainActor func `load selects the first visible row`() async {
         let viewModel = DiscoverViewModel(
             discoverPackagesRepository: StubDiscoverPackagesRepository(
                 snapshot: DiscoverTopPackagesSnapshot(
@@ -170,7 +170,9 @@ struct DiscoverViewModelTests {
         #expect(viewModel.selectedPackage?.id == .formula(name: "node"))
     }
 
-    @Test @MainActor func `rows with equal install count are sorted alphabetically`() async {
+    @Test @MainActor func `visible packages preserve the source order within a kind`() async {
+        // The view model never re-ranks — rows appear in the order the repository handed them down
+        // (here: the backend's install rank), not alphabetically or by count.
         let viewModel = DiscoverViewModel(
             discoverPackagesRepository: StubDiscoverPackagesRepository(
                 snapshot: DiscoverTopPackagesSnapshot(
@@ -188,7 +190,7 @@ struct DiscoverViewModelTests {
 
         await viewModel.load()
 
-        #expect(viewModel.visiblePackages.map(\.name) == ["git", "node", "wget"])
+        #expect(viewModel.visiblePackages.map(\.name) == ["wget", "git", "node"])
     }
 
     @Test @MainActor func `visible packages partition by kind formulae first then casks`() async {
@@ -447,7 +449,8 @@ struct DiscoverViewModelTests {
 
         #expect(viewModel.isSearching)
         #expect(!viewModel.showsInstallMetrics)
-        #expect(viewModel.visiblePackages.map(\.name) == ["imagemagick", "ripgrep"])
+        // Results preserve the catalogue's match order (the view model never re-sorts them).
+        #expect(viewModel.visiblePackages.map(\.name) == ["ripgrep", "imagemagick"])
         // Search results all surface a zero install count (catalogue search has no analytics).
         #expect(viewModel.selectedPackage?.thirtyDayInstallCount == 0)
     }

--- a/Tests/BrewFeatureDiscoverTests/DiscoverViewModelTests.swift
+++ b/Tests/BrewFeatureDiscoverTests/DiscoverViewModelTests.swift
@@ -53,8 +53,8 @@ struct DiscoverViewModelTests {
 
     @Test @MainActor func `load maps discover repository transport errors to underlying message`() async {
         let viewModel = DiscoverViewModel(
-            discoverPackagesRepository: ThrowingDiscoverPackagesRepository(
-                error: BrewAPIClientError.transport(underlying: "offline"),
+            discoverPackagesRepository: StubDiscoverPackagesRepository(
+                state: .failed(BrewAPIClientError.transport(underlying: "offline")),
             ),
             catalogueRepository: StubCatalogueRepository(),
             installedRepository: installedRepo(),
@@ -71,7 +71,7 @@ struct DiscoverViewModelTests {
 
     @Test @MainActor func `load maps unknown discover repository errors to generic message`() async {
         let viewModel = DiscoverViewModel(
-            discoverPackagesRepository: ThrowingDiscoverPackagesRepository(error: DiscoverOddError()),
+            discoverPackagesRepository: StubDiscoverPackagesRepository(state: .failed(DiscoverOddError())),
             catalogueRepository: StubCatalogueRepository(),
             installedRepository: installedRepo(),
         )
@@ -273,14 +273,12 @@ struct DiscoverViewModelTests {
 
     @Test @MainActor func `subtitle reflects loading state`() {
         let viewModel = DiscoverViewModel(
-            discoverPackagesRepository: StubDiscoverPackagesRepository(
-                snapshot: DiscoverTopPackagesSnapshot(topFormulae: [], topCasks: []),
-            ),
+            discoverPackagesRepository: StubDiscoverPackagesRepository(state: .loading),
             catalogueRepository: StubCatalogueRepository(),
             installedRepository: installedRepo(),
         )
 
-        // VM starts in .loading before load() is called
+        // Trending projects the repository's .loading state (e.g. tab opened mid-preload).
         #expect(viewModel.paneHeading == "Trending")
         #expect(viewModel.subtitleText == "Loading packages…")
         #expect(!viewModel.isSubtitleError)
@@ -305,7 +303,7 @@ struct DiscoverViewModelTests {
 
     @Test @MainActor func `subtitle reflects error state`() async {
         let viewModel = DiscoverViewModel(
-            discoverPackagesRepository: ThrowingDiscoverPackagesRepository(error: DiscoverOddError()),
+            discoverPackagesRepository: StubDiscoverPackagesRepository(state: .failed(DiscoverOddError())),
             catalogueRepository: StubCatalogueRepository(),
             installedRepository: installedRepo(),
         )
@@ -601,20 +599,18 @@ struct DiscoverViewModelTests {
 
     @Test @MainActor func `shouldFocusList is false while trending is still loading`() {
         let viewModel = DiscoverViewModel(
-            discoverPackagesRepository: StubDiscoverPackagesRepository(
-                snapshot: DiscoverTopPackagesSnapshot(topFormulae: [], topCasks: []),
-            ),
+            discoverPackagesRepository: StubDiscoverPackagesRepository(state: .loading),
             catalogueRepository: StubCatalogueRepository(),
             installedRepository: installedRepo(),
         )
 
-        // trending starts as .loading and load() has not been awaited yet.
+        // The list only takes focus once trending has loaded; here the repository is still loading.
         #expect(!viewModel.shouldFocusList)
     }
 
     @Test @MainActor func `shouldFocusList is false when trending failed to load`() async {
         let viewModel = DiscoverViewModel(
-            discoverPackagesRepository: ThrowingDiscoverPackagesRepository(error: DiscoverOddError()),
+            discoverPackagesRepository: StubDiscoverPackagesRepository(state: .failed(DiscoverOddError())),
             catalogueRepository: StubCatalogueRepository(),
             installedRepository: installedRepo(),
         )
@@ -643,47 +639,36 @@ struct DiscoverViewModelTests {
     }
 }
 
+@Observable
 @MainActor
-private struct StubDiscoverPackagesRepository: DiscoverPackagesRepository {
-    let snapshot: DiscoverTopPackagesSnapshot
+private final class StubDiscoverPackagesRepository: DiscoverPackagesRepository {
+    private(set) var state: LoadState<[DiscoveryBrewPackage], any Error>
 
-    func loadTopPackages(
-        limit _: Int,
-        window _: BrewAnalyticsWindow,
-    ) async throws -> DiscoverTopPackagesSnapshot {
-        snapshot
+    init(snapshot: DiscoverTopPackagesSnapshot) {
+        state = .loaded(snapshot.topFormulae + snapshot.topCasks)
     }
+
+    init(state: LoadState<[DiscoveryBrewPackage], any Error>) {
+        self.state = state
+    }
+
+    func load(forceRefresh _: Bool) async {}
 }
 
+@Observable
 @MainActor
 private final class MutableDiscoverPackagesRepository: DiscoverPackagesRepository {
     var snapshot: DiscoverTopPackagesSnapshot
+    private(set) var state: LoadState<[DiscoveryBrewPackage], any Error>
 
     init(snapshot: DiscoverTopPackagesSnapshot) {
         self.snapshot = snapshot
+        state = .loaded(snapshot.topFormulae + snapshot.topCasks)
     }
 
-    func loadTopPackages(
-        limit _: Int,
-        window _: BrewAnalyticsWindow,
-    ) async throws -> DiscoverTopPackagesSnapshot {
-        snapshot
-    }
-}
-
-@MainActor
-private struct ThrowingDiscoverPackagesRepository: DiscoverPackagesRepository {
-    let error: Error
-
-    init(error: Error = DiscoverOddError()) {
-        self.error = error
-    }
-
-    func loadTopPackages(
-        limit _: Int,
-        window _: BrewAnalyticsWindow,
-    ) async throws -> DiscoverTopPackagesSnapshot {
-        throw error
+    /// Re-projects the current snapshot, so tests can mutate `snapshot` then reload to see the change.
+    func load(forceRefresh _: Bool) async {
+        state = .loaded(snapshot.topFormulae + snapshot.topCasks)
     }
 }
 

--- a/Tests/BrewFeatureDiscoverTests/DiscoverViewModelTests.swift
+++ b/Tests/BrewFeatureDiscoverTests/DiscoverViewModelTests.swift
@@ -171,8 +171,6 @@ struct DiscoverViewModelTests {
     }
 
     @Test @MainActor func `visible packages preserve the source order within a kind`() async {
-        // The view model never re-ranks — rows appear in the order the repository handed them down
-        // (here: the backend's install rank), not alphabetically or by count.
         let viewModel = DiscoverViewModel(
             discoverPackagesRepository: StubDiscoverPackagesRepository(
                 snapshot: DiscoverTopPackagesSnapshot(
@@ -278,7 +276,6 @@ struct DiscoverViewModelTests {
             installedRepository: installedRepo(),
         )
 
-        // Trending projects the repository's .loading state (e.g. tab opened mid-preload).
         #expect(viewModel.paneHeading == "Trending")
         #expect(viewModel.subtitleText == "Loading packages…")
         #expect(!viewModel.isSubtitleError)
@@ -447,7 +444,6 @@ struct DiscoverViewModelTests {
 
         #expect(viewModel.isSearching)
         #expect(!viewModel.showsInstallMetrics)
-        // Results preserve the catalogue's match order (the view model never re-sorts them).
         #expect(viewModel.visiblePackages.map(\.name) == ["ripgrep", "imagemagick"])
         // Search results all surface a zero install count (catalogue search has no analytics).
         #expect(viewModel.selectedPackage?.thirtyDayInstallCount == 0)
@@ -604,7 +600,6 @@ struct DiscoverViewModelTests {
             installedRepository: installedRepo(),
         )
 
-        // The list only takes focus once trending has loaded; here the repository is still loading.
         #expect(!viewModel.shouldFocusList)
     }
 
@@ -666,7 +661,6 @@ private final class MutableDiscoverPackagesRepository: DiscoverPackagesRepositor
         state = .loaded(snapshot.topFormulae + snapshot.topCasks)
     }
 
-    /// Re-projects the current snapshot, so tests can mutate `snapshot` then reload to see the change.
     func load(forceRefresh _: Bool) async {
         state = .loaded(snapshot.topFormulae + snapshot.topCasks)
     }

--- a/Tests/BrewNetworkingTests/BrewAPIClientURLSessionIntegrationTests.swift
+++ b/Tests/BrewNetworkingTests/BrewAPIClientURLSessionIntegrationTests.swift
@@ -25,8 +25,8 @@ struct BrewAPIClientURLSessionIntegrationTests {
               "start_date": "2026-04-17",
               "end_date": "2026-05-17",
               "formulae": {
-                "wget": [{ "formula": "wget", "count": "1,000" }],
-                "bat": [{ "formula": "bat", "count": "200" }]
+                "wget": [{ "number": 1, "formula": "wget", "count": "1,000" }],
+                "bat": [{ "number": 2, "formula": "bat", "count": "200" }]
               }
             }
             """.utf8,
@@ -137,8 +137,8 @@ struct BrewAPIClientURLSessionIntegrationTests {
 
         let formula = try JSONDecoder().decode(BrewAnalyticsJSON.self, from: formulaData)
         let cask = try JSONDecoder().decode(BrewAnalyticsJSON.self, from: caskData)
-        #expect(formula.packageCounts.first?.name == "wget")
-        #expect(cask.packageCounts.first?.name == "iterm2")
+        #expect(try formula.rankedPackageCounts().first?.name == "wget")
+        #expect(try cask.rankedPackageCounts().first?.name == "iterm2")
         #expect(StubURLProtocol.requests(forHost: host).count == 2)
     }
 
@@ -206,7 +206,7 @@ struct BrewAPIClientURLSessionIntegrationTests {
                   "start_date": "2026-04-17",
                   "end_date": "2026-05-17",
                   "formulae": {
-                    "\(name)": [{ "formula": "\(name)", "count": "100" }]
+                    "\(name)": [{ "number": 1, "formula": "\(name)", "count": "100" }]
                   }
                 }
                 """.utf8,
@@ -226,7 +226,7 @@ struct BrewAPIClientURLSessionIntegrationTests {
                   "start_date": "2026-04-17",
                   "end_date": "2026-05-17",
                   "formulae": {
-                    "\(name)": [{ "cask": "\(name)", "count": "50" }]
+                    "\(name)": [{ "number": 1, "cask": "\(name)", "count": "50" }]
                   }
                 }
                 """.utf8,

--- a/Tests/BrewNetworkingTests/BrewAPIClientURLSessionIntegrationTests.swift
+++ b/Tests/BrewNetworkingTests/BrewAPIClientURLSessionIntegrationTests.swift
@@ -25,8 +25,8 @@ struct BrewAPIClientURLSessionIntegrationTests {
               "start_date": "2026-04-17",
               "end_date": "2026-05-17",
               "formulae": {
-                "wget": [{ "number": 1, "formula": "wget", "count": "1,000" }],
-                "bat": [{ "number": 2, "formula": "bat", "count": "200" }]
+                "wget": [{ "formula": "wget", "count": "1,000" }],
+                "bat": [{ "formula": "bat", "count": "200" }]
               }
             }
             """.utf8,
@@ -206,7 +206,7 @@ struct BrewAPIClientURLSessionIntegrationTests {
                   "start_date": "2026-04-17",
                   "end_date": "2026-05-17",
                   "formulae": {
-                    "\(name)": [{ "number": 1, "formula": "\(name)", "count": "100" }]
+                    "\(name)": [{ "formula": "\(name)", "count": "100" }]
                   }
                 }
                 """.utf8,
@@ -226,7 +226,7 @@ struct BrewAPIClientURLSessionIntegrationTests {
                   "start_date": "2026-04-17",
                   "end_date": "2026-05-17",
                   "formulae": {
-                    "\(name)": [{ "number": 1, "cask": "\(name)", "count": "50" }]
+                    "\(name)": [{ "cask": "\(name)", "count": "50" }]
                   }
                 }
                 """.utf8,

--- a/Tests/BrewNetworkingTests/DiscoverAnalyticsCacheTests.swift
+++ b/Tests/BrewNetworkingTests/DiscoverAnalyticsCacheTests.swift
@@ -144,7 +144,7 @@ private struct TestFixture {
               "start_date": "2026-04-17",
               "end_date": "2026-05-17",
               "formulae": {
-                "\(name)": [{ "\(key)": "\(name)", "count": "100" }]
+                "\(name)": [{ "number": 1, "\(key)": "\(name)", "count": "100" }]
               }
             }
             """.utf8,

--- a/Tests/BrewNetworkingTests/DiscoverAnalyticsCacheTests.swift
+++ b/Tests/BrewNetworkingTests/DiscoverAnalyticsCacheTests.swift
@@ -144,7 +144,7 @@ private struct TestFixture {
               "start_date": "2026-04-17",
               "end_date": "2026-05-17",
               "formulae": {
-                "\(name)": [{ "number": 1, "\(key)": "\(name)", "count": "100" }]
+                "\(name)": [{ "\(key)": "\(name)", "count": "100" }]
               }
             }
             """.utf8,

--- a/Tests/BrewRepositoriesTests/BrewAPIClientConcurrentIntegrationTests.swift
+++ b/Tests/BrewRepositoriesTests/BrewAPIClientConcurrentIntegrationTests.swift
@@ -280,7 +280,7 @@ private extension StubURLProtocol.StubbedResult {
               "start_date": "2026-04-17",
               "end_date": "2026-05-17",
               "formulae": {
-                "wget": [{ "formula": "wget", "count": "100" }]
+                "wget": [{ "number": 1, "formula": "wget", "count": "100" }]
               }
             }
             """.utf8,
@@ -298,7 +298,7 @@ private extension StubURLProtocol.StubbedResult {
               "start_date": "2026-04-17",
               "end_date": "2026-05-17",
               "formulae": {
-                "iterm2": [{ "cask": "iterm2", "count": "50" }]
+                "iterm2": [{ "number": 1, "cask": "iterm2", "count": "50" }]
               }
             }
             """.utf8,

--- a/Tests/BrewRepositoriesTests/BrewAPIClientConcurrentIntegrationTests.swift
+++ b/Tests/BrewRepositoriesTests/BrewAPIClientConcurrentIntegrationTests.swift
@@ -29,12 +29,15 @@ struct BrewAPIClientConcurrentIntegrationTests {
             apiClient: client,
             formulaCatalogueNames: ["wget"],
             caskCatalogueNames: ["iterm2"],
+            topPackagesLimit: 1,
         )
 
-        let snapshot = try await repository.loadTopPackages(limit: 1, window: .days30)
+        await repository.load()
 
-        #expect(snapshot.topFormulae.first?.reference == .formula(name: "wget"))
-        #expect(snapshot.topCasks.first?.reference == .cask(token: "iterm2"))
+        #expect(try #require(repository.state.value).map(\.reference) == [
+            .formula(name: "wget"),
+            .cask(token: "iterm2"),
+        ])
         #expect(StubURLProtocol.requests(forHost: host).count == 2)
     }
 
@@ -103,18 +106,21 @@ struct BrewAPIClientConcurrentIntegrationTests {
             catalogueRepository: catalogueRepository,
             cache: InMemoryDiscoverAnalyticsCache(),
             defaultsKeyPrefix: "DiscoverAnalyticsConcurrent.\(UUID().uuidString)",
+            topPackagesLimit: 1,
         )
 
-        async let topPackagesTask = discoverRepository.loadTopPackages(limit: 1, window: .days30)
+        async let topPackagesTask: Void = discoverRepository.load()
         async let formulaCatalogueTask = catalogueRepository.package(for: .formula(name: "wget"))
         async let caskCatalogueTask = catalogueRepository.package(for: .cask(token: "iterm2"))
 
-        let snapshot = try await topPackagesTask
+        _ = await topPackagesTask
         _ = try await formulaCatalogueTask
         _ = try await caskCatalogueTask
 
-        #expect(snapshot.topFormulae.count == 1)
-        #expect(snapshot.topCasks.count == 1)
+        #expect(try #require(discoverRepository.state.value).map(\.reference) == [
+            .formula(name: "wget"),
+            .cask(token: "iterm2"),
+        ])
         #expect(StubURLProtocol.requests(forHost: host).count == 2)
     }
 
@@ -154,6 +160,7 @@ private func makeDiscoverRepository(
     apiClient: URLSessionBrewAPIClient,
     formulaCatalogueNames: [String],
     caskCatalogueNames: [String],
+    topPackagesLimit: Int = 10,
 ) async throws -> BrewDiscoverPackagesRepository {
     try await BrewDiscoverPackagesRepository(
         apiClient: apiClient,
@@ -164,6 +171,7 @@ private func makeDiscoverRepository(
         ),
         cache: InMemoryDiscoverAnalyticsCache(),
         defaultsKeyPrefix: "DiscoverAnalyticsConcurrent.\(UUID().uuidString)",
+        topPackagesLimit: topPackagesLimit,
     )
 }
 

--- a/Tests/BrewRepositoriesTests/BrewAPIClientConcurrentIntegrationTests.swift
+++ b/Tests/BrewRepositoriesTests/BrewAPIClientConcurrentIntegrationTests.swift
@@ -288,7 +288,7 @@ private extension StubURLProtocol.StubbedResult {
               "start_date": "2026-04-17",
               "end_date": "2026-05-17",
               "formulae": {
-                "wget": [{ "number": 1, "formula": "wget", "count": "100" }]
+                "wget": [{ "formula": "wget", "count": "100" }]
               }
             }
             """.utf8,
@@ -306,7 +306,7 @@ private extension StubURLProtocol.StubbedResult {
               "start_date": "2026-04-17",
               "end_date": "2026-05-17",
               "formulae": {
-                "iterm2": [{ "number": 1, "cask": "iterm2", "count": "50" }]
+                "iterm2": [{ "cask": "iterm2", "count": "50" }]
               }
             }
             """.utf8,

--- a/Tests/BrewRepositoriesTests/BrewDiscoverPackagesRepositoryTests.swift
+++ b/Tests/BrewRepositoriesTests/BrewDiscoverPackagesRepositoryTests.swift
@@ -49,8 +49,8 @@ struct BrewDiscoverPackagesRepositoryTests {
               "start_date": "2026-04-17",
               "end_date": "2026-05-17",
               "formulae": {
-                "alpha": [{ "number": 1, "formula": "alpha", "count": "400" }],
-                "beta": [{ "number": 2, "formula": "beta", "count": "400" }]
+                "alpha": [{ "formula": "alpha", "count": "400" }],
+                "beta": [{ "formula": "beta", "count": "400" }]
               }
             }
             """,
@@ -64,7 +64,7 @@ struct BrewDiscoverPackagesRepositoryTests {
               "start_date": "2026-04-17",
               "end_date": "2026-05-17",
               "formulae": {
-                "gamma": [{ "number": 1, "cask": "gamma", "count": "40" }]
+                "gamma": [{ "cask": "gamma", "count": "40" }]
               }
             }
             """,
@@ -137,7 +137,7 @@ struct BrewDiscoverPackagesRepositoryTests {
               "start_date": "2026-04-17",
               "end_date": "2026-05-17",
               "formulae": {
-                "wget": [{ "number": 1, "formula": "wget", "count": "10" }]
+                "wget": [{ "formula": "wget", "count": "10" }]
               }
             }
             """,
@@ -545,9 +545,9 @@ private enum DiscoverAnalyticsFixtures {
               "start_date": "2026-04-17",
               "end_date": "2026-05-17",
               "formulae": {
-                "wget": [{ "number": 2, "formula": "wget", "count": "500" }],
-                "bat": [{ "number": 1, "formula": "bat", "count": "1,500" }],
-                "fd": [{ "number": 3, "formula": "fd", "count": "300" }]
+                "wget": [{ "formula": "wget", "count": "500" }],
+                "bat": [{ "formula": "bat", "count": "1,500" }],
+                "fd": [{ "formula": "fd", "count": "300" }]
               }
             }
             """,
@@ -564,9 +564,9 @@ private enum DiscoverAnalyticsFixtures {
               "start_date": "2026-04-17",
               "end_date": "2026-05-17",
               "formulae": {
-                "iterm2": [{ "number": 2, "cask": "iterm2", "count": "400" }],
-                "raycast": [{ "number": 1, "cask": "raycast", "count": "450" }],
-                "docker-desktop": [{ "number": 3, "cask": "docker-desktop", "count": "50" }]
+                "iterm2": [{ "cask": "iterm2", "count": "400" }],
+                "raycast": [{ "cask": "raycast", "count": "450" }],
+                "docker-desktop": [{ "cask": "docker-desktop", "count": "50" }]
               }
             }
             """,
@@ -598,9 +598,9 @@ private enum DiscoverAnalyticsFixtures {
               "start_date": "2026-04-17",
               "end_date": "2026-05-17",
               "formulae": {
-                "missing": [{ "number": 1, "formula": "missing", "count": "2,000" }],
-                "bat": [{ "number": 2, "formula": "bat", "count": "1,500" }],
-                "wget": [{ "number": 3, "formula": "wget", "count": "500" }]
+                "missing": [{ "formula": "missing", "count": "2,000" }],
+                "bat": [{ "formula": "bat", "count": "1,500" }],
+                "wget": [{ "formula": "wget", "count": "500" }]
               }
             }
             """,

--- a/Tests/BrewRepositoriesTests/BrewDiscoverPackagesRepositoryTests.swift
+++ b/Tests/BrewRepositoriesTests/BrewDiscoverPackagesRepositoryTests.swift
@@ -37,7 +37,7 @@ struct BrewDiscoverPackagesRepositoryTests {
         ])
     }
 
-    @Test @MainActor func `load parses string counts and honors backend rank`() async throws {
+    @Test @MainActor func `load parses string counts and breaks equal counts by name`() async throws {
         let prefix = uniquePrefix()
         defer { cleanup(prefix) }
         let formulaAnalytics = analyticsData(

--- a/Tests/BrewRepositoriesTests/BrewDiscoverPackagesRepositoryTests.swift
+++ b/Tests/BrewRepositoriesTests/BrewDiscoverPackagesRepositoryTests.swift
@@ -47,20 +47,20 @@ struct BrewDiscoverPackagesRepositoryTests {
         ])
     }
 
-    @Test @MainActor func `loadTopPackages supports string counts and tie break sorting`() async throws {
+    @Test @MainActor func `loadTopPackages parses string counts and honors backend rank`() async throws {
         let prefix = uniquePrefix()
         defer { cleanup(prefix) }
         let formulaAnalytics = analyticsData(
             """
             {
               "category": "formula_install_on_request",
-              "total_items": "2",
-              "total_count": "1,000",
+              "total_items": 2,
+              "total_count": 1000,
               "start_date": "2026-04-17",
               "end_date": "2026-05-17",
               "formulae": {
-                "alpha": [{ "formula": "alpha", "count": "400" }],
-                "beta": [{ "formula": "beta", "count": "400" }]
+                "alpha": [{ "number": 1, "formula": "alpha", "count": "400" }],
+                "beta": [{ "number": 2, "formula": "beta", "count": "400" }]
               }
             }
             """,
@@ -74,7 +74,7 @@ struct BrewDiscoverPackagesRepositoryTests {
               "start_date": "2026-04-17",
               "end_date": "2026-05-17",
               "formulae": {
-                "gamma": [{ "cask": "gamma", "count": "40" }]
+                "gamma": [{ "number": 1, "cask": "gamma", "count": "40" }]
               }
             }
             """,
@@ -143,7 +143,7 @@ struct BrewDiscoverPackagesRepositoryTests {
               "start_date": "2026-04-17",
               "end_date": "2026-05-17",
               "formulae": {
-                "wget": [{ "formula": "wget", "count": "10" }]
+                "wget": [{ "number": 1, "formula": "wget", "count": "10" }]
               }
             }
             """,
@@ -527,9 +527,9 @@ private enum DiscoverAnalyticsFixtures {
               "start_date": "2026-04-17",
               "end_date": "2026-05-17",
               "formulae": {
-                "wget": [{ "formula": "wget", "count": "500" }],
-                "bat": [{ "formula": "bat", "count": "1,500" }],
-                "fd": [{ "formula": "fd", "count": "300" }]
+                "wget": [{ "number": 2, "formula": "wget", "count": "500" }],
+                "bat": [{ "number": 1, "formula": "bat", "count": "1,500" }],
+                "fd": [{ "number": 3, "formula": "fd", "count": "300" }]
               }
             }
             """,
@@ -546,9 +546,9 @@ private enum DiscoverAnalyticsFixtures {
               "start_date": "2026-04-17",
               "end_date": "2026-05-17",
               "formulae": {
-                "iterm2": [{ "cask": "iterm2", "count": "400" }],
-                "raycast": [{ "cask": "raycast", "count": "450" }],
-                "docker-desktop": [{ "cask": "docker-desktop", "count": "50" }]
+                "iterm2": [{ "number": 2, "cask": "iterm2", "count": "400" }],
+                "raycast": [{ "number": 1, "cask": "raycast", "count": "450" }],
+                "docker-desktop": [{ "number": 3, "cask": "docker-desktop", "count": "50" }]
               }
             }
             """,
@@ -580,9 +580,9 @@ private enum DiscoverAnalyticsFixtures {
               "start_date": "2026-04-17",
               "end_date": "2026-05-17",
               "formulae": {
-                "missing": [{ "formula": "missing", "count": "2,000" }],
-                "bat": [{ "formula": "bat", "count": "1,500" }],
-                "wget": [{ "formula": "wget", "count": "500" }]
+                "missing": [{ "number": 1, "formula": "missing", "count": "2,000" }],
+                "bat": [{ "number": 2, "formula": "bat", "count": "1,500" }],
+                "wget": [{ "number": 3, "formula": "wget", "count": "500" }]
               }
             }
             """,

--- a/Tests/BrewRepositoriesTests/BrewDiscoverPackagesRepositoryTests.swift
+++ b/Tests/BrewRepositoriesTests/BrewDiscoverPackagesRepositoryTests.swift
@@ -15,7 +15,7 @@ import Testing
 struct BrewDiscoverPackagesRepositoryTests {
     // MARK: - Enrichment behaviour
 
-    @Test @MainActor func `loadTopPackages sorts descending and applies limit`() async throws {
+    @Test @MainActor func `load exposes ranked packages and applies limit`() async throws {
         let prefix = uniquePrefix()
         defer { cleanup(prefix) }
         let (repository, _) = makeRepository(
@@ -24,30 +24,20 @@ struct BrewDiscoverPackagesRepositoryTests {
             formulaCatalogueNames: ["wget", "bat", "fd"],
             caskCatalogueNames: ["iterm2", "raycast", "docker-desktop"],
             defaultsKeyPrefix: prefix,
+            topPackagesLimit: 2,
         )
 
-        let snapshot = try await repository.loadTopPackages(limit: 2, window: .days30)
-        #expect(snapshot.topFormulae == [
+        await repository.load()
+
+        #expect(try #require(repository.state.value) == [
             discoveryPackage(name: "bat", thirtyDayInstallCount: 1500, latestVersion: "1.0.0"),
             discoveryPackage(name: "wget", thirtyDayInstallCount: 500, latestVersion: "1.0.0"),
-        ])
-        #expect(snapshot.topCasks == [
-            discoveryPackage(
-                name: "raycast",
-                kind: .cask,
-                thirtyDayInstallCount: 450,
-                latestVersion: "2.0.0",
-            ),
-            discoveryPackage(
-                name: "iterm2",
-                kind: .cask,
-                thirtyDayInstallCount: 400,
-                latestVersion: "2.0.0",
-            ),
+            discoveryPackage(name: "raycast", kind: .cask, thirtyDayInstallCount: 450, latestVersion: "2.0.0"),
+            discoveryPackage(name: "iterm2", kind: .cask, thirtyDayInstallCount: 400, latestVersion: "2.0.0"),
         ])
     }
 
-    @Test @MainActor func `loadTopPackages parses string counts and honors backend rank`() async throws {
+    @Test @MainActor func `load parses string counts and honors backend rank`() async throws {
         let prefix = uniquePrefix()
         defer { cleanup(prefix) }
         let formulaAnalytics = analyticsData(
@@ -87,14 +77,16 @@ struct BrewDiscoverPackagesRepositoryTests {
             defaultsKeyPrefix: prefix,
         )
 
-        let snapshot = try await repository.loadTopPackages(limit: 10, window: .days30)
-        #expect(snapshot.topFormulae == [
+        await repository.load()
+
+        #expect(try #require(repository.state.value) == [
             discoveryPackage(name: "alpha", thirtyDayInstallCount: 400, latestVersion: "1.0.0"),
             discoveryPackage(name: "beta", thirtyDayInstallCount: 400, latestVersion: "1.0.0"),
+            discoveryPackage(name: "gamma", kind: .cask, thirtyDayInstallCount: 40, latestVersion: "2.0.0"),
         ])
     }
 
-    @Test @MainActor func `loadTopPackages excludes analytics entries missing from catalogue`() async throws {
+    @Test @MainActor func `load excludes analytics entries missing from catalogue`() async throws {
         let prefix = uniquePrefix()
         defer { cleanup(prefix) }
         let (repository, _) = makeRepository(
@@ -105,15 +97,15 @@ struct BrewDiscoverPackagesRepositoryTests {
             defaultsKeyPrefix: prefix,
         )
 
-        let snapshot = try await repository.loadTopPackages(limit: 10, window: .days30)
-        #expect(snapshot.topFormulae == [
+        await repository.load()
+
+        #expect(try #require(repository.state.value) == [
             discoveryPackage(name: "bat", thirtyDayInstallCount: 1500, latestVersion: "1.0.0"),
             discoveryPackage(name: "wget", thirtyDayInstallCount: 500, latestVersion: "1.0.0"),
         ])
-        #expect(snapshot.topCasks.isEmpty)
     }
 
-    @Test @MainActor func `loadTopPackages advances past unmatched analytics to fill limit`() async throws {
+    @Test @MainActor func `load advances past unmatched analytics to fill limit`() async throws {
         let prefix = uniquePrefix()
         defer { cleanup(prefix) }
         let (repository, _) = makeRepository(
@@ -122,16 +114,18 @@ struct BrewDiscoverPackagesRepositoryTests {
             formulaCatalogueNames: ["bat", "wget"],
             caskCatalogueNames: [],
             defaultsKeyPrefix: prefix,
+            topPackagesLimit: 2,
         )
 
-        let snapshot = try await repository.loadTopPackages(limit: 2, window: .days30)
-        #expect(snapshot.topFormulae == [
+        await repository.load()
+
+        #expect(try #require(repository.state.value) == [
             discoveryPackage(name: "bat", thirtyDayInstallCount: 1500, latestVersion: "1.0.0"),
             discoveryPackage(name: "wget", thirtyDayInstallCount: 500, latestVersion: "1.0.0"),
         ])
     }
 
-    @Test @MainActor func `loadTopPackages returns empty lists when limit is zero`() async throws {
+    @Test @MainActor func `load returns an empty list when limit is zero`() async throws {
         let prefix = uniquePrefix()
         defer { cleanup(prefix) }
         let analyticsPayload = analyticsData(
@@ -154,14 +148,15 @@ struct BrewDiscoverPackagesRepositoryTests {
             formulaCatalogueNames: ["wget"],
             caskCatalogueNames: ["wget"],
             defaultsKeyPrefix: prefix,
+            topPackagesLimit: 0,
         )
 
-        let snapshot = try await repository.loadTopPackages(limit: 0, window: .days30)
-        #expect(snapshot.topFormulae.isEmpty)
-        #expect(snapshot.topCasks.isEmpty)
+        await repository.load()
+
+        #expect(try #require(repository.state.value).isEmpty)
     }
 
-    @Test @MainActor func `loadTopPackages forwards client errors`() async throws {
+    @Test @MainActor func `load surfaces client errors as a failed state`() async {
         let prefix = uniquePrefix()
         defer { cleanup(prefix) }
         let repository = BrewDiscoverPackagesRepository(
@@ -170,9 +165,14 @@ struct BrewDiscoverPackagesRepositoryTests {
             cache: InMemoryDiscoverAnalyticsCache(),
             defaultsKeyPrefix: prefix,
         )
-        await #expect(throws: BrewAPIClientError.self) {
-            _ = try await repository.loadTopPackages(limit: 10, window: .days30)
+
+        await repository.load()
+
+        guard case let .failed(error) = repository.state else {
+            Issue.record("expected failed state")
+            return
         }
+        #expect(error is BrewAPIClientError)
     }
 
     // MARK: - 24-hour caching
@@ -186,10 +186,13 @@ struct BrewDiscoverPackagesRepositoryTests {
             formulaCatalogueNames: ["bat", "wget", "fd"],
             caskCatalogueNames: ["iterm2", "raycast", "docker-desktop"],
             defaultsKeyPrefix: prefix,
+            topPackagesLimit: 2,
         )
 
-        let first = try await repository.loadTopPackages(limit: 2, window: .days30)
-        let second = try await repository.loadTopPackages(limit: 2, window: .days30)
+        await repository.load()
+        let first = try #require(repository.state.value)
+        await repository.load()
+        let second = try #require(repository.state.value)
 
         #expect(first == second)
         // One formula + one cask fetch on the cold load; the warm load hits neither endpoint.
@@ -212,12 +215,13 @@ struct BrewDiscoverPackagesRepositoryTests {
             caskCatalogueNames: [],
             cache: cache,
             defaultsKeyPrefix: prefix,
+            topPackagesLimit: 2,
         )
         markFresh(repository, window: .days30)
 
-        let snapshot = try await repository.loadTopPackages(limit: 2, window: .days30)
+        await repository.load()
 
-        #expect(snapshot.topFormulae == [
+        #expect(try #require(repository.state.value) == [
             discoveryPackage(name: "bat", thirtyDayInstallCount: 1500, latestVersion: "1.0.0"),
             discoveryPackage(name: "wget", thirtyDayInstallCount: 500, latestVersion: "1.0.0"),
         ])
@@ -241,19 +245,20 @@ struct BrewDiscoverPackagesRepositoryTests {
             caskCatalogueNames: [],
             cache: cache,
             defaultsKeyPrefix: prefix,
+            topPackagesLimit: 2,
         )
         markStale(repository, window: .days30)
 
-        let snapshot = try await repository.loadTopPackages(limit: 2, window: .days30)
+        await repository.load()
 
-        #expect(snapshot.topFormulae == [
+        #expect(try #require(repository.state.value) == [
             discoveryPackage(name: "bat", thirtyDayInstallCount: 1500, latestVersion: "1.0.0"),
             discoveryPackage(name: "wget", thirtyDayInstallCount: 500, latestVersion: "1.0.0"),
         ])
         #expect(await spy.analyticsCallCount == 2)
     }
 
-    @Test @MainActor func `load refetches once the ttl has elapsed`() async throws {
+    @Test @MainActor func `load refetches once the ttl has elapsed`() async {
         let prefix = uniquePrefix()
         defer { cleanup(prefix) }
         let (repository, spy) = makeRepository(
@@ -262,14 +267,15 @@ struct BrewDiscoverPackagesRepositoryTests {
             formulaCatalogueNames: ["bat", "wget"],
             caskCatalogueNames: [],
             defaultsKeyPrefix: prefix,
+            topPackagesLimit: 2,
         )
 
-        _ = try await repository.loadTopPackages(limit: 2, window: .days30)
+        await repository.load()
         #expect(await spy.analyticsCallCount == 2)
 
         // Simulate more than 24h passing since the last refresh.
         markStale(repository, window: .days30)
-        _ = try await repository.loadTopPackages(limit: 2, window: .days30)
+        await repository.load()
 
         #expect(await spy.analyticsCallCount == 4)
     }
@@ -294,12 +300,13 @@ struct BrewDiscoverPackagesRepositoryTests {
             ),
             cache: cache,
             defaultsKeyPrefix: prefix,
+            topPackagesLimit: 2,
         )
         markStale(repository, window: .days30)
 
-        let snapshot = try await repository.loadTopPackages(limit: 2, window: .days30)
+        await repository.load()
 
-        #expect(snapshot.topFormulae == [
+        #expect(try #require(repository.state.value) == [
             discoveryPackage(name: "bat", thirtyDayInstallCount: 1500, latestVersion: "1.0.0"),
             discoveryPackage(name: "wget", thirtyDayInstallCount: 500, latestVersion: "1.0.0"),
         ])
@@ -307,7 +314,7 @@ struct BrewDiscoverPackagesRepositoryTests {
         #expect(await spy.analyticsCallCount == 2)
         #expect(await spy.receivedFormulaETags == [#""formula-e1""#])
         // ...and the refreshed timestamp means the next load serves from cache with no fetch.
-        _ = try await repository.loadTopPackages(limit: 2, window: .days30)
+        await repository.load()
         #expect(await spy.analyticsCallCount == 2)
     }
 
@@ -320,16 +327,19 @@ struct BrewDiscoverPackagesRepositoryTests {
             formulaCatalogueNames: ["bat", "wget"],
             caskCatalogueNames: [],
             defaultsKeyPrefix: prefix,
+            topPackagesLimit: 2,
             pendingError: BrewAPIClientError.transport(underlying: "offline"),
         )
 
-        await #expect(throws: BrewAPIClientError.self) {
-            _ = try await repository.loadTopPackages(limit: 2, window: .days30)
+        await repository.load()
+        guard case .failed = repository.state else {
+            Issue.record("expected failed state after the first load")
+            return
         }
 
         // The failed attempt left the window stale, so a second load retries and succeeds.
-        let snapshot = try await repository.loadTopPackages(limit: 2, window: .days30)
-        #expect(snapshot.topFormulae == [
+        await repository.load()
+        #expect(try #require(repository.state.value) == [
             discoveryPackage(name: "bat", thirtyDayInstallCount: 1500, latestVersion: "1.0.0"),
             discoveryPackage(name: "wget", thirtyDayInstallCount: 500, latestVersion: "1.0.0"),
         ])
@@ -345,14 +355,19 @@ struct BrewDiscoverPackagesRepositoryTests {
             formulaCatalogueNames: ["bat", "wget", "fd"],
             caskCatalogueNames: ["iterm2", "raycast", "docker-desktop"],
             defaultsKeyPrefix: prefix,
+            topPackagesLimit: 2,
         )
 
-        async let first = repository.loadTopPackages(limit: 2, window: .days30)
-        async let second = repository.loadTopPackages(limit: 2, window: .days30)
-        let firstSnapshot = try await first
-        let secondSnapshot = try await second
+        async let first: Void = repository.load()
+        async let second: Void = repository.load()
+        _ = await (first, second)
 
-        #expect(firstSnapshot == secondSnapshot)
+        #expect(try #require(repository.state.value) == [
+            discoveryPackage(name: "bat", thirtyDayInstallCount: 1500, latestVersion: "1.0.0"),
+            discoveryPackage(name: "wget", thirtyDayInstallCount: 500, latestVersion: "1.0.0"),
+            discoveryPackage(name: "raycast", kind: .cask, thirtyDayInstallCount: 450, latestVersion: "2.0.0"),
+            discoveryPackage(name: "iterm2", kind: .cask, thirtyDayInstallCount: 400, latestVersion: "2.0.0"),
+        ])
         #expect(await spy.analyticsCallCount == 2)
     }
 
@@ -374,8 +389,10 @@ struct BrewDiscoverPackagesRepositoryTests {
             caskCatalogueNames: [],
             cache: firstCache,
             defaultsKeyPrefix: fixture.repositoryDefaultsPrefix,
+            topPackagesLimit: 2,
         )
-        let firstSnapshot = try await firstRepository.loadTopPackages(limit: 2, window: .days30)
+        await firstRepository.load()
+        let firstPackages = try #require(firstRepository.state.value)
         #expect(await firstSpy.analyticsCallCount == 2)
 
         // Second launch: a brand-new cache instance reads the persisted bytes from disk.
@@ -391,14 +408,15 @@ struct BrewDiscoverPackagesRepositoryTests {
             caskCatalogueNames: [],
             cache: secondCache,
             defaultsKeyPrefix: fixture.repositoryDefaultsPrefix,
+            topPackagesLimit: 2,
         )
-        let relaunchSnapshot = try await secondRepository.loadTopPackages(limit: 2, window: .days30)
-        #expect(relaunchSnapshot == firstSnapshot)
+        await secondRepository.load()
+        #expect(try #require(secondRepository.state.value) == firstPackages)
         #expect(await secondSpy.analyticsCallCount == 0)
 
         // Once 24h has elapsed, the relaunched repository refetches.
         markStale(secondRepository, window: .days30)
-        _ = try await secondRepository.loadTopPackages(limit: 2, window: .days30)
+        await secondRepository.load()
         #expect(await secondSpy.analyticsCallCount == 2)
     }
 }
@@ -602,6 +620,7 @@ private func makeRepository(
     caskCatalogueNames: [String],
     cache: any DiscoverAnalyticsCaching = InMemoryDiscoverAnalyticsCache(),
     defaultsKeyPrefix: String,
+    topPackagesLimit: Int = 10,
     pendingError: (any Error)? = nil,
 ) -> (BrewDiscoverPackagesRepository, SpyBrewAPIClient) {
     let spy = SpyBrewAPIClient(
@@ -617,6 +636,7 @@ private func makeRepository(
         ),
         cache: cache,
         defaultsKeyPrefix: defaultsKeyPrefix,
+        topPackagesLimit: topPackagesLimit,
     )
     return (repository, spy)
 }


### PR DESCRIPTION
# PR: Preload Discover trending and make its repository observable

## Summary

Preloads the Discover tab's "Trending" list at app launch so the screen feels
instant on first visit, and reshapes the Discover data source to match the
observable pattern already used by `BrewInstalledPackagesRepository`. Also fixes
a decode bug that made trending fail on every load.

## Changes

- Converted `BrewDiscoverPackagesRepository` from an actor into an
  `@Observable @MainActor` source of truth exposing a
  `LoadState<[DiscoveryBrewPackage], any Error>`. Loads are cache-first, coalesce
  a single in-flight task, and re-fetch on return to the tab once the 24h TTL
  lapses. The protocol now vends `state` plus `load(forceRefresh:)`.
- `BrewApp` warms the catalogue and analytics caches, then preloads the trending
  list at window creation, ordered after its dependencies.
- `DiscoverViewModel` now reads repository `state` through a computed property and
  no longer re-ranks rows; sectioning is filter-only.
- Ranking moved into the analytics DTO. `BrewAnalyticsJSON` is now a thin wire
  mirror; `rankedPackageCounts()` derives order from install count with a name
  tie-break.

## Why this split

The DTO and ranking change lands first as its own step so the observable refactor
sits on a correct, well-tested data layer.

## Bug fix

The live Homebrew analytics API keys entries by name alphabetically and carries no
rank field. An earlier assumption decoded a required `number` field, so every real
response failed and trending showed an error every time. Ranking is now
reconstructed from `count`, and a kept end-to-end integration test drives the view
model through the real repository against a live-shaped payload to lock the shape in.

## Testing

- [x] `scripts/test` (624 tests pass)
- [x] SwiftFormat, SwiftLint, and BrewUILint clean
- [x] App target typecheck (swiftc -typecheck) passes

## PR checklist

- [x] Followed the repository's contribution and workflow guidance
- [x] Explained what changed and why it should land now
- [x] Ran relevant local checks for the changed scope
- [x] Changes are scoped and free of unrelated modifications

-----

- [x] AI was used to generate or assist with generating this PR.
- [x] Claude Code implemented the refactor and tests step by step; each commit was
  built, tested, and linted, and the API shape was verified against the live
  endpoint before the fix landed.
