### PR TITLE
Upgrades: keep the header stable when a filter matches nothing

### DIFF
--- a/Sources/BrewFeatureInstalled/ViewModels/UpgradesViewModel.swift
+++ b/Sources/BrewFeatureInstalled/ViewModels/UpgradesViewModel.swift
@@ -387,9 +387,6 @@ extension UpgradesViewModel {
     /// What "Upgrade All" upgrades, given the active filters:
     /// - A search narrows the batch to the visible rows by name (`brew upgrade git slack`).
     /// - Otherwise the scope picker maps to everything / `--formula` / `--cask`.
-    ///
-    /// A search matching nothing falls back to the scope: ``BrewUpgradeSelection/explicit(_:)`` with an
-    /// empty name list would display — and run — as a bare `brew upgrade`, the opposite of what it means.
     var upgradeSelection: BrewUpgradeSelection {
         if isSearchActive, !allRows.isEmpty {
             return .explicit(allRows.map(\.name))

--- a/Sources/BrewFeatureInstalled/ViewModels/UpgradesViewModel.swift
+++ b/Sources/BrewFeatureInstalled/ViewModels/UpgradesViewModel.swift
@@ -332,14 +332,66 @@ extension UpgradesViewModel {
         upgradeSelection.displayCommand
     }
 
+    var bulkUpgradeSummary: String {
+        switch upgradeSelection {
+        case .all:
+            String(
+                localized: "Upgrades every outdated package",
+                comment: "Upgrades header command summary for an unfiltered batch",
+            )
+        case .formulae:
+            String(
+                localized: "Upgrades every outdated formula",
+                comment: "Upgrades header command summary scoped to formulae",
+            )
+        case .casks:
+            String(
+                localized: "Upgrades every outdated cask",
+                comment: "Upgrades header command summary scoped to casks",
+            )
+        case let .explicit(names):
+            Self.searchedUpgradeSummary(count: names.count)
+        }
+    }
+
+    private static func searchedUpgradeSummary(count: Int) -> String {
+        if count == 1 {
+            return String(
+                localized: "Upgrades the 1 package matching your search",
+                comment: "Upgrades header command summary for a single searched package",
+            )
+        }
+        return String(
+            localized: "Upgrades the \(count) packages matching your search",
+            comment: "Upgrades header command summary for multiple searched packages",
+        )
+    }
+
+    var isFilteringOutEveryUpgrade: Bool {
+        outdatedCount == 0 && totalOutdatedCount > 0
+    }
+
+    var emptyUpgradeActionTitle: String {
+        if isFilteringOutEveryUpgrade {
+            return String(
+                localized: "Nothing to upgrade here",
+                comment: "Upgrades header stand-in when filters hide every available upgrade",
+            )
+        }
+        return String(
+            localized: "Nothing to upgrade",
+            comment: "Upgrades header stand-in when no package is outdated",
+        )
+    }
+
     /// What "Upgrade All" upgrades, given the active filters:
     /// - A search narrows the batch to the visible rows by name (`brew upgrade git slack`).
     /// - Otherwise the scope picker maps to everything / `--formula` / `--cask`.
     ///
-    /// The button is gated on `outdatedCount > 0`, so ``BrewUpgradeSelection/explicit(_:)`` is never
-    /// submitted with an empty name list.
+    /// A search matching nothing falls back to the scope: ``BrewUpgradeSelection/explicit(_:)`` with an
+    /// empty name list would display — and run — as a bare `brew upgrade`, the opposite of what it means.
     var upgradeSelection: BrewUpgradeSelection {
-        if isSearchActive {
+        if isSearchActive, !allRows.isEmpty {
             return .explicit(allRows.map(\.name))
         }
         switch scope {

--- a/Sources/BrewFeatureInstalled/Views/UpgradesPackagesView.swift
+++ b/Sources/BrewFeatureInstalled/Views/UpgradesPackagesView.swift
@@ -58,7 +58,6 @@ struct UpgradesPackagesView: View {
             .accessibilityElement(children: .combine)
             .accessibilityHeading(.h1)
 
-            // Held at a constant height whatever the filters match, so the list below doesn't jump.
             if viewModel.state.isLoaded {
                 CommandBlockView(
                     command: viewModel.bulkUpgradeDisplayCommand,
@@ -93,13 +92,13 @@ struct UpgradesPackagesView: View {
 
     private var nothingToUpgradeIndicator: some View {
         HStack {
-            Image(systemName: "checkmark.circle.fill").foregroundStyle(Color.brewStatusSuccess).font(.brewBody)
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(Color.brewStatusSuccess)
+                .accessibilityHidden(true)
             Text(viewModel.emptyUpgradeActionTitle)
-                .font(.brewBody)
                 .foregroundStyle(Color.brewTextSecondary)
-                .accessibilityElement(children: .combine)
-                .accessibilityLabel(viewModel.emptyUpgradeActionTitle)
         }
+        .font(.brewBody)
     }
 
     /// Kind filter shown whenever there is outdated inventory to narrow. Filters client-side; never refetches.

--- a/Sources/BrewFeatureInstalled/Views/UpgradesPackagesView.swift
+++ b/Sources/BrewFeatureInstalled/Views/UpgradesPackagesView.swift
@@ -58,12 +58,22 @@ struct UpgradesPackagesView: View {
             .accessibilityElement(children: .combine)
             .accessibilityHeading(.h1)
 
-            if viewModel.outdatedCount > 0 {
+            // Held at a constant height whatever the filters match, so the list below doesn't jump.
+            if viewModel.state.isLoaded {
                 CommandBlockView(
                     command: viewModel.bulkUpgradeDisplayCommand,
-                    summaryText: "Upgrades every outdated package",
+                    summaryText: viewModel.bulkUpgradeSummary,
                 )
 
+                upgradeAction
+            }
+        }
+        .padding(BrewSpacing.lg)
+    }
+
+    private var upgradeAction: some View {
+        Group {
+            if viewModel.outdatedCount > 0 {
                 Button {
                     viewModel.upgradeAll()
                 } label: {
@@ -74,9 +84,22 @@ struct UpgradesPackagesView: View {
                 .keyboardShortcut("u", modifiers: [.command, .shift])
                 .disabled(viewModel.isUpgradingAny)
                 .accessibilityLabel("Upgrade all \(viewModel.outdatedCount) packages")
+            } else {
+                nothingToUpgradeIndicator
             }
         }
-        .padding(BrewSpacing.lg)
+        .frame(height: BrewLayout.headerActionHeight)
+    }
+
+    private var nothingToUpgradeIndicator: some View {
+        HStack {
+            Image(systemName: "checkmark.circle.fill").foregroundStyle(Color.brewStatusSuccess).font(.brewBody)
+            Text(viewModel.emptyUpgradeActionTitle)
+                .font(.brewBody)
+                .foregroundStyle(Color.brewTextSecondary)
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(viewModel.emptyUpgradeActionTitle)
+        }
     }
 
     /// Kind filter shown whenever there is outdated inventory to narrow. Filters client-side; never refetches.
@@ -261,6 +284,21 @@ struct UpgradesPackagesView: View {
             .environment(\.brewCommandCenter, PreviewSupport.commandCenter)
             .task {
                 await viewModel.load()
+            }
+            .frame(minWidth: 360, minHeight: 500)
+    }
+
+    #Preview("Upgrades list - filtered to nothing") {
+        let viewModel = UpgradesViewModel(
+            repository: PreviewSupport.makeInstalledPackagesRepository(),
+            brewCommandCenter: PreviewSupport.commandCenter,
+            commandFactory: PreviewSupport.mutatingCommandFactory,
+        )
+        UpgradesPackagesView(viewModel: viewModel)
+            .environment(\.brewCommandCenter, PreviewSupport.commandCenter)
+            .task {
+                await viewModel.load()
+                viewModel.searchQuery = "no-such-package"
             }
             .frame(minWidth: 360, minHeight: 500)
     }

--- a/Sources/BrewUIComponents/Theme/BrewSpacing.swift
+++ b/Sources/BrewUIComponents/Theme/BrewSpacing.swift
@@ -48,6 +48,10 @@ public enum BrewLayout {
     public static let installedDetailColumnMaxWidth: CGFloat = 1200
     public static let installedThreePaneMinWindowWidth: CGFloat = 960
 
+    /// Call-to-action row in a pane header. Clears a `.regular` bordered button, so pinning the row to it
+    /// leaves the button's own metrics alone while giving anything that stands in for it the same height.
+    public static let headerActionHeight: CGFloat = 28
+
     /// Default window width.
     public static let defaultWindowWidth: CGFloat = 1000
 

--- a/Tests/BrewFeatureInstalledTests/UpgradesViewModelScopeTests.swift
+++ b/Tests/BrewFeatureInstalledTests/UpgradesViewModelScopeTests.swift
@@ -190,7 +190,6 @@ struct UpgradesViewModelScopeTests {
 
         vm.searchQuery = "no-such-package"
 
-        // An empty `.explicit([])` would display and run as a bare `brew upgrade`.
         #expect(vm.outdatedCount == 0)
         #expect(vm.upgradeSelection == .all)
         #expect(vm.bulkUpgradeDisplayCommand == "brew upgrade")
@@ -226,7 +225,6 @@ struct UpgradesViewModelScopeTests {
         vm.searchQuery = "wget"
         #expect(vm.bulkUpgradeSummary == "Upgrades the 1 package matching your search")
 
-        // No matches falls back to the scope selection, so the summary follows it.
         vm.searchQuery = "no-such-package"
         #expect(vm.bulkUpgradeSummary == "Upgrades every outdated package")
     }
@@ -241,7 +239,6 @@ struct UpgradesViewModelScopeTests {
         #expect(vm.isFilteringOutEveryUpgrade)
         #expect(vm.emptyUpgradeActionTitle == "Nothing to upgrade here")
 
-        // Nothing outdated at all: not a filtering problem, even with a filter applied.
         let upToDate = Self.makeViewModel(packages: [
             .fixture(name: "git", kind: .formula, outdated: false),
         ])

--- a/Tests/BrewFeatureInstalledTests/UpgradesViewModelScopeTests.swift
+++ b/Tests/BrewFeatureInstalledTests/UpgradesViewModelScopeTests.swift
@@ -185,6 +185,86 @@ struct UpgradesViewModelScopeTests {
         #expect(vm.upgradeSelection == .explicit(["git"]))
     }
 
+    @Test @MainActor func `upgradeSelection falls back to the scope when a search matches nothing`() {
+        let vm = Self.makeViewModel(packages: Self.mixedOutdated)
+
+        vm.searchQuery = "no-such-package"
+
+        // An empty `.explicit([])` would display and run as a bare `brew upgrade`.
+        #expect(vm.outdatedCount == 0)
+        #expect(vm.upgradeSelection == .all)
+        #expect(vm.bulkUpgradeDisplayCommand == "brew upgrade")
+
+        vm.scope = .casks
+        #expect(vm.upgradeSelection == .casks)
+        #expect(vm.bulkUpgradeDisplayCommand == "brew upgrade --cask")
+    }
+
+    // MARK: - bulkUpgradeSummary
+
+    @Test @MainActor func `bulkUpgradeSummary describes the scoped selection`() {
+        let vm = Self.makeViewModel(packages: Self.mixedOutdated)
+        #expect(vm.bulkUpgradeSummary == "Upgrades every outdated package")
+
+        vm.scope = .formulae
+        #expect(vm.bulkUpgradeSummary == "Upgrades every outdated formula")
+
+        vm.scope = .casks
+        #expect(vm.bulkUpgradeSummary == "Upgrades every outdated cask")
+    }
+
+    @Test @MainActor func `bulkUpgradeSummary counts the searched packages`() {
+        let vm = Self.makeViewModel(packages: [
+            .fixture(name: "git", kind: .formula, outdated: true),
+            .fixture(name: "github", kind: .cask, outdated: true),
+            .fixture(name: "wget", kind: .formula, outdated: true),
+        ])
+
+        vm.searchQuery = "git"
+        #expect(vm.bulkUpgradeSummary == "Upgrades the 2 packages matching your search")
+
+        vm.searchQuery = "wget"
+        #expect(vm.bulkUpgradeSummary == "Upgrades the 1 package matching your search")
+
+        // No matches falls back to the scope selection, so the summary follows it.
+        vm.searchQuery = "no-such-package"
+        #expect(vm.bulkUpgradeSummary == "Upgrades every outdated package")
+    }
+
+    // MARK: - Empty upgrade action
+
+    @Test @MainActor func `isFilteringOutEveryUpgrade distinguishes hidden upgrades from none`() {
+        let vm = Self.makeViewModel(packages: Self.mixedOutdated)
+        #expect(!vm.isFilteringOutEveryUpgrade)
+
+        vm.searchQuery = "no-such-package"
+        #expect(vm.isFilteringOutEveryUpgrade)
+        #expect(vm.emptyUpgradeActionTitle == "Nothing to upgrade here")
+
+        // Nothing outdated at all: not a filtering problem, even with a filter applied.
+        let upToDate = Self.makeViewModel(packages: [
+            .fixture(name: "git", kind: .formula, outdated: false),
+        ])
+        #expect(!upToDate.isFilteringOutEveryUpgrade)
+        #expect(upToDate.emptyUpgradeActionTitle == "Nothing to upgrade")
+
+        upToDate.scope = .casks
+        #expect(!upToDate.isFilteringOutEveryUpgrade)
+        #expect(upToDate.emptyUpgradeActionTitle == "Nothing to upgrade")
+    }
+
+    @Test @MainActor func `scope that hides every upgrade reports the filtered title`() {
+        let vm = Self.makeViewModel(packages: [
+            .fixture(name: "git", kind: .formula, outdated: true),
+        ])
+
+        vm.scope = .casks
+
+        #expect(vm.outdatedCount == 0)
+        #expect(vm.isFilteringOutEveryUpgrade)
+        #expect(vm.emptyUpgradeActionTitle == "Nothing to upgrade here")
+    }
+
     // MARK: - upgradeAll submission
 
     @Test @MainActor func `upgradeAll submits the scoped selection as both id and command`() async {


### PR DESCRIPTION
# PR: Keep the Upgrades header stable when a filter matches nothing

## Summary

The Upgrades header hid the terminal command block and the Upgrade All button whenever the active scope or search matched no packages, so the list jumped up and back down as you moved between All, Formulae and Casks. The header now keeps its height in every filter state.

## Changes

- `UpgradesPackagesView`: the command block and the action row now render for any loaded inventory rather than only when `outdatedCount > 0`. The gate moved to `state.isLoaded` so a spinner or error state still does not promise a command.
- Added `upgradeAction`, which shows Upgrade All when there is something to run and a quiet "Nothing to upgrade" status label otherwise. A disabled button read as a dead control, so this is a plain label with a success checkmark. The row is pinned to a new `BrewLayout.headerActionHeight` token (28pt), applied to the row rather than the button, so the button keeps its native `.regular` bordered metrics.
- Copy varies by cause: "Nothing to upgrade here" when filters are hiding upgrades, "Nothing to upgrade" when nothing is outdated at all.
- `UpgradesViewModel.bulkUpgradeSummary` replaces the hardcoded "Upgrades every outdated package" footer. It now tracks the selection, so a scope filter reads "every outdated formula" or "every outdated cask" and a search reads "the N packages matching your search". The old string was already wrong under a scope filter and would have been wrong more often now the block is always visible.
- `upgradeSelection` falls back to the scope when a search matches nothing. It previously returned `.explicit([])`, which renders as a bare `brew upgrade`, so the always visible command block would have claimed a zero match search upgrades everything.
- Added a preview for the filtered-to-nothing state.

## Testing

- [x] `scripts/test` (631 + 19 tests, exits 0)
- [x] `swiftformat --lint .`, `swiftlint lint --strict`, BrewUILint over Homebrew + Sources
- [x] Five new cases in `UpgradesViewModelScopeTests` covering the empty search fallback, all four summary variants, and the filtered versus empty title split
- [x] Visual check in the running app still to do. The 28pt row height is reasoned from `.regular` bordered button metrics, not measured

## PR checklist

- [x] Have you followed this repository's contribution and workflow guidance?
- [x] Have you explained what changed and why this should land now?
- [x] Have you run relevant local checks for the changed scope?
- [x] Are changes scoped and free of unrelated modifications?

-----

- [x] AI was used to generate or assist with generating this PR.
- [x] Claude wrote the view model logic, the view restructure and the tests from a description of the layout bug. I reworked the empty state indicator by hand and reviewed the comments down to why-notes and public API docs. Local test, lint and format gates were run and pass. The rendered result has not been checked in the app yet.
