### PR TITLE
Discover: don't steal search focus when the query is cleared

### DIFF
--- a/Sources/BrewFeatureDiscover/ViewModels/DiscoverViewModel.swift
+++ b/Sources/BrewFeatureDiscover/ViewModels/DiscoverViewModel.swift
@@ -76,8 +76,13 @@ final class DiscoverViewModel {
         isSearching ? results : trending
     }
 
+    /// Bound to `.searchable(isPresented:)`; lives here so ``shouldFocusList`` can factor it in.
+    var isSearchFieldPresented: Bool = false
+
+    /// Never claims focus while the search field is open — clearing the query back to empty must not
+    /// kick the cursor out of it.
     var shouldFocusList: Bool {
-        trending.isLoaded && !isSearching
+        trending.isLoaded && !isSearching && !isSearchFieldPresented
     }
 
     /// Search results have no analytics, so install-count metadata is suppressed in that mode.

--- a/Sources/BrewFeatureDiscover/Views/DiscoverPackagesView.swift
+++ b/Sources/BrewFeatureDiscover/Views/DiscoverPackagesView.swift
@@ -5,7 +5,6 @@ import SwiftUI
 /// Middle column of the main window: Discover package list.
 struct DiscoverPackagesView: View {
     @Bindable var viewModel: DiscoverViewModel
-    @State private var searchPresented = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -24,11 +23,11 @@ struct DiscoverPackagesView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .searchable(
             text: $viewModel.query,
-            isPresented: $searchPresented,
+            isPresented: $viewModel.isSearchFieldPresented,
             placement: .toolbar,
             prompt: "Search Homebrew's Packages",
         )
-        .focusedSceneValue(\.searchPresented, $searchPresented)
+        .focusedSceneValue(\.searchPresented, $viewModel.isSearchFieldPresented)
         .task(id: viewModel.query) {
             // Debounce so intermediate keystrokes don't each fire a search; cancellation handles the rest.
             try? await Task.sleep(for: .milliseconds(250))

--- a/Tests/BrewFeatureDiscoverTests/DiscoverViewModelTests.swift
+++ b/Tests/BrewFeatureDiscoverTests/DiscoverViewModelTests.swift
@@ -632,6 +632,64 @@ struct DiscoverViewModelTests {
 
         #expect(!viewModel.shouldFocusList)
     }
+
+    @Test @MainActor func `shouldFocusList is false while the search field is presented`() async {
+        let viewModel = await loadedTrendingViewModel()
+
+        viewModel.isSearchFieldPresented = true
+
+        #expect(!viewModel.shouldFocusList)
+    }
+
+    @Test @MainActor func `shouldFocusList returns to true once the search field is dismissed`() async {
+        let viewModel = await loadedTrendingViewModel()
+
+        viewModel.isSearchFieldPresented = true
+        #expect(!viewModel.shouldFocusList)
+
+        viewModel.isSearchFieldPresented = false
+        #expect(viewModel.shouldFocusList)
+    }
+
+    @Test @MainActor func `shouldFocusList stays false when the query is cleared while the field is presented`() async {
+        let viewModel = await loadedTrendingViewModel()
+
+        viewModel.isSearchFieldPresented = true
+        viewModel.query = "git"
+        #expect(!viewModel.shouldFocusList)
+
+        viewModel.query = ""
+
+        #expect(!viewModel.shouldFocusList)
+    }
+
+    @Test @MainActor func `shouldFocusList stays false when the field is presented but trending has not loaded`() {
+        let viewModel = DiscoverViewModel(
+            discoverPackagesRepository: StubDiscoverPackagesRepository(state: .loading),
+            catalogueRepository: StubCatalogueRepository(),
+            installedRepository: installedRepo(),
+        )
+
+        viewModel.isSearchFieldPresented = true
+
+        #expect(!viewModel.shouldFocusList)
+    }
+
+    @MainActor
+    private func loadedTrendingViewModel() async -> DiscoverViewModel {
+        let viewModel = DiscoverViewModel(
+            discoverPackagesRepository: StubDiscoverPackagesRepository(
+                snapshot: DiscoverTopPackagesSnapshot(
+                    topFormulae: [discoveryPackage(name: "git", thirtyDayInstallCount: 100)],
+                    topCasks: [],
+                ),
+            ),
+            catalogueRepository: StubCatalogueRepository(),
+            installedRepository: installedRepo(),
+        )
+        await viewModel.load()
+        return viewModel
+    }
 }
 
 @Observable


### PR DESCRIPTION
# PR: Discover: don't steal search focus when the query is cleared

## Summary

On the Discover screen, focusing the search field, typing, then deleting back to an empty query knocked the cursor out of the search field. The package list was claiming keyboard focus the moment the query went empty.

## Changes

- `DiscoverViewModel`: `shouldFocusList` was `trending.isLoaded && !isSearching`, so clearing the last character flipped it back to true and the list grabbed focus. It now also requires that the search field is closed.
- `DiscoverViewModel`: added `isSearchFieldPresented`, mirroring the pattern the Installed and Upgrades tabs already use, so the focus decision stays in the view model and is unit testable.
- `DiscoverPackagesView`: dropped the local `searchPresented` state and bound `.searchable(isPresented:)` and `.focusedSceneValue` to the view model instead.
- `DiscoverViewModelTests`: covers field presented, field dismissed, presented before trending loads, and a regression test for the type-then-clear sequence.

Behaviour is otherwise unchanged: the list still takes focus once trending loads on a cold open.

## Testing

- [x] `scripts/test` passes for both packages.
- [x] `swiftformat --lint`, `swiftlint --strict` and BrewUILint are clean.

## PR checklist

- [x] Have you followed this repository's contribution and workflow guidance?
- [x] Have you explained what changed and why this should land now?
- [x] Have you run relevant local checks for the changed scope?
- [x] Are changes scoped and free of unrelated modifications?

-----

- [x] AI was used to generate or assist with generating this PR.
- [x] If yes, describe exactly how AI was used and what manual verification was performed.

Claude Code diagnosed the focus bug, wrote the fix and the tests, and ran the test, format and lint checks listed above. The original bug report and the cause were identified by a human; the fix was reviewed before commit. The bug itself has not been reproduced manually in the running app since the fix.