### PR TITLE
Tty conversion

### DIFF
--- a/Homebrew.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Homebrew.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "f643a9ba692112c683b49eb5cfeedddf95a3ede6d99e7b434e1467fd75e8c646",
+  "originHash" : "d4c9156b86c0e19120c6ea97b87fd29bd58ef67d661c8eac71269335ae22736f",
   "pins" : [
+    {
+      "identity" : "swift-subprocess",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-subprocess.git",
+      "state" : {
+        "revision" : "b3937ab85dd32f6e9435914599c1519074769c1a",
+        "version" : "1.0.0"
+      }
+    },
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
@@ -8,6 +17,15 @@
       "state" : {
         "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
         "version" : "602.0.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system",
+      "state" : {
+        "revision" : "704705c5c51156ede21172a38654d522ce487074",
+        "version" : "1.8.0"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "3a8c38daadbe8d3680d9ab6539cd679eca22d760ea4922effa380094d5189128",
+  "pins" : [
+    {
+      "identity" : "swift-subprocess",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-subprocess.git",
+      "state" : {
+        "revision" : "b3937ab85dd32f6e9435914599c1519074769c1a",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system",
+      "state" : {
+        "revision" : "704705c5c51156ede21172a38654d522ce487074",
+        "version" : "1.8.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -33,9 +33,6 @@ let package = Package(
         // needs. Confined to `BrewCLI` behind the `BrewCommandRunning` protocol, so it has exactly one conformer.
         // Version pinned exactly, per the same convention.
         .package(url: "https://github.com/swiftlang/swift-subprocess.git", exact: "1.0.0"),
-        // Already in the graph as swift-subprocess's own dependency; declared explicitly because
-        // `BrewCLI` names `FileDescriptor` directly when handing the pty replica to `Subprocess`.
-        .package(url: "https://github.com/apple/swift-system", exact: "1.8.0"),
     ],
     targets: [
         // Dependency-free by design: linked by both the app and the BrewUITests target, so it must
@@ -87,7 +84,6 @@ let package = Package(
             dependencies: [
                 "BrewCore",
                 .product(name: "Subprocess", package: "swift-subprocess"),
-                .product(name: "SystemPackage", package: "swift-system"),
             ],
             swiftSettings: [
                 .defaultIsolation(nil),

--- a/Package.swift
+++ b/Package.swift
@@ -25,6 +25,15 @@ let package = Package(
         .library(name: "BrewFeatureDoctor", targets: ["BrewFeatureDoctor"]),
         .library(name: "BrewFeatureConfig", targets: ["BrewFeatureConfig"]),
     ],
+    dependencies: [
+        // Justification (`CONVENTIONS.md` — Dependencies): running `brew` under a pseudo-terminal needs
+        // `setsid()` between fork and exec so the pty becomes the child's *controlling* terminal.
+        // `Foundation.Process` has no hook there and structurally cannot express it; `Subprocess` exposes it as
+        // `PlatformOptions.createSession`, along with the fd hand-off and process-group teardown the pty path
+        // needs. Confined to `BrewCLI` behind the `BrewCommandRunning` protocol, so it has exactly one conformer.
+        // Version pinned exactly, per the same convention.
+        .package(url: "https://github.com/swiftlang/swift-subprocess.git", exact: "1.0.0"),
+    ],
     targets: [
         // Dependency-free by design: linked by both the app and the BrewUITests target, so it must
         // not drag app code into the test bundle.
@@ -72,7 +81,10 @@ let package = Package(
         ),
         .target(
             name: "BrewCLI",
-            dependencies: ["BrewCore"],
+            dependencies: [
+                "BrewCore",
+                .product(name: "Subprocess", package: "swift-subprocess"),
+            ],
             swiftSettings: [
                 .defaultIsolation(nil),
                 .swiftLanguageMode(.v6),

--- a/Package.swift
+++ b/Package.swift
@@ -33,6 +33,9 @@ let package = Package(
         // needs. Confined to `BrewCLI` behind the `BrewCommandRunning` protocol, so it has exactly one conformer.
         // Version pinned exactly, per the same convention.
         .package(url: "https://github.com/swiftlang/swift-subprocess.git", exact: "1.0.0"),
+        // Already in the graph as swift-subprocess's own dependency; declared explicitly because
+        // `BrewCLI` names `FileDescriptor` directly when handing the pty replica to `Subprocess`.
+        .package(url: "https://github.com/apple/swift-system", exact: "1.8.0"),
     ],
     targets: [
         // Dependency-free by design: linked by both the app and the BrewUITests target, so it must
@@ -84,6 +87,7 @@ let package = Package(
             dependencies: [
                 "BrewCore",
                 .product(name: "Subprocess", package: "swift-subprocess"),
+                .product(name: "SystemPackage", package: "swift-system"),
             ],
             swiftSettings: [
                 .defaultIsolation(nil),

--- a/Package.swift
+++ b/Package.swift
@@ -26,12 +26,10 @@ let package = Package(
         .library(name: "BrewFeatureConfig", targets: ["BrewFeatureConfig"]),
     ],
     dependencies: [
-        // Justification (`CONVENTIONS.md` — Dependencies): running `brew` under a pseudo-terminal needs
-        // `setsid()` between fork and exec so the pty becomes the child's *controlling* terminal.
-        // `Foundation.Process` has no hook there and structurally cannot express it; `Subprocess` exposes it as
-        // `PlatformOptions.createSession`, along with the fd hand-off and process-group teardown the pty path
-        // needs. Confined to `BrewCLI` behind the `BrewCommandRunning` protocol, so it has exactly one conformer.
-        // Version pinned exactly, per the same convention.
+        // Justification (`CONVENTIONS.md` — Dependencies): a controlling-terminal pty needs `setsid()`
+        // between fork and exec, which `Foundation.Process` cannot express. `Subprocess` exposes it as
+        // `PlatformOptions.createSession`, plus the fd hand-off and process-group teardown the pty path
+        // needs. Confined to `BrewCLI` behind `BrewCommandRunning`, which has one production conformer.
         .package(url: "https://github.com/swiftlang/swift-subprocess.git", exact: "1.0.0"),
     ],
     targets: [

--- a/Sources/BrewCLI/BrewCommandService.swift
+++ b/Sources/BrewCLI/BrewCommandService.swift
@@ -5,6 +5,8 @@
 
 import BrewCore
 import Foundation
+import Subprocess
+import System
 
 /// Subprocess runner for Homebrew CLI (`ARCHITECTURE.md` — Command execution).
 public struct BrewCommandService: BrewCommandRunning {
@@ -17,136 +19,296 @@ public struct BrewCommandService: BrewCommandRunning {
     ) async throws -> CommandOutput {
         try Task.checkCancellation()
 
-        let process = Process()
-        process.executableURL = executableURL
-        process.arguments = arguments
-        let outPipe = Pipe()
-        let errPipe = Pipe()
-        process.standardOutput = outPipe
-        process.standardError = errPipe
-        process.standardInput = FileHandle.nullDevice
+        if options.usesPseudoTerminal {
+            return try await runOnPseudoTerminal(
+                executableURL: executableURL,
+                arguments: arguments,
+                options: options,
+            )
+        }
+        return try await runOnPipes(
+            executableURL: executableURL,
+            arguments: arguments,
+            options: options,
+        )
+    }
+}
 
-        // When nothing is observing, `sink` is nil and the drain skips the line-splitting work.
+// MARK: - Pseudo-terminal execution
+
+private extension BrewCommandService {
+    /// Runs the child against a pty, so `isatty` holds and Homebrew emits colour and progress on its own.
+    ///
+    /// One terminal device serves both stdout and stderr — that is what a terminal *is* — so the two
+    /// streams arrive interleaved in write order and every line is reported as
+    /// ``BrewCommandOutputLine/Stream/stdout``. ``CommandOutput/standardError`` is empty for these runs;
+    /// callers that need the streams apart must stay on the pipe path.
+    func runOnPseudoTerminal(
+        executableURL: URL,
+        arguments: [String],
+        options: BrewRunOptions,
+    ) async throws -> CommandOutput {
+        let terminal = try PseudoTerminal()
+        let childHasExited = TerminalDrainGate()
         let sink = options.lineObserver
 
-        // Homebrew strips colour when stdout isn't a TTY (which a `Pipe` never is); `HOMEBREW_COLOR` forces it
-        // back on, and `CLICOLOR_FORCE` does the same for the BSD-convention tools brew shells out to. Only ever
-        // set for display-only output (the scheduler never sets it for output that will be parsed).
-        if options.forceColor {
-            var environment = ProcessInfo.processInfo.environment
-            environment["HOMEBREW_COLOR"] = "1"
-            environment["CLICOLOR_FORCE"] = "1"
-            process.environment = environment
-        }
+        // Started before the spawn deliberately: the drain simply times out until there is something to
+        // read, and this process still holds the replica open, so it cannot see a premature end-of-input.
+        async let drained: Data = Self.drainTerminal(terminal, sink: sink, gate: childHasExited)
 
         do {
-            try process.run()
-        } catch {
-            throw BrewCommandError.launchFailed(underlying: String(describing: error))
-        }
-
-        let processController = ProcessController(process)
-        return try await withTaskCancellationHandler(operation: {
-            // Drain pipes concurrently while the subprocess runs.
-            // Large outputs (for example `brew info --installed --json=v2`) can deadlock
-            // if we wait for exit before reading from stdout/stderr.
-            async let outRead = Self.drainPipe(
-                handle: outPipe.fileHandleForReading,
-                stream: .stdout,
-                sink: sink,
-            )
-            async let errRead = Self.drainPipe(
-                handle: errPipe.fileHandleForReading,
-                stream: .stderr,
-                sink: sink,
+            let result = try await Subprocess.run(
+                .path(FilePath(executableURL.path)),
+                arguments: Arguments(arguments),
+                environment: Self.environment(for: options, isTerminal: true),
+                platformOptions: Self.platformOptions(),
+                input: .none,
+                output: .fileDescriptor(terminal.replicaDescriptor, closeAfterSpawningProcess: false),
+                error: .fileDescriptor(terminal.replicaDescriptor, closeAfterSpawningProcess: false),
+                body: { _ in
+                    // Runs once the child is spawned, which is the only safe moment to drop this
+                    // process's copy of the replica — see the ownership note on `PseudoTerminal`.
+                    terminal.closeReplica()
+                },
             )
 
-            let terminationStatus = await Self.waitForExit(process)
-            let outData = await outRead
-            let errData = await errRead
+            childHasExited.open()
+            let data = await drained
+            terminal.closePrimary()
             try Task.checkCancellation()
 
-            let stdout = String(bytes: outData, encoding: .utf8) ?? ""
-            let stderr = String(bytes: errData, encoding: .utf8) ?? ""
             return CommandOutput(
-                standardOutput: stdout,
-                standardError: stderr,
-                terminationStatus: terminationStatus,
+                standardOutput: String(bytes: data, encoding: .utf8) ?? "",
+                standardError: "",
+                terminationStatus: Self.exitCode(from: result.terminationStatus),
             )
-        }, onCancel: {
-            processController.terminateIfRunning()
-        })
+        } catch {
+            // Unblock and reap the drain before rethrowing, so no thread is left parked on the primary.
+            terminal.closeReplica()
+            childHasExited.open()
+            _ = await drained
+            terminal.closePrimary()
+
+            if error is CancellationError {
+                throw error
+            }
+            throw BrewCommandError.launchFailed(underlying: String(describing: error))
+        }
     }
 
-    /// Drains a subprocess pipe to EOF, returning the raw bytes verbatim for ``CommandOutput``.
-    /// When `sink` is non-nil, also emits each `\n`-terminated line through it as bytes arrive — the trailing
-    /// partial line (no terminating newline) is flushed on EOF if non-empty. Lines whose bytes aren't valid UTF-8
-    /// are dropped from the stream (they remain in the verbatim byte return).
-    private static func drainPipe(
-        handle: FileHandle,
-        stream: BrewCommandOutputLine.Stream,
+    /// Drains the terminal to end-of-input, emitting lines through `sink` as they arrive.
+    ///
+    /// Stops early when the child has exited and a full poll interval has passed with nothing to read.
+    /// That combination — process gone, terminal quiet — is what distinguishes "finished" from "a
+    /// grandchild is still holding the descriptor open", which would otherwise stall here indefinitely.
+    static func drainTerminal(
+        _ terminal: PseudoTerminal,
         sink: (@Sendable (BrewCommandOutputLine) -> Void)?,
+        gate: TerminalDrainGate,
     ) async -> Data {
         await withCheckedContinuation { (continuation: CheckedContinuation<Data, Never>) in
-            // `availableData` blocks; run on a GCD worker thread (matches `readAllData` behavior).
+            // `read` parks on `poll`; run it on a GCD worker rather than the cooperative pool.
             DispatchQueue.global(qos: .utility).async {
                 var fullOutput = Data()
                 var lineBuffer = Data()
-                while true {
-                    let chunk = handle.availableData
-                    if chunk.isEmpty {
-                        if let sink, !lineBuffer.isEmpty,
-                           let final = String(data: lineBuffer, encoding: .utf8)
-                        {
-                            sink(BrewCommandOutputLine(stream: stream, text: final))
+
+                loop: while true {
+                    switch terminal.read() {
+                    case let .data(chunk):
+                        fullOutput.append(chunk)
+                        if sink != nil {
+                            lineBuffer.append(chunk)
+                            emitCompleteLines(from: &lineBuffer, stream: .stdout, sink: sink)
                         }
-                        break
-                    }
-                    fullOutput.append(chunk)
-                    if let sink {
-                        lineBuffer.append(chunk)
-                        while let newlineIndex = lineBuffer.firstIndex(of: 0x0A) {
-                            let offset = lineBuffer.distance(from: lineBuffer.startIndex, to: newlineIndex)
-                            let lineData = lineBuffer.prefix(offset)
-                            if let lineText = String(data: lineData, encoding: .utf8) {
-                                sink(BrewCommandOutputLine(stream: stream, text: lineText))
-                            }
-                            lineBuffer = Data(lineBuffer.dropFirst(offset + 1))
+                    case .timedOut:
+                        if gate.isOpen {
+                            break loop
                         }
+                    case .endOfInput:
+                        break loop
                     }
                 }
-                continuation.resume(returning: fullOutput)
-            }
-        }
-    }
 
-    private static func waitForExit(_ process: Process) async -> Int32 {
-        await withCheckedContinuation { continuation in
-            // `waitUntilExit` blocks; run on a GCD worker thread.
-            DispatchQueue.global(qos: .utility).async {
-                process.waitUntilExit()
-                continuation.resume(returning: process.terminationStatus)
+                flushPartialLine(lineBuffer, stream: .stdout, sink: sink)
+                continuation.resume(returning: fullOutput)
             }
         }
     }
 }
 
-// `process` is the only non-Sendable stored state, and every access to it goes through `lock`; the
-// sole mutating call (`terminate`) runs under that lock, so concurrent use is serialised.
-// swiftlint:disable:next unchecked_sendable
-private final class ProcessController: @unchecked Sendable {
-    private let lock = NSLock()
-    private let process: Process
+// MARK: - Pipe execution
 
-    init(_ process: Process) {
-        self.process = process
+private extension BrewCommandService {
+    /// Runs the child against pipes: no terminal, stdout and stderr stay distinct. The path for output
+    /// that will be parsed.
+    func runOnPipes(
+        executableURL: URL,
+        arguments: [String],
+        options: BrewRunOptions,
+    ) async throws -> CommandOutput {
+        let sink = options.lineObserver
+
+        do {
+            let result = try await Subprocess.run(
+                .path(FilePath(executableURL.path)),
+                arguments: Arguments(arguments),
+                environment: Self.environment(for: options, isTerminal: false),
+                platformOptions: Self.platformOptions(),
+                input: .none,
+                output: .sequence,
+                error: .sequence,
+                body: { execution in
+                    // Drained concurrently: waiting for exit before reading deadlocks on large outputs
+                    // such as `brew info --installed --json=v2`.
+                    async let outRead = Self.drainSequence(
+                        execution.standardOutput,
+                        stream: .stdout,
+                        sink: sink,
+                    )
+                    async let errRead = Self.drainSequence(
+                        execution.standardError,
+                        stream: .stderr,
+                        sink: sink,
+                    )
+                    return await (outRead, errRead)
+                },
+            )
+
+            try Task.checkCancellation()
+            let (outData, errData) = result.closureResult
+            return CommandOutput(
+                standardOutput: String(bytes: outData, encoding: .utf8) ?? "",
+                standardError: String(bytes: errData, encoding: .utf8) ?? "",
+                terminationStatus: Self.exitCode(from: result.terminationStatus),
+            )
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            throw BrewCommandError.launchFailed(underlying: String(describing: error))
+        }
     }
 
-    func terminateIfRunning() {
+    /// Drains one of the subprocess's output streams, returning the raw bytes verbatim for
+    /// ``CommandOutput`` and emitting `\n`-terminated lines through `sink` as they arrive.
+    static func drainSequence(
+        _ sequence: SubprocessOutputSequence,
+        stream: BrewCommandOutputLine.Stream,
+        sink: (@Sendable (BrewCommandOutputLine) -> Void)?,
+    ) async -> Data {
+        var fullOutput = Data()
+        var lineBuffer = Data()
+
+        do {
+            for try await buffer in sequence {
+                let chunk = buffer.withUnsafeBytes { Data($0) }
+                fullOutput.append(chunk)
+                if sink != nil {
+                    lineBuffer.append(chunk)
+                    emitCompleteLines(from: &lineBuffer, stream: stream, sink: sink)
+                }
+            }
+        } catch {
+            // A read failure mid-stream still yields whatever was already collected; the exit status
+            // carried alongside it is what decides success or failure.
+        }
+
+        flushPartialLine(lineBuffer, stream: stream, sink: sink)
+        return fullOutput
+    }
+}
+
+// MARK: - Shared helpers
+
+private extension BrewCommandService {
+    /// Emits every complete `\n`-terminated line sitting in `buffer`, leaving any trailing partial line.
+    /// Lines whose bytes aren't valid UTF-8 are dropped from the stream (they remain in the verbatim bytes).
+    static func emitCompleteLines(
+        from buffer: inout Data,
+        stream: BrewCommandOutputLine.Stream,
+        sink: (@Sendable (BrewCommandOutputLine) -> Void)?,
+    ) {
+        guard let sink else {
+            return
+        }
+        while let newlineIndex = buffer.firstIndex(of: 0x0A) {
+            let offset = buffer.distance(from: buffer.startIndex, to: newlineIndex)
+            let lineData = buffer.prefix(offset)
+            if let lineText = String(bytes: lineData, encoding: .utf8) {
+                sink(BrewCommandOutputLine(stream: stream, text: lineText))
+            }
+            buffer = Data(buffer.dropFirst(offset + 1))
+        }
+    }
+
+    /// Emits a trailing line that arrived without a terminating newline.
+    static func flushPartialLine(
+        _ buffer: Data,
+        stream: BrewCommandOutputLine.Stream,
+        sink: (@Sendable (BrewCommandOutputLine) -> Void)?,
+    ) {
+        guard let sink, !buffer.isEmpty, let text = String(bytes: buffer, encoding: .utf8) else {
+            return
+        }
+        sink(BrewCommandOutputLine(stream: stream, text: text))
+    }
+
+    /// `createSession` puts the child in its own session, which is what makes the pty a *controlling*
+    /// terminal rather than merely a terminal-shaped descriptor, and it gives the child and everything it
+    /// spawns a process group of their own. Teardown then signals that whole group, so cancelling an
+    /// install also stops the `curl` or `git` it is waiting on instead of orphaning it.
+    static func platformOptions() -> PlatformOptions {
+        var platformOptions = PlatformOptions()
+        platformOptions.createSession = true
+        platformOptions.teardownSequence = [
+            .gracefulShutDown(toProcessGroup: true, allowedDurationToNextStep: .seconds(2)),
+        ]
+        return platformOptions
+    }
+
+    /// Homebrew strips colour when stdout isn't a TTY, so the pipe path forces it back on via
+    /// `HOMEBREW_COLOR` (and `CLICOLOR_FORCE` for the BSD-convention tools brew shells out to). The
+    /// terminal path needs neither — it *is* a TTY — but does need `TERM`, which a GUI process launched
+    /// from Finder or launchd does not inherit; without it, tools treat the terminal as capability-less
+    /// and suppress the colour and progress rendering the pty was allocated to get.
+    static func environment(for options: BrewRunOptions, isTerminal: Bool) -> Environment {
+        if isTerminal {
+            return .inherit.updating(["TERM": "xterm-256color"])
+        }
+        guard options.forceColor else {
+            return .inherit
+        }
+        return .inherit.updating(["HOMEBREW_COLOR": "1", "CLICOLOR_FORCE": "1"])
+    }
+
+    /// Maps a termination status onto the `Int32` exit code ``CommandOutput`` carries. A signalled child
+    /// becomes `128 + signal`, the shell convention, which keeps "non-zero means failure" true.
+    static func exitCode(from status: TerminationStatus) -> Int32 {
+        switch status {
+        case let .exited(code):
+            code
+        case let .signaled(signal):
+            128 + signal
+        }
+    }
+}
+
+/// One-way flag telling the terminal drain that the child has exited, so a quiet terminal now means
+/// "finished" rather than "waiting". Set from the task that awaits the subprocess, read from the drain's
+/// GCD worker, hence the lock.
+// swiftlint:disable:next unchecked_sendable
+private final class TerminalDrainGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var opened = false
+
+    var isOpen: Bool {
         lock.lock()
         defer { lock.unlock() }
-        if process.isRunning {
-            process.terminate()
-        }
+        return opened
+    }
+
+    func open() {
+        lock.lock()
+        defer { lock.unlock() }
+        opened = true
     }
 }

--- a/Sources/BrewCLI/BrewCommandService.swift
+++ b/Sources/BrewCLI/BrewCommandService.swift
@@ -10,7 +10,17 @@ import System
 
 /// Subprocess runner for Homebrew CLI (`ARCHITECTURE.md` — Command execution).
 public struct BrewCommandService: BrewCommandRunning {
-    public init() {}
+    private let makeTerminal: @Sendable () throws -> PseudoTerminal
+
+    public init() {
+        self.init(makeTerminal: { try PseudoTerminal() })
+    }
+
+    /// Seam for testing the pty-allocation failure path, which is otherwise only reachable by exhausting
+    /// the machine's pty devices.
+    init(makeTerminal: @escaping @Sendable () throws -> PseudoTerminal) {
+        self.makeTerminal = makeTerminal
+    }
 
     public func run(
         executableURL: URL,
@@ -19,8 +29,9 @@ public struct BrewCommandService: BrewCommandRunning {
     ) async throws -> CommandOutput {
         try Task.checkCancellation()
 
-        if options.usesPseudoTerminal {
+        if options.usesPseudoTerminal, let terminal = allocateTerminal() {
             return try await runOnPseudoTerminal(
+                terminal: terminal,
                 executableURL: executableURL,
                 arguments: arguments,
                 options: options,
@@ -29,8 +40,29 @@ public struct BrewCommandService: BrewCommandRunning {
         return try await runOnPipes(
             executableURL: executableURL,
             arguments: arguments,
-            options: options,
+            // A run that asked for a terminal and did not get one still wants colour: the terminal was
+            // the thing supplying it, so on this path Homebrew has to be told explicitly.
+            options: options.usesPseudoTerminal ? Self.colourisedPipeFallback(from: options) : options,
         )
+    }
+
+    /// Allocates a pty, or returns nil so the caller degrades to pipes.
+    ///
+    /// Allocation is an environmental resource that can genuinely run out — the device pool is much
+    /// smaller than `kern.tty.ptmx_max` suggests. Failing an install outright over it would be a poor
+    /// trade when the command runs perfectly well on pipes; the cost of degrading is Homebrew's progress
+    /// rendering, not the operation.
+    private func allocateTerminal() -> PseudoTerminal? {
+        try? makeTerminal()
+    }
+
+    /// The pipe-path options for a run that wanted a terminal: colour forced back on, streaming and
+    /// everything else preserved.
+    static func colourisedPipeFallback(from options: BrewRunOptions) -> BrewRunOptions {
+        var fallback = options
+        fallback.usesPseudoTerminal = false
+        fallback.forceColor = true
+        return fallback
     }
 }
 
@@ -44,11 +76,11 @@ private extension BrewCommandService {
     /// ``BrewCommandOutputLine/Stream/stdout``. ``CommandOutput/standardError`` is empty for these runs;
     /// callers that need the streams apart must stay on the pipe path.
     func runOnPseudoTerminal(
+        terminal: PseudoTerminal,
         executableURL: URL,
         arguments: [String],
         options: BrewRunOptions,
     ) async throws -> CommandOutput {
-        let terminal = try PseudoTerminal()
         let childHasExited = TerminalDrainGate()
         let sink = options.lineObserver
 

--- a/Sources/BrewCLI/BrewCommandService.swift
+++ b/Sources/BrewCLI/BrewCommandService.swift
@@ -71,10 +71,8 @@ private extension BrewCommandService {
     /// ``BrewCommandOutputLine/Stream/stdout``, and ``CommandOutput/standardError`` is empty. Callers that
     /// need the streams apart must stay on the pipe path.
     ///
-    /// ``CommandOutput/standardOutput`` is the *assembled* transcript, not the verbatim bytes: on a
-    /// terminal the raw bytes are a cursor script, in which a whole download is one line carrying every
-    /// intermediate redraw. Resolving the overwrites is what makes the text usable as the diagnostic for
-    /// a failed run, which is the only thing that reads it on this path.
+    /// ``CommandOutput/standardOutput`` is the assembled transcript, not the verbatim bytes: raw pty
+    /// bytes are a cursor script in which a whole download is one line of redraws.
     func runOnPseudoTerminal(
         terminal: PseudoTerminal,
         executableURL: URL,
@@ -132,9 +130,6 @@ private extension BrewCommandService {
     ///
     /// Stops once the child has exited and a poll interval has passed with nothing to read. Waiting for
     /// end-of-input instead would stall on any grandchild still holding the descriptor open.
-    ///
-    /// Returns the settled lines as one transcript. The assembler runs whether or not anyone is
-    /// streaming, because that transcript is the run's only readable output.
     static func drainTerminal(
         _ terminal: PseudoTerminal,
         sink: (@Sendable (BrewCommandOutputLine) -> Void)?,
@@ -175,8 +170,7 @@ private extension BrewCommandService {
                     transcript += trailing.text
                     sink?(BrewCommandOutputLine(stream: .stdout, line: trailing, isComplete: true))
                 }
-                // Surfaced rather than swallowed: the exit status may still say success, and without this
-                // the truncation is indistinguishable from the command simply having said less.
+                // The exit status may still say success, so truncation has to say so itself.
                 if let readFailure {
                     let notice = truncationNotice(errno: readFailure)
                     transcript += transcript.isEmpty || transcript.hasSuffix("\n") ? notice : "\n" + notice
@@ -243,7 +237,6 @@ private extension BrewCommandService {
 
             try Task.checkCancellation()
             let (outData, errData) = result.closureResult
-            // Lossy on purpose: one undecodable byte would otherwise discard the whole output.
             return CommandOutput(
                 standardOutput: UTF8StreamDecoder.lossyString(outData),
                 standardError: UTF8StreamDecoder.lossyString(errData),
@@ -286,8 +279,6 @@ private extension BrewCommandService {
 // MARK: - Shared helpers
 
 private extension BrewCommandService {
-    /// Undecodable bytes become U+FFFD rather than costing the line it sits in, which the failable
-    /// initialiser would have dropped from the stream entirely.
     static func emitCompleteLines(
         from buffer: inout Data,
         stream: BrewCommandOutputLine.Stream,

--- a/Sources/BrewCLI/BrewCommandService.swift
+++ b/Sources/BrewCLI/BrewCommandService.swift
@@ -98,6 +98,11 @@ private extension BrewCommandService {
 
     /// Drains the terminal to end-of-input, emitting lines through `sink` as they arrive.
     ///
+    /// Output goes through ``TerminalLineAssembler`` rather than being split on newlines, because a
+    /// terminal's redraws are separated by carriage returns rather than newlines — a whole download is
+    /// one "line" by that measure. The assembler resolves the overwrites and reports the line while it is
+    /// still being drawn, which is what lets the console animate a progress bar in place.
+    ///
     /// Stops early when the child has exited and a full poll interval has passed with nothing to read.
     /// That combination — process gone, terminal quiet — is what distinguishes "finished" from "a
     /// grandchild is still holding the descriptor open", which would otherwise stall here indefinitely.
@@ -110,15 +115,18 @@ private extension BrewCommandService {
             // `read` parks on `poll`; run it on a GCD worker rather than the cooperative pool.
             DispatchQueue.global(qos: .utility).async {
                 var fullOutput = Data()
-                var lineBuffer = Data()
+                var undecoded = Data()
+                var assembler = TerminalLineAssembler()
 
                 loop: while true {
                     switch terminal.read() {
                     case let .data(chunk):
                         fullOutput.append(chunk)
                         if sink != nil {
-                            lineBuffer.append(chunk)
-                            emitCompleteLines(from: &lineBuffer, stream: .stdout, sink: sink)
+                            undecoded.append(chunk)
+                            for event in assembler.consume(takeDecodableUTF8Prefix(&undecoded)) {
+                                emit(event, sink: sink)
+                            }
                         }
                     case .timedOut:
                         if gate.isOpen {
@@ -129,10 +137,48 @@ private extension BrewCommandService {
                     }
                 }
 
-                flushPartialLine(lineBuffer, stream: .stdout, sink: sink)
+                // Output that ended without a trailing newline is settled by the stream ending.
+                if let sink, let trailing = assembler.flush() {
+                    sink(BrewCommandOutputLine(stream: .stdout, line: trailing, isComplete: true))
+                }
                 continuation.resume(returning: fullOutput)
             }
         }
+    }
+
+    /// Forwards one assembler event as an output line. Everything from a terminal is reported on
+    /// ``BrewCommandOutputLine/Stream/stdout``: one device carries both streams, so they cannot be told apart.
+    static func emit(_ event: TerminalLineEvent, sink: (@Sendable (BrewCommandOutputLine) -> Void)?) {
+        guard let sink else {
+            return
+        }
+        switch event {
+        case let .committed(line):
+            sink(BrewCommandOutputLine(stream: .stdout, line: line, isComplete: true))
+        case let .revised(line):
+            sink(BrewCommandOutputLine(stream: .stdout, line: line, isComplete: false))
+        }
+    }
+
+    /// Takes the longest valid UTF-8 prefix of `buffer`, leaving any trailing bytes behind.
+    ///
+    /// Terminal reads land on arbitrary byte boundaries, so a multi-byte character can be split across two
+    /// reads. Holding the remainder until the rest arrives keeps such a character intact instead of
+    /// dropping it. A sequence can be at most four bytes, so at most three trailing bytes are ever held;
+    /// beyond that the bytes are genuinely undecodable and one is dropped so the drain cannot stall.
+    static func takeDecodableUTF8Prefix(_ buffer: inout Data) -> String {
+        guard !buffer.isEmpty else {
+            return ""
+        }
+        for dropped in 0 ... min(3, buffer.count) {
+            let candidate = buffer.prefix(buffer.count - dropped)
+            if let text = String(bytes: candidate, encoding: .utf8) {
+                buffer = Data(buffer.dropFirst(candidate.count))
+                return text
+            }
+        }
+        buffer = Data(buffer.dropFirst())
+        return ""
     }
 }
 

--- a/Sources/BrewCLI/BrewCommandService.swift
+++ b/Sources/BrewCLI/BrewCommandService.swift
@@ -29,7 +29,18 @@ public struct BrewCommandService: BrewCommandRunning {
     ) async throws -> CommandOutput {
         try Task.checkCancellation()
 
-        if options.usesPseudoTerminal, let terminal = allocateTerminal() {
+        switch options.output {
+        case .pipes:
+            return try await runOnPipes(executableURL: executableURL, arguments: arguments, options: options)
+
+        case .pseudoTerminal:
+            guard let terminal = allocateTerminal() else {
+                return try await runOnPipes(
+                    executableURL: executableURL,
+                    arguments: arguments,
+                    options: Self.pipeFallback(from: options),
+                )
+            }
             return try await runOnPseudoTerminal(
                 terminal: terminal,
                 executableURL: executableURL,
@@ -37,12 +48,6 @@ public struct BrewCommandService: BrewCommandRunning {
                 options: options,
             )
         }
-        return try await runOnPipes(
-            executableURL: executableURL,
-            arguments: arguments,
-            // The terminal was what supplied colour, so on this path Homebrew has to be told explicitly.
-            options: options.usesPseudoTerminal ? Self.colourisedPipeFallback(from: options) : options,
-        )
     }
 
     /// Nil rather than throwing: the device pool is much smaller than `kern.tty.ptmx_max` suggests, and
@@ -51,10 +56,10 @@ public struct BrewCommandService: BrewCommandRunning {
         try? makeTerminal()
     }
 
-    static func colourisedPipeFallback(from options: BrewRunOptions) -> BrewRunOptions {
+    /// The terminal was what supplied colour, so on pipes Homebrew has to be told explicitly.
+    static func pipeFallback(from options: BrewRunOptions) -> BrewRunOptions {
         var fallback = options
-        fallback.usesPseudoTerminal = false
-        fallback.forceColor = true
+        fallback.output = .pipes(forceColor: true)
         return fallback
     }
 }
@@ -65,6 +70,11 @@ private extension BrewCommandService {
     /// One device serves both streams, so they arrive interleaved, every line is reported as
     /// ``BrewCommandOutputLine/Stream/stdout``, and ``CommandOutput/standardError`` is empty. Callers that
     /// need the streams apart must stay on the pipe path.
+    ///
+    /// ``CommandOutput/standardOutput`` is the *assembled* transcript, not the verbatim bytes: on a
+    /// terminal the raw bytes are a cursor script, in which a whole download is one line carrying every
+    /// intermediate redraw. Resolving the overwrites is what makes the text usable as the diagnostic for
+    /// a failed run, which is the only thing that reads it on this path.
     func runOnPseudoTerminal(
         terminal: PseudoTerminal,
         executableURL: URL,
@@ -76,13 +86,13 @@ private extension BrewCommandService {
 
         // Started before the spawn: the drain times out until there is something to read, and this
         // process still holds the replica open, so it cannot see a premature end-of-input.
-        async let drained: Data = Self.drainTerminal(terminal, sink: sink, gate: childHasExited)
+        async let drained: String = Self.drainTerminal(terminal, sink: sink, gate: childHasExited)
 
         do {
             let result = try await Subprocess.run(
                 .path(FilePath(executableURL.path)),
                 arguments: Arguments(arguments),
-                environment: Self.environment(for: options, isTerminal: true),
+                environment: Self.environment(for: options),
                 platformOptions: Self.platformOptions(),
                 input: .none,
                 output: .fileDescriptor(terminal.replicaDescriptor, closeAfterSpawningProcess: false),
@@ -94,12 +104,12 @@ private extension BrewCommandService {
             )
 
             childHasExited.open()
-            let data = await drained
+            let transcript = await drained
             terminal.closePrimary()
             try Task.checkCancellation()
 
             return CommandOutput(
-                standardOutput: String(bytes: data, encoding: .utf8) ?? "",
+                standardOutput: transcript,
                 standardError: "",
                 terminationStatus: Self.exitCode(from: result.terminationStatus),
             )
@@ -122,27 +132,31 @@ private extension BrewCommandService {
     ///
     /// Stops once the child has exited and a poll interval has passed with nothing to read. Waiting for
     /// end-of-input instead would stall on any grandchild still holding the descriptor open.
+    ///
+    /// Returns the settled lines as one transcript. The assembler runs whether or not anyone is
+    /// streaming, because that transcript is the run's only readable output.
     static func drainTerminal(
         _ terminal: PseudoTerminal,
         sink: (@Sendable (BrewCommandOutputLine) -> Void)?,
         gate: TerminalDrainGate,
-    ) async -> Data {
-        await withCheckedContinuation { (continuation: CheckedContinuation<Data, Never>) in
+    ) async -> String {
+        await withCheckedContinuation { (continuation: CheckedContinuation<String, Never>) in
             // `read` parks on `poll`; run it on a GCD worker rather than the cooperative pool.
             DispatchQueue.global(qos: .utility).async {
-                var fullOutput = Data()
+                var transcript = ""
                 var undecoded = Data()
                 var assembler = TerminalLineAssembler()
+                var readFailure: Int32?
 
                 loop: while true {
                     switch terminal.read() {
                     case let .data(chunk):
-                        fullOutput.append(chunk)
-                        if sink != nil {
-                            undecoded.append(chunk)
-                            for event in assembler.consume(takeDecodableUTF8Prefix(&undecoded)) {
-                                emit(event, sink: sink)
+                        undecoded.append(chunk)
+                        for event in assembler.consume(UTF8StreamDecoder.takeDecodablePrefix(&undecoded)) {
+                            if case let .committed(line) = event {
+                                transcript += line.text + "\n"
                             }
+                            emit(event, sink: sink)
                         }
                     case .timedOut:
                         if gate.isOpen {
@@ -150,16 +164,31 @@ private extension BrewCommandService {
                         }
                     case .endOfInput:
                         break loop
+                    case let .failed(code):
+                        readFailure = code
+                        break loop
                     }
                 }
 
                 // Output that ended without a trailing newline is settled by the stream ending.
-                if let sink, let trailing = assembler.flush() {
-                    sink(BrewCommandOutputLine(stream: .stdout, line: trailing, isComplete: true))
+                if let trailing = assembler.flush() {
+                    transcript += trailing.text
+                    sink?(BrewCommandOutputLine(stream: .stdout, line: trailing, isComplete: true))
                 }
-                continuation.resume(returning: fullOutput)
+                // Surfaced rather than swallowed: the exit status may still say success, and without this
+                // the truncation is indistinguishable from the command simply having said less.
+                if let readFailure {
+                    let notice = truncationNotice(errno: readFailure)
+                    transcript += transcript.isEmpty || transcript.hasSuffix("\n") ? notice : "\n" + notice
+                    sink?(BrewCommandOutputLine(stream: .stderr, text: notice))
+                }
+                continuation.resume(returning: transcript)
             }
         }
+    }
+
+    static func truncationNotice(errno code: Int32) -> String {
+        "[output truncated: could not read the pseudo-terminal: \(PseudoTerminal.describe(errno: code))]"
     }
 
     /// Everything from a terminal is reported on stdout: one device carries both streams.
@@ -173,24 +202,6 @@ private extension BrewCommandService {
         case let .revised(line):
             sink(BrewCommandOutputLine(stream: .stdout, line: line, isComplete: false))
         }
-    }
-
-    /// Reads land on arbitrary byte boundaries, so a multi-byte character can be split across two of them.
-    /// A sequence is at most four bytes, so at most three trailing bytes are ever held back; beyond that
-    /// the bytes are undecodable and one is dropped so the drain cannot stall.
-    static func takeDecodableUTF8Prefix(_ buffer: inout Data) -> String {
-        guard !buffer.isEmpty else {
-            return ""
-        }
-        for dropped in 0 ... min(3, buffer.count) {
-            let candidate = buffer.prefix(buffer.count - dropped)
-            if let text = String(bytes: candidate, encoding: .utf8) {
-                buffer = Data(buffer.dropFirst(candidate.count))
-                return text
-            }
-        }
-        buffer = Data(buffer.dropFirst())
-        return ""
     }
 }
 
@@ -209,7 +220,7 @@ private extension BrewCommandService {
             let result = try await Subprocess.run(
                 .path(FilePath(executableURL.path)),
                 arguments: Arguments(arguments),
-                environment: Self.environment(for: options, isTerminal: false),
+                environment: Self.environment(for: options),
                 platformOptions: Self.platformOptions(),
                 input: .none,
                 output: .sequence,
@@ -232,9 +243,10 @@ private extension BrewCommandService {
 
             try Task.checkCancellation()
             let (outData, errData) = result.closureResult
+            // Lossy on purpose: one undecodable byte would otherwise discard the whole output.
             return CommandOutput(
-                standardOutput: String(bytes: outData, encoding: .utf8) ?? "",
-                standardError: String(bytes: errData, encoding: .utf8) ?? "",
+                standardOutput: UTF8StreamDecoder.lossyString(outData),
+                standardError: UTF8StreamDecoder.lossyString(errData),
                 terminationStatus: Self.exitCode(from: result.terminationStatus),
             )
         } catch is CancellationError {
@@ -274,7 +286,8 @@ private extension BrewCommandService {
 // MARK: - Shared helpers
 
 private extension BrewCommandService {
-    /// Lines whose bytes aren't valid UTF-8 are dropped from the stream, but remain in the verbatim bytes.
+    /// Undecodable bytes become U+FFFD rather than costing the line it sits in, which the failable
+    /// initialiser would have dropped from the stream entirely.
     static func emitCompleteLines(
         from buffer: inout Data,
         stream: BrewCommandOutputLine.Stream,
@@ -285,10 +298,7 @@ private extension BrewCommandService {
         }
         while let newlineIndex = buffer.firstIndex(of: 0x0A) {
             let offset = buffer.distance(from: buffer.startIndex, to: newlineIndex)
-            let lineData = buffer.prefix(offset)
-            if let lineText = String(bytes: lineData, encoding: .utf8) {
-                sink(BrewCommandOutputLine(stream: stream, text: lineText))
-            }
+            sink(BrewCommandOutputLine(stream: stream, text: UTF8StreamDecoder.lossyString(buffer.prefix(offset))))
             buffer = Data(buffer.dropFirst(offset + 1))
         }
     }
@@ -298,10 +308,10 @@ private extension BrewCommandService {
         stream: BrewCommandOutputLine.Stream,
         sink: (@Sendable (BrewCommandOutputLine) -> Void)?,
     ) {
-        guard let sink, !buffer.isEmpty, let text = String(bytes: buffer, encoding: .utf8) else {
+        guard let sink, !buffer.isEmpty else {
             return
         }
-        sink(BrewCommandOutputLine(stream: stream, text: text))
+        sink(BrewCommandOutputLine(stream: stream, text: UTF8StreamDecoder.lossyString(buffer)))
     }
 
     /// `createSession` is what makes the pty a *controlling* terminal rather than merely a terminal-shaped
@@ -319,14 +329,13 @@ private extension BrewCommandService {
     /// Homebrew strips colour off a non-TTY, so the pipe path forces it back on (`CLICOLOR_FORCE` covers
     /// the BSD-convention tools brew shells out to). The terminal path needs `TERM` instead: a GUI process
     /// launched from Finder inherits none, and without it tools treat the terminal as capability-less.
-    static func environment(for options: BrewRunOptions, isTerminal: Bool) -> Environment {
-        if isTerminal {
-            return .inherit.updating(["TERM": "xterm-256color"])
+    static func environment(for options: BrewRunOptions) -> Environment {
+        switch options.output {
+        case .pseudoTerminal:
+            .inherit.updating(["TERM": "xterm-256color"])
+        case let .pipes(forceColor):
+            forceColor ? .inherit.updating(["HOMEBREW_COLOR": "1", "CLICOLOR_FORCE": "1"]) : .inherit
         }
-        guard options.forceColor else {
-            return .inherit
-        }
-        return .inherit.updating(["HOMEBREW_COLOR": "1", "CLICOLOR_FORCE": "1"])
     }
 
     /// A signalled child becomes `128 + signal`, the shell convention, keeping "non-zero means failure".

--- a/Sources/BrewCLI/BrewCommandService.swift
+++ b/Sources/BrewCLI/BrewCommandService.swift
@@ -16,8 +16,8 @@ public struct BrewCommandService: BrewCommandRunning {
         self.init(makeTerminal: { try PseudoTerminal() })
     }
 
-    /// Seam for testing the pty-allocation failure path, which is otherwise only reachable by exhausting
-    /// the machine's pty devices.
+    /// Seam for testing the allocation-failure path, otherwise reachable only by exhausting the
+    /// machine's pty devices.
     init(makeTerminal: @escaping @Sendable () throws -> PseudoTerminal) {
         self.makeTerminal = makeTerminal
     }
@@ -40,24 +40,17 @@ public struct BrewCommandService: BrewCommandRunning {
         return try await runOnPipes(
             executableURL: executableURL,
             arguments: arguments,
-            // A run that asked for a terminal and did not get one still wants colour: the terminal was
-            // the thing supplying it, so on this path Homebrew has to be told explicitly.
+            // The terminal was what supplied colour, so on this path Homebrew has to be told explicitly.
             options: options.usesPseudoTerminal ? Self.colourisedPipeFallback(from: options) : options,
         )
     }
 
-    /// Allocates a pty, or returns nil so the caller degrades to pipes.
-    ///
-    /// Allocation is an environmental resource that can genuinely run out — the device pool is much
-    /// smaller than `kern.tty.ptmx_max` suggests. Failing an install outright over it would be a poor
-    /// trade when the command runs perfectly well on pipes; the cost of degrading is Homebrew's progress
-    /// rendering, not the operation.
+    /// Nil rather than throwing: the device pool is much smaller than `kern.tty.ptmx_max` suggests, and
+    /// failing an install over it is a poor trade when the command runs fine on pipes.
     private func allocateTerminal() -> PseudoTerminal? {
         try? makeTerminal()
     }
 
-    /// The pipe-path options for a run that wanted a terminal: colour forced back on, streaming and
-    /// everything else preserved.
     static func colourisedPipeFallback(from options: BrewRunOptions) -> BrewRunOptions {
         var fallback = options
         fallback.usesPseudoTerminal = false
@@ -69,12 +62,9 @@ public struct BrewCommandService: BrewCommandRunning {
 // MARK: - Pseudo-terminal execution
 
 private extension BrewCommandService {
-    /// Runs the child against a pty, so `isatty` holds and Homebrew emits colour and progress on its own.
-    ///
-    /// One terminal device serves both stdout and stderr — that is what a terminal *is* — so the two
-    /// streams arrive interleaved in write order and every line is reported as
-    /// ``BrewCommandOutputLine/Stream/stdout``. ``CommandOutput/standardError`` is empty for these runs;
-    /// callers that need the streams apart must stay on the pipe path.
+    /// One device serves both streams, so they arrive interleaved, every line is reported as
+    /// ``BrewCommandOutputLine/Stream/stdout``, and ``CommandOutput/standardError`` is empty. Callers that
+    /// need the streams apart must stay on the pipe path.
     func runOnPseudoTerminal(
         terminal: PseudoTerminal,
         executableURL: URL,
@@ -84,8 +74,8 @@ private extension BrewCommandService {
         let childHasExited = TerminalDrainGate()
         let sink = options.lineObserver
 
-        // Started before the spawn deliberately: the drain simply times out until there is something to
-        // read, and this process still holds the replica open, so it cannot see a premature end-of-input.
+        // Started before the spawn: the drain times out until there is something to read, and this
+        // process still holds the replica open, so it cannot see a premature end-of-input.
         async let drained: Data = Self.drainTerminal(terminal, sink: sink, gate: childHasExited)
 
         do {
@@ -98,8 +88,7 @@ private extension BrewCommandService {
                 output: .fileDescriptor(terminal.replicaDescriptor, closeAfterSpawningProcess: false),
                 error: .fileDescriptor(terminal.replicaDescriptor, closeAfterSpawningProcess: false),
                 body: { _ in
-                    // Runs once the child is spawned, which is the only safe moment to drop this
-                    // process's copy of the replica — see the ownership note on `PseudoTerminal`.
+                    // Runs once the child is spawned, the only safe moment to drop our replica copy.
                     terminal.closeReplica()
                 },
             )
@@ -115,7 +104,7 @@ private extension BrewCommandService {
                 terminationStatus: Self.exitCode(from: result.terminationStatus),
             )
         } catch {
-            // Unblock and reap the drain before rethrowing, so no thread is left parked on the primary.
+            // Reap the drain before rethrowing, so no thread is left parked on the primary.
             terminal.closeReplica()
             childHasExited.open()
             _ = await drained
@@ -128,16 +117,11 @@ private extension BrewCommandService {
         }
     }
 
-    /// Drains the terminal to end-of-input, emitting lines through `sink` as they arrive.
+    /// Goes through ``TerminalLineAssembler`` rather than splitting on newlines: a terminal's redraws are
+    /// separated by carriage returns, so by the newline measure a whole download is one line.
     ///
-    /// Output goes through ``TerminalLineAssembler`` rather than being split on newlines, because a
-    /// terminal's redraws are separated by carriage returns rather than newlines — a whole download is
-    /// one "line" by that measure. The assembler resolves the overwrites and reports the line while it is
-    /// still being drawn, which is what lets the console animate a progress bar in place.
-    ///
-    /// Stops early when the child has exited and a full poll interval has passed with nothing to read.
-    /// That combination — process gone, terminal quiet — is what distinguishes "finished" from "a
-    /// grandchild is still holding the descriptor open", which would otherwise stall here indefinitely.
+    /// Stops once the child has exited and a poll interval has passed with nothing to read. Waiting for
+    /// end-of-input instead would stall on any grandchild still holding the descriptor open.
     static func drainTerminal(
         _ terminal: PseudoTerminal,
         sink: (@Sendable (BrewCommandOutputLine) -> Void)?,
@@ -178,8 +162,7 @@ private extension BrewCommandService {
         }
     }
 
-    /// Forwards one assembler event as an output line. Everything from a terminal is reported on
-    /// ``BrewCommandOutputLine/Stream/stdout``: one device carries both streams, so they cannot be told apart.
+    /// Everything from a terminal is reported on stdout: one device carries both streams.
     static func emit(_ event: TerminalLineEvent, sink: (@Sendable (BrewCommandOutputLine) -> Void)?) {
         guard let sink else {
             return
@@ -192,12 +175,9 @@ private extension BrewCommandService {
         }
     }
 
-    /// Takes the longest valid UTF-8 prefix of `buffer`, leaving any trailing bytes behind.
-    ///
-    /// Terminal reads land on arbitrary byte boundaries, so a multi-byte character can be split across two
-    /// reads. Holding the remainder until the rest arrives keeps such a character intact instead of
-    /// dropping it. A sequence can be at most four bytes, so at most three trailing bytes are ever held;
-    /// beyond that the bytes are genuinely undecodable and one is dropped so the drain cannot stall.
+    /// Reads land on arbitrary byte boundaries, so a multi-byte character can be split across two of them.
+    /// A sequence is at most four bytes, so at most three trailing bytes are ever held back; beyond that
+    /// the bytes are undecodable and one is dropped so the drain cannot stall.
     static func takeDecodableUTF8Prefix(_ buffer: inout Data) -> String {
         guard !buffer.isEmpty else {
             return ""
@@ -217,8 +197,7 @@ private extension BrewCommandService {
 // MARK: - Pipe execution
 
 private extension BrewCommandService {
-    /// Runs the child against pipes: no terminal, stdout and stderr stay distinct. The path for output
-    /// that will be parsed.
+    /// No terminal, so stdout and stderr stay distinct. The path for output that will be parsed.
     func runOnPipes(
         executableURL: URL,
         arguments: [String],
@@ -236,8 +215,7 @@ private extension BrewCommandService {
                 output: .sequence,
                 error: .sequence,
                 body: { execution in
-                    // Drained concurrently: waiting for exit before reading deadlocks on large outputs
-                    // such as `brew info --installed --json=v2`.
+                    // Drained concurrently: waiting for exit before reading deadlocks on large outputs.
                     async let outRead = Self.drainSequence(
                         execution.standardOutput,
                         stream: .stdout,
@@ -266,8 +244,7 @@ private extension BrewCommandService {
         }
     }
 
-    /// Drains one of the subprocess's output streams, returning the raw bytes verbatim for
-    /// ``CommandOutput`` and emitting `\n`-terminated lines through `sink` as they arrive.
+    /// Returns the bytes verbatim for ``CommandOutput``, emitting `\n`-terminated lines as they arrive.
     static func drainSequence(
         _ sequence: SubprocessOutputSequence,
         stream: BrewCommandOutputLine.Stream,
@@ -286,8 +263,7 @@ private extension BrewCommandService {
                 }
             }
         } catch {
-            // A read failure mid-stream still yields whatever was already collected; the exit status
-            // carried alongside it is what decides success or failure.
+            // A mid-stream read failure still yields what was collected; the exit status decides success.
         }
 
         flushPartialLine(lineBuffer, stream: stream, sink: sink)
@@ -298,8 +274,7 @@ private extension BrewCommandService {
 // MARK: - Shared helpers
 
 private extension BrewCommandService {
-    /// Emits every complete `\n`-terminated line sitting in `buffer`, leaving any trailing partial line.
-    /// Lines whose bytes aren't valid UTF-8 are dropped from the stream (they remain in the verbatim bytes).
+    /// Lines whose bytes aren't valid UTF-8 are dropped from the stream, but remain in the verbatim bytes.
     static func emitCompleteLines(
         from buffer: inout Data,
         stream: BrewCommandOutputLine.Stream,
@@ -318,7 +293,6 @@ private extension BrewCommandService {
         }
     }
 
-    /// Emits a trailing line that arrived without a terminating newline.
     static func flushPartialLine(
         _ buffer: Data,
         stream: BrewCommandOutputLine.Stream,
@@ -330,10 +304,9 @@ private extension BrewCommandService {
         sink(BrewCommandOutputLine(stream: stream, text: text))
     }
 
-    /// `createSession` puts the child in its own session, which is what makes the pty a *controlling*
-    /// terminal rather than merely a terminal-shaped descriptor, and it gives the child and everything it
-    /// spawns a process group of their own. Teardown then signals that whole group, so cancelling an
-    /// install also stops the `curl` or `git` it is waiting on instead of orphaning it.
+    /// `createSession` is what makes the pty a *controlling* terminal rather than merely a terminal-shaped
+    /// descriptor, and puts the child and its descendants in one process group. Teardown then signals the
+    /// whole group, so cancelling an install stops the `curl` or `git` it is waiting on.
     static func platformOptions() -> PlatformOptions {
         var platformOptions = PlatformOptions()
         platformOptions.createSession = true
@@ -343,11 +316,9 @@ private extension BrewCommandService {
         return platformOptions
     }
 
-    /// Homebrew strips colour when stdout isn't a TTY, so the pipe path forces it back on via
-    /// `HOMEBREW_COLOR` (and `CLICOLOR_FORCE` for the BSD-convention tools brew shells out to). The
-    /// terminal path needs neither — it *is* a TTY — but does need `TERM`, which a GUI process launched
-    /// from Finder or launchd does not inherit; without it, tools treat the terminal as capability-less
-    /// and suppress the colour and progress rendering the pty was allocated to get.
+    /// Homebrew strips colour off a non-TTY, so the pipe path forces it back on (`CLICOLOR_FORCE` covers
+    /// the BSD-convention tools brew shells out to). The terminal path needs `TERM` instead: a GUI process
+    /// launched from Finder inherits none, and without it tools treat the terminal as capability-less.
     static func environment(for options: BrewRunOptions, isTerminal: Bool) -> Environment {
         if isTerminal {
             return .inherit.updating(["TERM": "xterm-256color"])
@@ -358,8 +329,7 @@ private extension BrewCommandService {
         return .inherit.updating(["HOMEBREW_COLOR": "1", "CLICOLOR_FORCE": "1"])
     }
 
-    /// Maps a termination status onto the `Int32` exit code ``CommandOutput`` carries. A signalled child
-    /// becomes `128 + signal`, the shell convention, which keeps "non-zero means failure" true.
+    /// A signalled child becomes `128 + signal`, the shell convention, keeping "non-zero means failure".
     static func exitCode(from status: TerminationStatus) -> Int32 {
         switch status {
         case let .exited(code):
@@ -370,9 +340,8 @@ private extension BrewCommandService {
     }
 }
 
-/// One-way flag telling the terminal drain that the child has exited, so a quiet terminal now means
-/// "finished" rather than "waiting". Set from the task that awaits the subprocess, read from the drain's
-/// GCD worker, hence the lock.
+/// Tells the drain the child has exited, so a quiet terminal means "finished" rather than "waiting".
+/// Set from the task awaiting the subprocess, read from the drain's GCD worker, hence the lock.
 // swiftlint:disable:next unchecked_sendable
 private final class TerminalDrainGate: @unchecked Sendable {
     private let lock = NSLock()

--- a/Sources/BrewCLI/CommandFailureDetail.swift
+++ b/Sources/BrewCLI/CommandFailureDetail.swift
@@ -6,14 +6,10 @@
 import BrewCore
 import Foundation
 
-/// Picks the text that explains a non-zero exit.
-///
-/// A pipe-backed run keeps the streams apart, so stderr is the answer. A terminal-backed run merges them
-/// into one device, leaving ``CommandOutput/standardError`` empty and the transcript as the only account
-/// of what went wrong — without this, every failed install would reach the user as a bare exit code.
+/// Picks the text that explains a non-zero exit. A terminal-backed run merges the streams, leaving
+/// ``CommandOutput/standardError`` empty and the transcript as the only account of what went wrong.
 enum CommandFailureDetail {
-    /// Brew's own errors are the last thing it prints, and this text goes into an error banner rather
-    /// than a log pane, so the transcript is trimmed to its tail.
+    /// It goes into an error banner, not a log pane, and brew prints its errors last.
     static let maxTranscriptLines = 20
 
     static func detail(from output: CommandOutput) -> String {

--- a/Sources/BrewCLI/CommandFailureDetail.swift
+++ b/Sources/BrewCLI/CommandFailureDetail.swift
@@ -1,0 +1,32 @@
+//
+//  CommandFailureDetail.swift
+//  BrewCLI
+//
+
+import BrewCore
+import Foundation
+
+/// Picks the text that explains a non-zero exit.
+///
+/// A pipe-backed run keeps the streams apart, so stderr is the answer. A terminal-backed run merges them
+/// into one device, leaving ``CommandOutput/standardError`` empty and the transcript as the only account
+/// of what went wrong — without this, every failed install would reach the user as a bare exit code.
+enum CommandFailureDetail {
+    /// Brew's own errors are the last thing it prints, and this text goes into an error banner rather
+    /// than a log pane, so the transcript is trimmed to its tail.
+    static let maxTranscriptLines = 20
+
+    static func detail(from output: CommandOutput) -> String {
+        guard output.standardError.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return output.standardError
+        }
+        return tail(of: output.standardOutput, lines: maxTranscriptLines)
+    }
+
+    static func tail(of text: String, lines limit: Int) -> String {
+        let all = text.split(separator: "\n", omittingEmptySubsequences: false)
+        // A trailing newline leaves an empty final element that would otherwise use up one of the slots.
+        let meaningful = all.last?.isEmpty == true ? all.dropLast() : all[...]
+        return meaningful.suffix(limit).joined(separator: "\n")
+    }
+}

--- a/Sources/BrewCLI/PseudoTerminal.swift
+++ b/Sources/BrewCLI/PseudoTerminal.swift
@@ -46,9 +46,13 @@ final class PseudoTerminal: @unchecked Sendable {
         var replica: Int32 = -1
         var size = winsize(ws_row: rows, ws_col: columns, ws_xpixel: 0, ws_ypixel: 0)
 
-        guard openpty(&primary, &replica, nil, nil, &size) == 0 else {
+        let result = openpty(&primary, &replica, nil, nil, &size)
+        // Captured before anything else runs: building the message allocates, and an allocation can make
+        // syscalls of its own that overwrite `errno` — which reports a nonsense code for the real failure.
+        let failureCode = errno
+        guard result == 0 else {
             throw BrewCommandError.launchFailed(
-                underlying: "openpty failed: \(String(cString: strerror(errno)))",
+                underlying: "openpty failed: \(String(cString: strerror(failureCode))) (\(failureCode))",
             )
         }
 

--- a/Sources/BrewCLI/PseudoTerminal.swift
+++ b/Sources/BrewCLI/PseudoTerminal.swift
@@ -6,7 +6,7 @@
 import BrewCore
 import Darwin
 import Foundation
-import SystemPackage
+import System
 
 /// An allocated pseudo-terminal pair, used to give `brew` a real terminal on stdout/stderr.
 ///
@@ -94,30 +94,52 @@ final class PseudoTerminal: @unchecked Sendable {
         close(primaryFD)
     }
 
-    /// One blocking read from the primary. Returns `nil` at end-of-input (the child and every other
-    /// writer have gone away), otherwise the bytes read. `EINTR` is retried rather than surfaced.
-    func read() -> Data? {
-        var buffer = [UInt8](repeating: 0, count: 4096)
-        while true {
-            let bytesRead = buffer.withUnsafeMutableBytes { raw -> Int in
-                guard let base = raw.baseAddress else {
-                    return 0
-                }
-                return Darwin.read(primaryFD, base, raw.count)
-            }
+    /// The result of one bounded read from the primary.
+    enum ReadOutcome: Equatable {
+        /// Bytes were read.
+        case data(Data)
+        /// Nothing arrived within the timeout. The terminal is still open.
+        case timedOut
+        /// No writers remain: the child and everything it spawned have closed their end.
+        case endOfInput
+    }
 
-            if bytesRead > 0 {
-                return Data(buffer[0 ..< bytesRead])
-            }
-            if bytesRead == 0 {
-                return nil
-            }
-            // `EIO` here is the normal "last writer closed" signal on Darwin, not a fault.
-            if errno == EINTR {
-                continue
-            }
-            return nil
+    /// One read from the primary, waiting at most `timeout` for bytes to arrive.
+    ///
+    /// The timeout exists because end-of-input is driven by *descriptors*, not by process exit: any
+    /// grandchild that inherited the replica (a `curl`, a cask's installer) holds the terminal open after
+    /// `brew` itself exits. An unbounded read would hang the drain — and with it the console job — until
+    /// that straggler happened to finish. Returning ``ReadOutcome/timedOut`` lets the caller notice the
+    /// child is gone and stop on its own terms.
+    func read(timeout: Duration = .milliseconds(100)) -> ReadOutcome {
+        var descriptor = pollfd(fd: primaryFD, events: Int16(POLLIN), revents: 0)
+        let milliseconds = Int32(clamping: timeout.components.seconds * 1000
+            + Int64(timeout.components.attoseconds / 1_000_000_000_000_000))
+
+        let ready = poll(&descriptor, 1, milliseconds)
+        if ready == 0 {
+            return .timedOut
         }
+        if ready < 0 {
+            return errno == EINTR ? .timedOut : .endOfInput
+        }
+
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        let bytesRead = buffer.withUnsafeMutableBytes { raw -> Int in
+            guard let base = raw.baseAddress else {
+                return 0
+            }
+            return Darwin.read(primaryFD, base, raw.count)
+        }
+
+        if bytesRead > 0 {
+            return .data(Data(buffer[0 ..< bytesRead]))
+        }
+        if bytesRead < 0, errno == EINTR || errno == EAGAIN {
+            return .timedOut
+        }
+        // Both `0` and `-1`/`EIO` mean the last writer closed; `EIO` is the normal Darwin path here.
+        return .endOfInput
     }
 
     /// Puts the replica into a mode that hands back exactly the bytes the child wrote.

--- a/Sources/BrewCLI/PseudoTerminal.swift
+++ b/Sources/BrewCLI/PseudoTerminal.swift
@@ -13,8 +13,12 @@ import System
 ///
 /// The replica must be closed in this process once the child is spawned. While any replica descriptor
 /// stays open here the kernel sees a potential writer, so reads on the primary never report EOF.
-// `read` deliberately touches `primaryFD` unlocked: it parks for as long as the child is quiet, and
-// holding the lock across it would deadlock `closeReplica`.
+///
+/// The descriptors never change after `init`, so ``read(timeout:)`` touches `primaryFD` without taking
+/// the lock — which guards only the closed flags, and which `read` could not hold anyway, since it parks
+/// for as long as the child stays quiet. What is *not* safe is closing the primary while a read is
+/// parked on it: the descriptor number would be freed and could be reused underneath the parked `poll`.
+/// See the ordering requirement on ``closePrimary()``.
 // swiftlint:disable:next unchecked_sendable
 final class PseudoTerminal: @unchecked Sendable {
     /// Non-zero because `openpty` defaults to 0x0, which some tools read as "not a real terminal" and
@@ -23,8 +27,8 @@ final class PseudoTerminal: @unchecked Sendable {
     static let defaultRows: UInt16 = 40
 
     private let lock = NSLock()
-    private var primaryFD: Int32
-    private var replicaFD: Int32
+    private let primaryFD: Int32
+    private let replicaFD: Int32
     private var isPrimaryClosed = false
     private var isReplicaClosed = false
 
@@ -38,9 +42,7 @@ final class PseudoTerminal: @unchecked Sendable {
         // that overwrite `errno`.
         let failureCode = errno
         guard result == 0 else {
-            throw BrewCommandError.launchFailed(
-                underlying: "openpty failed: \(String(cString: strerror(failureCode))) (\(failureCode))",
-            )
+            throw BrewCommandError.launchFailed(underlying: "openpty failed: \(Self.describe(errno: failureCode))")
         }
 
         primaryFD = primary
@@ -71,7 +73,8 @@ final class PseudoTerminal: @unchecked Sendable {
         close(replicaFD)
     }
 
-    /// Idempotent.
+    /// Idempotent. Must not be called while a ``read(timeout:)`` is in flight — see the note on the
+    /// type. Callers let the drain finish first.
     func closePrimary() {
         lock.lock()
         defer { lock.unlock() }
@@ -86,8 +89,11 @@ final class PseudoTerminal: @unchecked Sendable {
         case data(Data)
         /// Nothing arrived within the timeout; the terminal is still open.
         case timedOut
-        /// No writers remain.
+        /// No writers remain: the ordinary end of a run.
         case endOfInput
+        /// The descriptor itself went bad, so no more output can be read. Kept distinct from
+        /// ``endOfInput`` so a truncated run is not silently reported as a complete one.
+        case failed(errno: Int32)
     }
 
     /// The timeout exists because end-of-input is driven by descriptors, not process exit: a grandchild
@@ -103,7 +109,13 @@ final class PseudoTerminal: @unchecked Sendable {
             return .timedOut
         }
         if ready < 0 {
-            return errno == EINTR ? .timedOut : .endOfInput
+            let pollCode = errno
+            return pollCode == EINTR ? .timedOut : .failed(errno: pollCode)
+        }
+        // `POLLHUP` is the ordinary hang-up and falls through to `read`; `POLLNVAL` means the descriptor
+        // is not open at all, which `read` would report indistinguishably from a clean finish.
+        if descriptor.revents & Int16(POLLNVAL) != 0 {
+            return .failed(errno: EBADF)
         }
 
         var buffer = [UInt8](repeating: 0, count: 4096)
@@ -113,15 +125,24 @@ final class PseudoTerminal: @unchecked Sendable {
             }
             return Darwin.read(primaryFD, base, raw.count)
         }
+        let readCode = errno
 
         if bytesRead > 0 {
             return .data(Data(buffer[0 ..< bytesRead]))
         }
-        if bytesRead < 0, errno == EINTR || errno == EAGAIN {
+        if bytesRead == 0 {
+            return .endOfInput
+        }
+        if readCode == EINTR || readCode == EAGAIN {
             return .timedOut
         }
-        // Both `0` and `-1`/`EIO` mean the last writer closed; `EIO` is the normal Darwin path.
-        return .endOfInput
+        // `EIO` is Darwin's normal report that the last writer closed; anything else is a real fault.
+        return readCode == EIO ? .endOfInput : .failed(errno: readCode)
+    }
+
+    /// `strerror`'s text plus the raw code, so a report is actionable without a second lookup.
+    static func describe(errno code: Int32) -> String {
+        "\(String(cString: strerror(code))) (\(code))"
     }
 
     /// Clearing `OPOST` disables `ONLCR`, which would otherwise rewrite every `\n` as `\r\n` and leave a

--- a/Sources/BrewCLI/PseudoTerminal.swift
+++ b/Sources/BrewCLI/PseudoTerminal.swift
@@ -1,0 +1,142 @@
+//
+//  PseudoTerminal.swift
+//  BrewCLI
+//
+
+import BrewCore
+import Darwin
+import Foundation
+import SystemPackage
+
+/// An allocated pseudo-terminal pair, used to give `brew` a real terminal on stdout/stderr.
+///
+/// A pty is two file descriptors onto one kernel terminal device: the **primary** (POSIX: master), which
+/// this process holds and reads the child's output from, and the **replica** (POSIX: slave), which becomes
+/// the child's stdout/stderr. The replica *is* a terminal device, so `isatty(1)` is true in the child —
+/// that is the whole point. Homebrew then emits colour and progress rendering on its own, and the libc
+/// in every tool `brew` shells out to switches from block buffering to line buffering, so output arrives
+/// as it is produced rather than in 4–8 KB bursts.
+///
+/// Ownership rules that matter (both are easy to get wrong and both hang or crash if you do):
+///   - The replica must be closed in *this* process once the child has been spawned. While any replica
+///     descriptor stays open here, the kernel sees a potential writer and reads on the primary never
+///     report EOF — the drain would block forever after the child exits.
+///   - Reads on the primary can report end-of-input as either `0` or `-1`/`EIO` depending on ordering.
+///     Both mean "no writers left". ``read()`` normalises them.
+// The three descriptor fields are the only mutable state, and every access to them goes through `lock`.
+// `read` touches `primaryFD` without the lock deliberately: it blocks for as long as the child is quiet,
+// so holding the lock across it would deadlock `closeReplica` — the fd is stable for the read's lifetime
+// because only the drain calls `closePrimary`, and only after `read` has returned nil.
+// swiftlint:disable:next unchecked_sendable
+final class PseudoTerminal: @unchecked Sendable {
+    /// Terminal size reported to the child via `TIOCGWINSZ`. `openpty` would otherwise leave this at 0×0,
+    /// which some tools read as "not a real terminal" and use to suppress progress rendering entirely.
+    static let defaultColumns: UInt16 = 120
+    static let defaultRows: UInt16 = 40
+
+    private let lock = NSLock()
+    private var primaryFD: Int32
+    private var replicaFD: Int32
+    private var isPrimaryClosed = false
+    private var isReplicaClosed = false
+
+    /// Allocates the pair and configures the line discipline. Throws if the kernel cannot provide a pty.
+    init(columns: UInt16 = PseudoTerminal.defaultColumns, rows: UInt16 = PseudoTerminal.defaultRows) throws {
+        var primary: Int32 = -1
+        var replica: Int32 = -1
+        var size = winsize(ws_row: rows, ws_col: columns, ws_xpixel: 0, ws_ypixel: 0)
+
+        guard openpty(&primary, &replica, nil, nil, &size) == 0 else {
+            throw BrewCommandError.launchFailed(
+                underlying: "openpty failed: \(String(cString: strerror(errno)))",
+            )
+        }
+
+        primaryFD = primary
+        replicaFD = replica
+        Self.configureLineDiscipline(replica)
+    }
+
+    deinit {
+        // Belt and braces: the run path closes both explicitly, but an early `throw` between allocation
+        // and spawn would otherwise leak a pair.
+        if !isReplicaClosed { close(replicaFD) }
+        if !isPrimaryClosed { close(primaryFD) }
+    }
+
+    /// The child's end of the pair, to be handed to `Subprocess` as stdout/stderr.
+    var replicaDescriptor: FileDescriptor {
+        lock.lock()
+        defer { lock.unlock() }
+        return FileDescriptor(rawValue: replicaFD)
+    }
+
+    /// Closes this process's copy of the replica. Call once, immediately after the child is spawned —
+    /// see the ownership note on the type. Idempotent.
+    func closeReplica() {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !isReplicaClosed else {
+            return
+        }
+        isReplicaClosed = true
+        close(replicaFD)
+    }
+
+    /// Closes the primary. Idempotent; safe to call after ``closeReplica()``.
+    func closePrimary() {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !isPrimaryClosed else {
+            return
+        }
+        isPrimaryClosed = true
+        close(primaryFD)
+    }
+
+    /// One blocking read from the primary. Returns `nil` at end-of-input (the child and every other
+    /// writer have gone away), otherwise the bytes read. `EINTR` is retried rather than surfaced.
+    func read() -> Data? {
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while true {
+            let bytesRead = buffer.withUnsafeMutableBytes { raw -> Int in
+                guard let base = raw.baseAddress else {
+                    return 0
+                }
+                return Darwin.read(primaryFD, base, raw.count)
+            }
+
+            if bytesRead > 0 {
+                return Data(buffer[0 ..< bytesRead])
+            }
+            if bytesRead == 0 {
+                return nil
+            }
+            // `EIO` here is the normal "last writer closed" signal on Darwin, not a fault.
+            if errno == EINTR {
+                continue
+            }
+            return nil
+        }
+    }
+
+    /// Puts the replica into a mode that hands back exactly the bytes the child wrote.
+    ///
+    /// `OPOST` is cleared, which disables the output post-processing the kernel would otherwise apply —
+    /// most relevantly `ONLCR`, which rewrites every `\n` into `\r\n`. Leaving it on would put a stray
+    /// `\r` at the end of every captured line, which the console would render and the doctor parser would
+    /// have to strip. Clearing it does **not** affect carriage returns the child emits deliberately, so
+    /// progress-bar redraws still arrive intact — exactly the distinction we want.
+    ///
+    /// Echo is cleared because nothing in this app writes to the child's input; if that ever changes,
+    /// echo would otherwise reflect the written bytes straight back into the captured output.
+    private static func configureLineDiscipline(_ replica: Int32) {
+        var settings = termios()
+        guard tcgetattr(replica, &settings) == 0 else {
+            return
+        }
+        settings.c_oflag &= ~tcflag_t(OPOST)
+        settings.c_lflag &= ~tcflag_t(ECHO | ECHOE | ECHOK | ECHONL)
+        _ = tcsetattr(replica, TCSANOW, &settings)
+    }
+}

--- a/Sources/BrewCLI/PseudoTerminal.swift
+++ b/Sources/BrewCLI/PseudoTerminal.swift
@@ -8,29 +8,17 @@ import Darwin
 import Foundation
 import System
 
-/// An allocated pseudo-terminal pair, used to give `brew` a real terminal on stdout/stderr.
+/// A pty pair: the primary (POSIX: master) stays here, the replica (POSIX: slave) becomes the child's
+/// stdout/stderr and is a real terminal device, so `isatty` holds in the child.
 ///
-/// A pty is two file descriptors onto one kernel terminal device: the **primary** (POSIX: master), which
-/// this process holds and reads the child's output from, and the **replica** (POSIX: slave), which becomes
-/// the child's stdout/stderr. The replica *is* a terminal device, so `isatty(1)` is true in the child —
-/// that is the whole point. Homebrew then emits colour and progress rendering on its own, and the libc
-/// in every tool `brew` shells out to switches from block buffering to line buffering, so output arrives
-/// as it is produced rather than in 4–8 KB bursts.
-///
-/// Ownership rules that matter (both are easy to get wrong and both hang or crash if you do):
-///   - The replica must be closed in *this* process once the child has been spawned. While any replica
-///     descriptor stays open here, the kernel sees a potential writer and reads on the primary never
-///     report EOF — the drain would block forever after the child exits.
-///   - Reads on the primary can report end-of-input as either `0` or `-1`/`EIO` depending on ordering.
-///     Both mean "no writers left". ``read()`` normalises them.
-// The three descriptor fields are the only mutable state, and every access to them goes through `lock`.
-// `read` touches `primaryFD` without the lock deliberately: it blocks for as long as the child is quiet,
-// so holding the lock across it would deadlock `closeReplica` — the fd is stable for the read's lifetime
-// because only the drain calls `closePrimary`, and only after `read` has returned nil.
+/// The replica must be closed in this process once the child is spawned. While any replica descriptor
+/// stays open here the kernel sees a potential writer, so reads on the primary never report EOF.
+// `read` deliberately touches `primaryFD` unlocked: it parks for as long as the child is quiet, and
+// holding the lock across it would deadlock `closeReplica`.
 // swiftlint:disable:next unchecked_sendable
 final class PseudoTerminal: @unchecked Sendable {
-    /// Terminal size reported to the child via `TIOCGWINSZ`. `openpty` would otherwise leave this at 0×0,
-    /// which some tools read as "not a real terminal" and use to suppress progress rendering entirely.
+    /// Non-zero because `openpty` defaults to 0x0, which some tools read as "not a real terminal" and
+    /// use to suppress progress rendering.
     static let defaultColumns: UInt16 = 120
     static let defaultRows: UInt16 = 40
 
@@ -40,15 +28,14 @@ final class PseudoTerminal: @unchecked Sendable {
     private var isPrimaryClosed = false
     private var isReplicaClosed = false
 
-    /// Allocates the pair and configures the line discipline. Throws if the kernel cannot provide a pty.
     init(columns: UInt16 = PseudoTerminal.defaultColumns, rows: UInt16 = PseudoTerminal.defaultRows) throws {
         var primary: Int32 = -1
         var replica: Int32 = -1
         var size = winsize(ws_row: rows, ws_col: columns, ws_xpixel: 0, ws_ypixel: 0)
 
         let result = openpty(&primary, &replica, nil, nil, &size)
-        // Captured before anything else runs: building the message allocates, and an allocation can make
-        // syscalls of its own that overwrite `errno` — which reports a nonsense code for the real failure.
+        // Captured before anything else: building the message allocates, and an allocation makes syscalls
+        // that overwrite `errno`.
         let failureCode = errno
         guard result == 0 else {
             throw BrewCommandError.launchFailed(
@@ -62,21 +49,18 @@ final class PseudoTerminal: @unchecked Sendable {
     }
 
     deinit {
-        // Belt and braces: the run path closes both explicitly, but an early `throw` between allocation
-        // and spawn would otherwise leak a pair.
+        // The run path closes both explicitly; this catches a throw between allocation and spawn.
         if !isReplicaClosed { close(replicaFD) }
         if !isPrimaryClosed { close(primaryFD) }
     }
 
-    /// The child's end of the pair, to be handed to `Subprocess` as stdout/stderr.
     var replicaDescriptor: FileDescriptor {
         lock.lock()
         defer { lock.unlock() }
         return FileDescriptor(rawValue: replicaFD)
     }
 
-    /// Closes this process's copy of the replica. Call once, immediately after the child is spawned —
-    /// see the ownership note on the type. Idempotent.
+    /// Call immediately after the child is spawned; see the ownership note on the type. Idempotent.
     func closeReplica() {
         lock.lock()
         defer { lock.unlock() }
@@ -87,7 +71,7 @@ final class PseudoTerminal: @unchecked Sendable {
         close(replicaFD)
     }
 
-    /// Closes the primary. Idempotent; safe to call after ``closeReplica()``.
+    /// Idempotent.
     func closePrimary() {
         lock.lock()
         defer { lock.unlock() }
@@ -98,23 +82,17 @@ final class PseudoTerminal: @unchecked Sendable {
         close(primaryFD)
     }
 
-    /// The result of one bounded read from the primary.
     enum ReadOutcome: Equatable {
-        /// Bytes were read.
         case data(Data)
-        /// Nothing arrived within the timeout. The terminal is still open.
+        /// Nothing arrived within the timeout; the terminal is still open.
         case timedOut
-        /// No writers remain: the child and everything it spawned have closed their end.
+        /// No writers remain.
         case endOfInput
     }
 
-    /// One read from the primary, waiting at most `timeout` for bytes to arrive.
-    ///
-    /// The timeout exists because end-of-input is driven by *descriptors*, not by process exit: any
-    /// grandchild that inherited the replica (a `curl`, a cask's installer) holds the terminal open after
-    /// `brew` itself exits. An unbounded read would hang the drain — and with it the console job — until
-    /// that straggler happened to finish. Returning ``ReadOutcome/timedOut`` lets the caller notice the
-    /// child is gone and stop on its own terms.
+    /// The timeout exists because end-of-input is driven by descriptors, not process exit: a grandchild
+    /// that inherited the replica holds the terminal open after `brew` exits, so an unbounded read would
+    /// hang the drain until that straggler finished.
     func read(timeout: Duration = .milliseconds(100)) -> ReadOutcome {
         var descriptor = pollfd(fd: primaryFD, events: Int16(POLLIN), revents: 0)
         let milliseconds = Int32(clamping: timeout.components.seconds * 1000
@@ -142,20 +120,13 @@ final class PseudoTerminal: @unchecked Sendable {
         if bytesRead < 0, errno == EINTR || errno == EAGAIN {
             return .timedOut
         }
-        // Both `0` and `-1`/`EIO` mean the last writer closed; `EIO` is the normal Darwin path here.
+        // Both `0` and `-1`/`EIO` mean the last writer closed; `EIO` is the normal Darwin path.
         return .endOfInput
     }
 
-    /// Puts the replica into a mode that hands back exactly the bytes the child wrote.
-    ///
-    /// `OPOST` is cleared, which disables the output post-processing the kernel would otherwise apply —
-    /// most relevantly `ONLCR`, which rewrites every `\n` into `\r\n`. Leaving it on would put a stray
-    /// `\r` at the end of every captured line, which the console would render and the doctor parser would
-    /// have to strip. Clearing it does **not** affect carriage returns the child emits deliberately, so
-    /// progress-bar redraws still arrive intact — exactly the distinction we want.
-    ///
-    /// Echo is cleared because nothing in this app writes to the child's input; if that ever changes,
-    /// echo would otherwise reflect the written bytes straight back into the captured output.
+    /// Clearing `OPOST` disables `ONLCR`, which would otherwise rewrite every `\n` as `\r\n` and leave a
+    /// stray `\r` on every captured line. Carriage returns the child writes itself are unaffected, so
+    /// progress redraws still arrive intact.
     private static func configureLineDiscipline(_ replica: Int32) {
         var settings = termios()
         guard tcgetattr(replica, &settings) == 0 else {

--- a/Sources/BrewCLI/PseudoTerminal.swift
+++ b/Sources/BrewCLI/PseudoTerminal.swift
@@ -14,11 +14,9 @@ import System
 /// The replica must be closed in this process once the child is spawned. While any replica descriptor
 /// stays open here the kernel sees a potential writer, so reads on the primary never report EOF.
 ///
-/// The descriptors never change after `init`, so ``read(timeout:)`` touches `primaryFD` without taking
-/// the lock — which guards only the closed flags, and which `read` could not hold anyway, since it parks
-/// for as long as the child stays quiet. What is *not* safe is closing the primary while a read is
-/// parked on it: the descriptor number would be freed and could be reused underneath the parked `poll`.
-/// See the ordering requirement on ``closePrimary()``.
+/// The descriptors never change after `init`, so ``read(timeout:)`` touches `primaryFD` unlocked; the
+/// lock guards only the closed flags, and `read` could not hold it anyway while parked on `poll`. What
+/// is unsafe is closing the primary out from under a parked read — see ``closePrimary()``.
 // swiftlint:disable:next unchecked_sendable
 final class PseudoTerminal: @unchecked Sendable {
     /// Non-zero because `openpty` defaults to 0x0, which some tools read as "not a real terminal" and
@@ -73,8 +71,7 @@ final class PseudoTerminal: @unchecked Sendable {
         close(replicaFD)
     }
 
-    /// Idempotent. Must not be called while a ``read(timeout:)`` is in flight — see the note on the
-    /// type. Callers let the drain finish first.
+    /// Idempotent. Must not be called while a ``read(timeout:)`` is in flight; let the drain finish.
     func closePrimary() {
         lock.lock()
         defer { lock.unlock() }
@@ -91,8 +88,7 @@ final class PseudoTerminal: @unchecked Sendable {
         case timedOut
         /// No writers remain: the ordinary end of a run.
         case endOfInput
-        /// The descriptor itself went bad, so no more output can be read. Kept distinct from
-        /// ``endOfInput`` so a truncated run is not silently reported as a complete one.
+        /// The descriptor went bad. Distinct from ``endOfInput`` so truncation is not read as success.
         case failed(errno: Int32)
     }
 
@@ -112,8 +108,8 @@ final class PseudoTerminal: @unchecked Sendable {
             let pollCode = errno
             return pollCode == EINTR ? .timedOut : .failed(errno: pollCode)
         }
-        // `POLLHUP` is the ordinary hang-up and falls through to `read`; `POLLNVAL` means the descriptor
-        // is not open at all, which `read` would report indistinguishably from a clean finish.
+        // `POLLHUP` is the ordinary hang-up and falls through to `read`; `POLLNVAL` is a dead fd, which
+        // `read` would report indistinguishably from a clean finish.
         if descriptor.revents & Int16(POLLNVAL) != 0 {
             return .failed(errno: EBADF)
         }
@@ -140,7 +136,6 @@ final class PseudoTerminal: @unchecked Sendable {
         return readCode == EIO ? .endOfInput : .failed(errno: readCode)
     }
 
-    /// `strerror`'s text plus the raw code, so a report is actionable without a second lookup.
     static func describe(errno code: Int32) -> String {
         "\(String(cString: strerror(code))) (\(code))"
     }

--- a/Sources/BrewCLI/SerialBrewCommandCenter.swift
+++ b/Sources/BrewCLI/SerialBrewCommandCenter.swift
@@ -130,9 +130,14 @@ public actor SerialBrewCommandCenter: BrewCommandCenter {
         let (lineStream, lineContinuation) = AsyncStream<BrewCommandOutputLine>.makeStream(
             bufferingPolicy: .unbounded,
         )
+        // `.display` work is only ever shown, so it runs against a pty and gets Homebrew's own colour and
+        // progress rendering. `.capture` work is parsed by its caller and stays on pipes, where stdout and
+        // stderr remain distinct — it still asks for colour explicitly, since a pipe would otherwise
+        // strip it and `brew doctor` is shown *and* parsed.
         let options = BrewRunOptions(
             lineObserver: { line in lineContinuation.yield(line) },
-            forceColor: true,
+            forceColor: mode == .capture,
+            usesPseudoTerminal: mode == .display,
         )
 
         let drainTask = Task { [weak self] in

--- a/Sources/BrewCLI/SerialBrewCommandCenter.swift
+++ b/Sources/BrewCLI/SerialBrewCommandCenter.swift
@@ -184,8 +184,7 @@ public actor SerialBrewCommandCenter: BrewCommandCenter {
                     options: options,
                 )
                 if mode == .display, output.terminationStatus != 0 {
-                    // Display work runs on a terminal, which merges the streams and so leaves
-                    // `standardError` empty; the transcript is what carries brew's message.
+                    // A terminal merges the streams, so `standardError` is empty here.
                     throw BrewCommandError.failed(
                         exitCode: output.terminationStatus,
                         stderr: CommandFailureDetail.detail(from: output),

--- a/Sources/BrewCLI/SerialBrewCommandCenter.swift
+++ b/Sources/BrewCLI/SerialBrewCommandCenter.swift
@@ -135,8 +135,7 @@ public actor SerialBrewCommandCenter: BrewCommandCenter {
         // pipe strips it and `brew doctor` is shown *and* parsed.
         let options = BrewRunOptions(
             lineObserver: { line in lineContinuation.yield(line) },
-            forceColor: mode == .capture,
-            usesPseudoTerminal: mode == .display,
+            output: mode == .display ? .pseudoTerminal : .pipes(forceColor: true),
         )
 
         let drainTask = Task { [weak self] in
@@ -185,9 +184,11 @@ public actor SerialBrewCommandCenter: BrewCommandCenter {
                     options: options,
                 )
                 if mode == .display, output.terminationStatus != 0 {
+                    // Display work runs on a terminal, which merges the streams and so leaves
+                    // `standardError` empty; the transcript is what carries brew's message.
                     throw BrewCommandError.failed(
                         exitCode: output.terminationStatus,
-                        stderr: output.standardError,
+                        stderr: CommandFailureDetail.detail(from: output),
                     )
                 }
                 return output

--- a/Sources/BrewCLI/SerialBrewCommandCenter.swift
+++ b/Sources/BrewCLI/SerialBrewCommandCenter.swift
@@ -130,10 +130,9 @@ public actor SerialBrewCommandCenter: BrewCommandCenter {
         let (lineStream, lineContinuation) = AsyncStream<BrewCommandOutputLine>.makeStream(
             bufferingPolicy: .unbounded,
         )
-        // `.display` work is only ever shown, so it runs against a pty and gets Homebrew's own colour and
-        // progress rendering. `.capture` work is parsed by its caller and stays on pipes, where stdout and
-        // stderr remain distinct — it still asks for colour explicitly, since a pipe would otherwise
-        // strip it and `brew doctor` is shown *and* parsed.
+        // `.display` work is only shown, so it runs against a pty. `.capture` work is parsed by its
+        // caller and stays on pipes, where the streams remain distinct; it still asks for colour, since a
+        // pipe strips it and `brew doctor` is shown *and* parsed.
         let options = BrewRunOptions(
             lineObserver: { line in lineContinuation.yield(line) },
             forceColor: mode == .capture,

--- a/Sources/BrewCLI/UTF8StreamDecoder.swift
+++ b/Sources/BrewCLI/UTF8StreamDecoder.swift
@@ -1,0 +1,68 @@
+//
+//  UTF8StreamDecoder.swift
+//  BrewCLI
+//
+
+import Foundation
+
+/// Decodes a byte stream that arrives in arbitrary chunks.
+///
+/// Reads land on byte boundaries the writer never chose, so a multi-byte character can be split across
+/// two of them. Only a genuinely *incomplete* trailing sequence is held back — at most three bytes.
+/// Everything else is decoded eagerly, with U+FFFD substituted for bytes that cannot be decoded, so a
+/// malformed byte costs one character rather than stalling the stream behind it.
+enum UTF8StreamDecoder {
+    /// Consumes and returns everything in `buffer` that is decodable now, leaving behind only a trailing
+    /// sequence still waiting for its continuation bytes.
+    static func takeDecodablePrefix(_ buffer: inout Data) -> String {
+        let ready = buffer.prefix(buffer.count - incompleteTrailingSequenceLength(buffer))
+        guard !ready.isEmpty else {
+            return ""
+        }
+        buffer = Data(buffer.dropFirst(ready.count))
+        return lossyString(ready)
+    }
+
+    /// Decodes bytes with U+FFFD substituted for anything invalid.
+    ///
+    /// `optional_data_string_conversion` prefers the failable initialiser, and rightly so for data that
+    /// is *supposed* to be valid, where returning nil surfaces corruption instead of hiding it. Command
+    /// output is not that: it is whatever the child happened to write, and nil there discards a whole
+    /// run's output — or a whole line of it — over one stray byte from a mangled locale or a filename
+    /// that was never UTF-8. Losing that byte is the smaller failure, and the only one a user can act on.
+    static func lossyString(_ bytes: some Collection<UInt8>) -> String {
+        // swiftlint:disable:next optional_data_string_conversion
+        String(decoding: bytes, as: UTF8.self)
+    }
+
+    /// The length of a trailing sequence whose continuation bytes have not arrived yet, or zero.
+    ///
+    /// A sequence is at most four bytes, so only the last three can be incomplete. Walks back over
+    /// continuation bytes to the lead byte and compares what it promises against what is present. A byte
+    /// that cannot start a sequence is never held back: waiting on it would stall the stream forever.
+    static func incompleteTrailingSequenceLength(_ buffer: Data) -> Int {
+        for trailing in 1 ..< 4 where trailing <= buffer.count {
+            let byte = buffer[buffer.index(buffer.endIndex, offsetBy: -trailing)]
+            if isContinuationByte(byte) {
+                continue
+            }
+            return expectedSequenceLength(leadByte: byte) > trailing ? trailing : 0
+        }
+        return 0
+    }
+
+    private static func isContinuationByte(_ byte: UInt8) -> Bool {
+        byte & 0b1100_0000 == 0b1000_0000
+    }
+
+    /// One for anything that cannot lead a multi-byte sequence, including the always-invalid `0xC0`,
+    /// `0xC1` and `0xF5...0xFF`, so such a byte is passed through to become U+FFFD rather than held back.
+    private static func expectedSequenceLength(leadByte: UInt8) -> Int {
+        switch leadByte {
+        case 0xC2 ... 0xDF: 2
+        case 0xE0 ... 0xEF: 3
+        case 0xF0 ... 0xF4: 4
+        default: 1
+        }
+    }
+}

--- a/Sources/BrewCLI/UTF8StreamDecoder.swift
+++ b/Sources/BrewCLI/UTF8StreamDecoder.swift
@@ -5,15 +5,8 @@
 
 import Foundation
 
-/// Decodes a byte stream that arrives in arbitrary chunks.
-///
-/// Reads land on byte boundaries the writer never chose, so a multi-byte character can be split across
-/// two of them. Only a genuinely *incomplete* trailing sequence is held back — at most three bytes.
-/// Everything else is decoded eagerly, with U+FFFD substituted for bytes that cannot be decoded, so a
-/// malformed byte costs one character rather than stalling the stream behind it.
+/// Decodes a byte stream that arrives in arbitrary chunks, holding back only a split trailing sequence.
 enum UTF8StreamDecoder {
-    /// Consumes and returns everything in `buffer` that is decodable now, leaving behind only a trailing
-    /// sequence still waiting for its continuation bytes.
     static func takeDecodablePrefix(_ buffer: inout Data) -> String {
         let ready = buffer.prefix(buffer.count - incompleteTrailingSequenceLength(buffer))
         guard !ready.isEmpty else {
@@ -23,23 +16,15 @@ enum UTF8StreamDecoder {
         return lossyString(ready)
     }
 
-    /// Decodes bytes with U+FFFD substituted for anything invalid.
-    ///
-    /// `optional_data_string_conversion` prefers the failable initialiser, and rightly so for data that
-    /// is *supposed* to be valid, where returning nil surfaces corruption instead of hiding it. Command
-    /// output is not that: it is whatever the child happened to write, and nil there discards a whole
-    /// run's output — or a whole line of it — over one stray byte from a mangled locale or a filename
-    /// that was never UTF-8. Losing that byte is the smaller failure, and the only one a user can act on.
+    /// Lossy on purpose: command output is whatever the child wrote, and the failable initialiser the
+    /// lint rule prefers would discard a whole run — or a whole line — over one stray byte.
     static func lossyString(_ bytes: some Collection<UInt8>) -> String {
         // swiftlint:disable:next optional_data_string_conversion
         String(decoding: bytes, as: UTF8.self)
     }
 
-    /// The length of a trailing sequence whose continuation bytes have not arrived yet, or zero.
-    ///
-    /// A sequence is at most four bytes, so only the last three can be incomplete. Walks back over
-    /// continuation bytes to the lead byte and compares what it promises against what is present. A byte
-    /// that cannot start a sequence is never held back: waiting on it would stall the stream forever.
+    /// Walks back over continuation bytes to the lead byte and compares what it promises against what is
+    /// present. A byte that cannot lead a sequence is never held back — waiting on it would never end.
     static func incompleteTrailingSequenceLength(_ buffer: Data) -> Int {
         for trailing in 1 ..< 4 where trailing <= buffer.count {
             let byte = buffer[buffer.index(buffer.endIndex, offsetBy: -trailing)]
@@ -55,13 +40,12 @@ enum UTF8StreamDecoder {
         byte & 0b1100_0000 == 0b1000_0000
     }
 
-    /// One for anything that cannot lead a multi-byte sequence, including the always-invalid `0xC0`,
-    /// `0xC1` and `0xF5...0xFF`, so such a byte is passed through to become U+FFFD rather than held back.
     private static func expectedSequenceLength(leadByte: UInt8) -> Int {
         switch leadByte {
         case 0xC2 ... 0xDF: 2
         case 0xE0 ... 0xEF: 3
         case 0xF0 ... 0xF4: 4
+        // Includes 0xC0, 0xC1 and 0xF5...0xFF, which can never lead.
         default: 1
         }
     }

--- a/Sources/BrewCore/Operations/ANSIParser.swift
+++ b/Sources/BrewCore/Operations/ANSIParser.swift
@@ -104,16 +104,13 @@ public enum ANSIParser {
         parse(input).map(\.text).joined()
     }
 
-    /// A CSI (Control Sequence Introducer) sequence, split into its parameters and the final byte that
-    /// says what it does — `m` for styling, `K` for erase-in-line, and so on.
+    /// A CSI sequence: its parameters, and the final byte saying what it does (`m` styling, `K` erase).
     struct ControlSequence: Equatable {
         let parameters: String
         let finalByte: Unicode.Scalar
     }
 
-    /// Scans the escape sequence starting at `start`, returning the index just past it and — for CSI
-    /// sequences — what it was. Shared with ``TerminalLineAssembler``, which needs the same scanning but
-    /// acts on more than just `m`.
+    /// Shared with ``TerminalLineAssembler``, which needs the same scanning but acts on more than `m`.
     static func scanEscape(
         _ scalars: [Unicode.Scalar],
         from start: Int,

--- a/Sources/BrewCore/Operations/ANSIParser.swift
+++ b/Sources/BrewCore/Operations/ANSIParser.swift
@@ -83,9 +83,9 @@ public enum ANSIParser {
                 continue
             }
 
-            let (next, sgrParameters) = skipEscape(scalars, from: index)
-            if let sgrParameters {
-                let newStyle = apply(sgrParameters, to: style)
+            let (next, control) = scanEscape(scalars, from: index)
+            if let control, control.finalByte == "m" {
+                let newStyle = apply(control.parameters, to: style)
                 if newStyle != style {
                     flush()
                     style = newStyle
@@ -104,43 +104,55 @@ public enum ANSIParser {
         parse(input).map(\.text).joined()
     }
 
-    private static func skipEscape(
+    /// A CSI (Control Sequence Introducer) sequence, split into its parameters and the final byte that
+    /// says what it does — `m` for styling, `K` for erase-in-line, and so on.
+    struct ControlSequence: Equatable {
+        let parameters: String
+        let finalByte: Unicode.Scalar
+    }
+
+    /// Scans the escape sequence starting at `start`, returning the index just past it and — for CSI
+    /// sequences — what it was. Shared with ``TerminalLineAssembler``, which needs the same scanning but
+    /// acts on more than just `m`.
+    static func scanEscape(
         _ scalars: [Unicode.Scalar],
         from start: Int,
-    ) -> (next: Int, sgrParameters: String?) {
+    ) -> (next: Int, control: ControlSequence?) {
         let afterEscape = start + 1
         guard afterEscape < scalars.count else {
-            return (next: scalars.count, sgrParameters: nil)
+            return (next: scalars.count, control: nil)
         }
 
         switch scalars[afterEscape] {
         case "[":
-            return skipControlSequence(scalars, paramsStart: afterEscape + 1)
+            return scanControlSequence(scalars, paramsStart: afterEscape + 1)
         case "]":
-            return (next: skipOperatingSystemCommand(scalars, from: afterEscape + 1), sgrParameters: nil)
+            return (next: skipOperatingSystemCommand(scalars, from: afterEscape + 1), control: nil)
         default:
             // Two-byte escape such as ESC ( or ESC =; drop ESC and the byte that follows it.
-            return (next: afterEscape + 1, sgrParameters: nil)
+            return (next: afterEscape + 1, control: nil)
         }
     }
 
-    private static func skipControlSequence(
+    private static func scanControlSequence(
         _ scalars: [Unicode.Scalar],
         paramsStart: Int,
-    ) -> (next: Int, sgrParameters: String?) {
+    ) -> (next: Int, control: ControlSequence?) {
         var cursor = paramsStart
         var parameters = ""
         while cursor < scalars.count {
             let scalar = scalars[cursor]
             // Final bytes are in 0x40...0x7E; parameter/intermediate bytes (digits, ';', ' ', etc.) precede them.
             if scalar.value >= 0x40, scalar.value <= 0x7E {
-                let isSGR = scalar == "m"
-                return (next: cursor + 1, sgrParameters: isSGR ? parameters : nil)
+                return (
+                    next: cursor + 1,
+                    control: ControlSequence(parameters: parameters, finalByte: scalar),
+                )
             }
             parameters.unicodeScalars.append(scalar)
             cursor += 1
         }
-        return (next: scalars.count, sgrParameters: nil)
+        return (next: scalars.count, control: nil)
     }
 
     /// Skips an OSC sequence, which runs until BEL (0x07) or the ST terminator (ESC `\`).
@@ -160,7 +172,7 @@ public enum ANSIParser {
 
     /// Applies one SGR parameter string to `style`. An empty parameter string is treated as a reset
     /// (`ESC[m` == `ESC[0m`).
-    private static func apply(_ parameters: String, to style: ANSIStyle) -> ANSIStyle {
+    static func apply(_ parameters: String, to style: ANSIStyle) -> ANSIStyle {
         let codes = parameters.isEmpty
             ? [0]
             : parameters.split(separator: ";", omittingEmptySubsequences: false).map { Int($0) ?? 0 }

--- a/Sources/BrewCore/Operations/BrewCommandOutputLine.swift
+++ b/Sources/BrewCore/Operations/BrewCommandOutputLine.swift
@@ -6,21 +6,72 @@
 import Foundation
 
 /// One line of subprocess output, attributed to a stream (`ARCHITECTURE.md` — command execution; transparency).
+///
+/// A line is not always final when it first appears. Terminal-backed runs report a line while it is still
+/// being drawn — a progress bar revises the same line hundreds of times before a newline settles it — so
+/// ``isComplete`` tells consumers whether to expect the line to change again. Pipe-backed runs have no
+/// redraws and only ever produce complete lines.
 public struct BrewCommandOutputLine: Identifiable, Equatable, Sendable {
     public let id: UUID
     public let stream: Stream
     public let text: String
     public let timestamp: Date
 
+    /// The line's visible content split into styled runs, resolved once when the line is created rather
+    /// than re-parsed on every render.
+    public let spans: [ANSISpan]
+
+    /// `false` while the line is still being drawn and may be revised; `true` once it is settled.
+    public let isComplete: Bool
+
     public enum Stream: Equatable, Sendable {
         case stdout
         case stderr
     }
 
-    public init(stream: Stream, text: String, timestamp: Date = Date(), id: UUID = UUID()) {
+    public init(
+        stream: Stream,
+        text: String,
+        timestamp: Date = Date(),
+        id: UUID = UUID(),
+        isComplete: Bool = true,
+    ) {
         self.id = id
         self.stream = stream
         self.text = text
         self.timestamp = timestamp
+        self.isComplete = isComplete
+        spans = ANSIParser.parse(text)
+    }
+
+    /// Builds a line from an assembled terminal line, whose styling and overwrites are already resolved.
+    public init(
+        stream: Stream,
+        line: TerminalLine,
+        isComplete: Bool,
+        timestamp: Date = Date(),
+        id: UUID = UUID(),
+    ) {
+        self.id = id
+        self.stream = stream
+        text = line.text
+        self.timestamp = timestamp
+        self.isComplete = isComplete
+        spans = line.spans
+    }
+
+    /// A copy carrying `other`'s identity, so a revision replaces its predecessor in place rather than
+    /// reading as a new row to anything keyed on ``id``.
+    public func adoptingIdentity(of other: BrewCommandOutputLine) -> BrewCommandOutputLine {
+        BrewCommandOutputLine(copying: self, id: other.id)
+    }
+
+    private init(copying other: BrewCommandOutputLine, id: UUID) {
+        self.id = id
+        stream = other.stream
+        text = other.text
+        timestamp = other.timestamp
+        isComplete = other.isComplete
+        spans = other.spans
     }
 }

--- a/Sources/BrewCore/Operations/BrewCommandOutputLine.swift
+++ b/Sources/BrewCore/Operations/BrewCommandOutputLine.swift
@@ -5,23 +5,20 @@
 
 import Foundation
 
-/// One line of subprocess output, attributed to a stream (`ARCHITECTURE.md` — command execution; transparency).
+/// One line of subprocess output, attributed to a stream (`ARCHITECTURE.md` — command execution).
 ///
-/// A line is not always final when it first appears. Terminal-backed runs report a line while it is still
-/// being drawn — a progress bar revises the same line hundreds of times before a newline settles it — so
-/// ``isComplete`` tells consumers whether to expect the line to change again. Pipe-backed runs have no
-/// redraws and only ever produce complete lines.
+/// Terminal-backed runs report a line while it is still being drawn, since a progress bar revises the
+/// same line many times before a newline settles it. Pipe-backed runs only ever produce complete lines.
 public struct BrewCommandOutputLine: Identifiable, Equatable, Sendable {
     public let id: UUID
     public let stream: Stream
     public let text: String
     public let timestamp: Date
 
-    /// The line's visible content split into styled runs, resolved once when the line is created rather
-    /// than re-parsed on every render.
+    /// Resolved once here rather than re-parsed on every render.
     public let spans: [ANSISpan]
 
-    /// `false` while the line is still being drawn and may be revised; `true` once it is settled.
+    /// `false` while the line may still be revised.
     public let isComplete: Bool
 
     public enum Stream: Equatable, Sendable {
@@ -44,7 +41,7 @@ public struct BrewCommandOutputLine: Identifiable, Equatable, Sendable {
         spans = ANSIParser.parse(text)
     }
 
-    /// Builds a line from an assembled terminal line, whose styling and overwrites are already resolved.
+    /// Styling and overwrites are already resolved by the assembler.
     public init(
         stream: Stream,
         line: TerminalLine,
@@ -60,8 +57,7 @@ public struct BrewCommandOutputLine: Identifiable, Equatable, Sendable {
         spans = line.spans
     }
 
-    /// A copy carrying `other`'s identity, so a revision replaces its predecessor in place rather than
-    /// reading as a new row to anything keyed on ``id``.
+    /// So a revision replaces its predecessor in place for anything keyed on ``id``.
     public func adoptingIdentity(of other: BrewCommandOutputLine) -> BrewCommandOutputLine {
         BrewCommandOutputLine(copying: self, id: other.id)
     }

--- a/Sources/BrewCore/Operations/BrewRunOptions.swift
+++ b/Sources/BrewCore/Operations/BrewRunOptions.swift
@@ -15,19 +15,14 @@ public struct BrewRunOptions: Sendable {
     /// Called with each `\n`-delimited line as it arrives, for live console display. Nil = buffered, no streaming.
     public var lineObserver: (@Sendable (BrewCommandOutputLine) -> Void)?
 
-    /// Force Homebrew to emit ANSI colour, which it strips off a non-TTY (a pipe). Set for console-shown work
-    /// that stays pipe-backed. Redundant when ``usesPseudoTerminal`` is set — a terminal gets colour anyway.
+    /// Homebrew strips colour off a non-TTY. Redundant when ``usesPseudoTerminal`` is set.
     public var forceColor: Bool
 
-    /// Run the subprocess against a pseudo-terminal instead of pipes, so `isatty` is true in the child.
+    /// Run against a pseudo-terminal instead of pipes, so `isatty` is true in the child: Homebrew emits
+    /// its progress rendering, and libc line-buffers instead of block-buffering.
     ///
-    /// Two consequences, both wanted for console-shown work: Homebrew and the tools it shells out to emit
-    /// their progress rendering, and libc switches from block buffering to line buffering so output arrives
-    /// as it is produced rather than in multi-kilobyte bursts.
-    ///
-    /// The cost is that a single terminal device carries both streams, so stdout and stderr arrive merged
-    /// and every line is attributed to ``BrewCommandOutputLine/Stream/stdout``. Runs whose output gets
-    /// parsed should leave this off and stay on pipes, where the two streams remain distinct.
+    /// The cost is that one device carries both streams, so they arrive merged and every line is
+    /// attributed to ``BrewCommandOutputLine/Stream/stdout``. Runs whose output gets parsed stay on pipes.
     public var usesPseudoTerminal: Bool
 
     public init(

--- a/Sources/BrewCore/Operations/BrewRunOptions.swift
+++ b/Sources/BrewCore/Operations/BrewRunOptions.swift
@@ -7,31 +7,38 @@ import Foundation
 
 /// How a subprocess run should surface its output.
 ///
-/// Streaming, colour, and terminal-backing are orthogonal. Background reads use none of them (silent,
-/// colourless, buffered, pipe-backed). Because colourised output may also be parsed (`brew doctor` is shown
-/// in colour *and* parsed), the rule is the defensive one: any consumer that parses strips ANSI first —
+/// Streaming and the output channel are orthogonal. Background reads use neither (silent, buffered,
+/// pipe-backed, colourless). Because colourised output may also be parsed (`brew doctor` is shown in
+/// colour *and* parsed), the rule is the defensive one: any consumer that parses strips ANSI first —
 /// colour is a display concern the parser must ignore.
 public struct BrewRunOptions: Sendable {
-    /// Called with each `\n`-delimited line as it arrives, for live console display. Nil = buffered, no streaming.
+    /// Where the child's stdout and stderr go. This decides what the child sees from `isatty`, whether
+    /// the two streams stay distinguishable, and therefore where colour comes from — one choice, so it
+    /// is one value rather than a set of flags that can contradict each other.
+    public enum OutputChannel: Equatable, Sendable {
+        /// Separate pipes, so stdout and stderr stay distinct. The path for output that gets parsed.
+        /// Homebrew strips colour off a pipe, hence the explicit ask.
+        case pipes(forceColor: Bool)
+
+        /// A pseudo-terminal, so `isatty` is true in the child: Homebrew emits its own progress
+        /// rendering and libc line-buffers instead of block-buffering. Colour needs no asking for.
+        ///
+        /// The cost is that one device carries both streams, so they arrive merged, every line is
+        /// attributed to ``BrewCommandOutputLine/Stream/stdout``, and ``CommandOutput/standardError``
+        /// comes back empty. Runs whose output gets parsed must use ``pipes(forceColor:)``.
+        case pseudoTerminal
+    }
+
+    /// Called with each line as it arrives, for live console display. Nil = buffered, no streaming.
     public var lineObserver: (@Sendable (BrewCommandOutputLine) -> Void)?
 
-    /// Homebrew strips colour off a non-TTY. Redundant when ``usesPseudoTerminal`` is set.
-    public var forceColor: Bool
-
-    /// Run against a pseudo-terminal instead of pipes, so `isatty` is true in the child: Homebrew emits
-    /// its progress rendering, and libc line-buffers instead of block-buffering.
-    ///
-    /// The cost is that one device carries both streams, so they arrive merged and every line is
-    /// attributed to ``BrewCommandOutputLine/Stream/stdout``. Runs whose output gets parsed stay on pipes.
-    public var usesPseudoTerminal: Bool
+    public var output: OutputChannel
 
     public init(
         lineObserver: (@Sendable (BrewCommandOutputLine) -> Void)? = nil,
-        forceColor: Bool = false,
-        usesPseudoTerminal: Bool = false,
+        output: OutputChannel = .pipes(forceColor: false),
     ) {
         self.lineObserver = lineObserver
-        self.forceColor = forceColor
-        self.usesPseudoTerminal = usesPseudoTerminal
+        self.output = output
     }
 }

--- a/Sources/BrewCore/Operations/BrewRunOptions.swift
+++ b/Sources/BrewCore/Operations/BrewRunOptions.swift
@@ -7,22 +7,36 @@ import Foundation
 
 /// How a subprocess run should surface its output.
 ///
-/// Streaming and colour are orthogonal. Background reads use neither (silent, colourless, buffered);
-/// output shown to the user uses both. Because colourised output may also be parsed (`brew doctor` is shown
+/// Streaming, colour, and terminal-backing are orthogonal. Background reads use none of them (silent,
+/// colourless, buffered, pipe-backed). Because colourised output may also be parsed (`brew doctor` is shown
 /// in colour *and* parsed), the rule is the defensive one: any consumer that parses strips ANSI first —
 /// colour is a display concern the parser must ignore.
 public struct BrewRunOptions: Sendable {
     /// Called with each `\n`-delimited line as it arrives, for live console display. Nil = buffered, no streaming.
     public var lineObserver: (@Sendable (BrewCommandOutputLine) -> Void)?
 
-    /// Force Homebrew to emit ANSI colour, which it strips off a non-TTY (a pipe). Set for console-shown work.
+    /// Force Homebrew to emit ANSI colour, which it strips off a non-TTY (a pipe). Set for console-shown work
+    /// that stays pipe-backed. Redundant when ``usesPseudoTerminal`` is set — a terminal gets colour anyway.
     public var forceColor: Bool
+
+    /// Run the subprocess against a pseudo-terminal instead of pipes, so `isatty` is true in the child.
+    ///
+    /// Two consequences, both wanted for console-shown work: Homebrew and the tools it shells out to emit
+    /// their progress rendering, and libc switches from block buffering to line buffering so output arrives
+    /// as it is produced rather than in multi-kilobyte bursts.
+    ///
+    /// The cost is that a single terminal device carries both streams, so stdout and stderr arrive merged
+    /// and every line is attributed to ``BrewCommandOutputLine/Stream/stdout``. Runs whose output gets
+    /// parsed should leave this off and stay on pipes, where the two streams remain distinct.
+    public var usesPseudoTerminal: Bool
 
     public init(
         lineObserver: (@Sendable (BrewCommandOutputLine) -> Void)? = nil,
         forceColor: Bool = false,
+        usesPseudoTerminal: Bool = false,
     ) {
         self.lineObserver = lineObserver
         self.forceColor = forceColor
+        self.usesPseudoTerminal = usesPseudoTerminal
     }
 }

--- a/Sources/BrewCore/Operations/BrewRunOptions.swift
+++ b/Sources/BrewCore/Operations/BrewRunOptions.swift
@@ -12,20 +12,15 @@ import Foundation
 /// colour *and* parsed), the rule is the defensive one: any consumer that parses strips ANSI first —
 /// colour is a display concern the parser must ignore.
 public struct BrewRunOptions: Sendable {
-    /// Where the child's stdout and stderr go. This decides what the child sees from `isatty`, whether
-    /// the two streams stay distinguishable, and therefore where colour comes from — one choice, so it
-    /// is one value rather than a set of flags that can contradict each other.
+    /// Where the child's stdout and stderr go.
     public enum OutputChannel: Equatable, Sendable {
-        /// Separate pipes, so stdout and stderr stay distinct. The path for output that gets parsed.
+        /// Separate pipes, so the streams stay distinct. The path for output that gets parsed.
         /// Homebrew strips colour off a pipe, hence the explicit ask.
         case pipes(forceColor: Bool)
 
         /// A pseudo-terminal, so `isatty` is true in the child: Homebrew emits its own progress
-        /// rendering and libc line-buffers instead of block-buffering. Colour needs no asking for.
-        ///
-        /// The cost is that one device carries both streams, so they arrive merged, every line is
-        /// attributed to ``BrewCommandOutputLine/Stream/stdout``, and ``CommandOutput/standardError``
-        /// comes back empty. Runs whose output gets parsed must use ``pipes(forceColor:)``.
+        /// rendering and libc line-buffers. One device carries both streams, so they arrive merged,
+        /// every line is attributed to stdout, and ``CommandOutput/standardError`` comes back empty.
         case pseudoTerminal
     }
 

--- a/Sources/BrewCore/Operations/TerminalLineAssembler.swift
+++ b/Sources/BrewCore/Operations/TerminalLineAssembler.swift
@@ -5,55 +5,39 @@
 
 import Foundation
 
-/// One line of terminal output as it currently stands, after every overwrite has been applied.
+/// A line of terminal output after every overwrite has been applied.
 public struct TerminalLine: Equatable, Sendable {
-    /// The visible content, split into runs that share a style.
     public let spans: [ANSISpan]
 
     public init(spans: [ANSISpan]) {
         self.spans = spans
     }
 
-    /// The visible content with styling dropped — for export, parsing, and comparison.
+    /// Visible content with styling dropped, for export and parsing.
     public var text: String {
         spans.map(\.text).joined()
     }
 }
 
-/// What consuming a chunk of terminal output produced.
 public enum TerminalLineEvent: Equatable, Sendable {
-    /// A line ended with a newline and will not change again.
+    /// Ended with a newline; will not change again.
     case committed(TerminalLine)
-    /// The line currently being written changed. It may change again, or be committed later.
+    /// Still being written; may change again before it commits.
     case revised(TerminalLine)
 }
 
-/// Applies terminal overwrite semantics to a byte stream, turning it into lines that settle.
+/// Applies terminal overwrite semantics to a byte stream.
 ///
-/// A terminal is not an append-only transcript: a carriage return moves the cursor back to the start of
-/// the line and what follows overwrites what was there. Programs that draw progress use this constantly —
-/// `curl` redraws its bar hundreds of times, every redraw separated by `\r` with no newline between them.
-/// Split that stream on newlines alone and a whole download collapses into one enormous "line" holding
-/// every intermediate state; render it verbatim and every redraw shows up as its own row.
+/// A terminal is not an append-only transcript: a carriage return moves the cursor back to column zero
+/// and what follows overwrites what was there. `curl` redraws its progress bar hundreds of times that
+/// way, with no newline between redraws, so splitting on newlines alone collapses a whole download into
+/// one enormous line holding every intermediate state.
 ///
-/// This type keeps the line as a grid of cells with a cursor, exactly as a terminal does, so an overwrite
-/// replaces earlier content instead of accumulating after it. It models what `brew` and the tools it
-/// shells out to actually emit:
-///   - `\r` returns the cursor to column zero
-///   - `\b` steps it back one column
-///   - `\n` commits the line and starts a new one
-///   - `ESC[K` erases from the cursor to the end of the line (`0`), to the start (`1`), or all of it (`2`)
-///   - SGR sequences set the style applied to cells written from then on
-///
-/// Cursor *movement* between lines (`ESC[A` and friends, used for multi-line progress displays) is not
-/// modelled: those sequences are consumed and ignored, which leaves the affected lines as separate rows
-/// rather than a redrawn block. Nothing Homebrew emits needs it today, and doing it properly means a
-/// screen buffer rather than a line — a different data model, and a much bigger change.
-///
-/// Style deliberately carries across lines, matching a real terminal: a colour opened on one line stays
-/// in effect until something resets it.
+/// Keeping the line as cells with a cursor makes an overwrite replace earlier content. Handles `\r`,
+/// `\b`, `\n`, `ESC[K` and SGR. Cursor movement *between* lines (`ESC[A` and friends, used for
+/// multi-line progress blocks) is consumed and ignored: doing it properly needs a screen buffer rather
+/// than a line. Style carries across lines, as it does in a real terminal.
 public struct TerminalLineAssembler: Sendable {
-    /// A single character cell, carrying the style in effect when it was written.
     private struct Cell: Equatable {
         var character: Character
         var style: ANSIStyle
@@ -67,21 +51,17 @@ public struct TerminalLineAssembler: Sendable {
 
     public init() {}
 
-    /// Whether anything has been written to the current, uncommitted line.
     public var hasPendingLine: Bool {
         !cells.isEmpty
     }
 
-    /// The current, uncommitted line.
     public var pendingLine: TerminalLine {
         TerminalLine(spans: Self.spans(from: cells))
     }
 
-    /// Consumes a chunk of output, returning the lines it completed and — if the in-progress line changed
-    /// — a final ``TerminalLineEvent/revised(_:)`` carrying its current state.
-    ///
-    /// Coalescing the revision to one event per chunk is deliberate: a progress bar writes far faster than
-    /// a UI needs to repaint, and one chunk is exactly one write as it reached us.
+    /// Returns the lines this chunk completed, plus one ``TerminalLineEvent/revised(_:)`` if the
+    /// in-progress line changed. One revision per chunk rather than per write: a progress bar writes far
+    /// faster than a UI needs to repaint.
     public mutating func consume(_ input: String) -> [TerminalLineEvent] {
         guard !input.isEmpty else {
             return []
@@ -115,7 +95,7 @@ public struct TerminalLineAssembler: Sendable {
                 }
                 index = next
             default:
-                // Other C0 controls (bell, tabs we do not expand) carry no visible content.
+                // Other C0 controls (bell, tabs) carry no visible content.
                 if scalar.value < 0x20 {
                     index += 1
                     continue
@@ -132,8 +112,7 @@ public struct TerminalLineAssembler: Sendable {
         return events
     }
 
-    /// Commits whatever is left in the in-progress line, for use when the stream ends without a trailing
-    /// newline. Returns nil when there is nothing pending.
+    /// Commits the in-progress line when the stream ends without a trailing newline.
     public mutating func flush() -> TerminalLine? {
         guard !cells.isEmpty else {
             return nil
@@ -144,8 +123,7 @@ public struct TerminalLineAssembler: Sendable {
         return line
     }
 
-    /// Writes one character at the cursor, padding with spaces if the cursor has been moved past the end
-    /// of what is currently there.
+    /// Pads with spaces if the cursor has moved past the end of the line.
     private mutating func write(_ character: Character) {
         if column > cells.count {
             cells.append(contentsOf: repeatElement(Cell(character: " ", style: style), count: column - cells.count))
@@ -159,7 +137,7 @@ public struct TerminalLineAssembler: Sendable {
         column += 1
     }
 
-    /// Applies a control sequence, returning whether it changed the visible line.
+    /// Returns whether the sequence changed the visible line.
     private mutating func apply(_ control: ANSIParser.ControlSequence) -> Bool {
         switch control.finalByte {
         case "m":
@@ -172,8 +150,8 @@ public struct TerminalLineAssembler: Sendable {
         }
     }
 
-    /// `ESC[K` — erase to the end of the line (0, the default), to the start (1), or the whole line (2).
-    /// Erasing to the start blanks the cells rather than removing them, so the cursor keeps its column.
+    /// Erase to end of line (0, the default), to the start (1), or all of it (2). Erasing to the start
+    /// blanks cells rather than removing them, so the cursor keeps its column.
     private mutating func eraseInLine(mode: Int) -> Bool {
         switch mode {
         case 0:
@@ -202,7 +180,7 @@ public struct TerminalLineAssembler: Sendable {
         }
     }
 
-    /// Merges adjacent cells that share a style into spans.
+    /// Merges adjacent cells sharing a style.
     private static func spans(from cells: [Cell]) -> [ANSISpan] {
         var spans: [ANSISpan] = []
         var text = ""

--- a/Sources/BrewCore/Operations/TerminalLineAssembler.swift
+++ b/Sources/BrewCore/Operations/TerminalLineAssembler.swift
@@ -34,9 +34,10 @@ public enum TerminalLineEvent: Equatable, Sendable {
 /// one enormous line holding every intermediate state.
 ///
 /// Keeping the line as cells with a cursor makes an overwrite replace earlier content. Handles `\r`,
-/// `\b`, `\n`, `ESC[K` and SGR. Cursor movement *between* lines (`ESC[A` and friends, used for
-/// multi-line progress blocks) is consumed and ignored: doing it properly needs a screen buffer rather
-/// than a line. Style carries across lines, as it does in a real terminal.
+/// `\b`, `\n`, `ESC[K`, the within-line cursor moves `ESC[G`, `ESC[C` and `ESC[D`, and SGR. Cursor
+/// movement *between* lines (`ESC[A` and friends, used for multi-line progress blocks) is consumed and
+/// ignored: doing it properly needs a screen buffer rather than a line. Style carries across lines, as
+/// it does in a real terminal.
 public struct TerminalLineAssembler: Sendable {
     private struct Cell: Equatable {
         var character: Character
@@ -44,6 +45,10 @@ public struct TerminalLineAssembler: Sendable {
     }
 
     private static let escape: Unicode.Scalar = "\u{1B}"
+
+    /// Well past any real terminal width. A malformed or hostile `ESC[999999999C` would otherwise ask
+    /// for a column the next write has to pad every cell up to.
+    private static let maxColumn = 4096
 
     private var cells: [Cell] = []
     private var column = 0
@@ -137,21 +142,47 @@ public struct TerminalLineAssembler: Sendable {
         column += 1
     }
 
-    /// Returns whether the sequence changed the visible line.
+    /// Returns whether the sequence changed the visible line. Moving the cursor never does on its own —
+    /// the write that follows is what shows.
     private mutating func apply(_ control: ANSIParser.ControlSequence) -> Bool {
         switch control.finalByte {
         case "m":
             style = ANSIParser.apply(control.parameters, to: style)
             return false
         case "K":
-            return eraseInLine(mode: Int(control.parameters) ?? 0)
+            return eraseInLine(mode: Self.parameter(control, default: 0))
+        case "G":
+            // Absolute column, 1-based. Several progress renderers use this where `curl` uses `\r`, so
+            // ignoring it would let a redraw append instead of overwrite.
+            move(to: Self.parameter(control, default: 1) - 1)
+            return false
+        case "C":
+            move(to: column + max(1, Self.parameter(control, default: 1)))
+            return false
+        case "D":
+            move(to: column - max(1, Self.parameter(control, default: 1)))
+            return false
         default:
             return false
         }
     }
 
+    private mutating func move(to target: Int) {
+        column = min(Self.maxColumn, max(0, target))
+    }
+
+    /// The first CSI parameter, or the sequence's documented default when it is absent or unreadable.
+    private static func parameter(_ control: ANSIParser.ControlSequence, default fallback: Int) -> Int {
+        guard let first = control.parameters.split(separator: ";").first, let value = Int(first) else {
+            return fallback
+        }
+        return value
+    }
+
     /// Erase to end of line (0, the default), to the start (1), or all of it (2). Erasing to the start
-    /// blanks cells rather than removing them, so the cursor keeps its column.
+    /// blanks cells rather than removing them, so the cursor keeps its column. Blanks take the *current*
+    /// style, which is what a terminal erases with — carrying the old one over would leave a stale
+    /// background behind.
     private mutating func eraseInLine(mode: Int) -> Bool {
         switch mode {
         case 0:
@@ -166,7 +197,7 @@ public struct TerminalLineAssembler: Sendable {
                 return false
             }
             for index in 0 ..< end {
-                cells[index].character = " "
+                cells[index] = Cell(character: " ", style: style)
             }
             return true
         case 2:

--- a/Sources/BrewCore/Operations/TerminalLineAssembler.swift
+++ b/Sources/BrewCore/Operations/TerminalLineAssembler.swift
@@ -46,8 +46,7 @@ public struct TerminalLineAssembler: Sendable {
 
     private static let escape: Unicode.Scalar = "\u{1B}"
 
-    /// Well past any real terminal width. A malformed or hostile `ESC[999999999C` would otherwise ask
-    /// for a column the next write has to pad every cell up to.
+    /// Well past any real width; caps what a malformed `ESC[999999999C` makes the next write pad.
     private static let maxColumn = 4096
 
     private var cells: [Cell] = []
@@ -142,8 +141,7 @@ public struct TerminalLineAssembler: Sendable {
         column += 1
     }
 
-    /// Returns whether the sequence changed the visible line. Moving the cursor never does on its own —
-    /// the write that follows is what shows.
+    /// Returns whether the sequence changed the visible line; moving the cursor never does on its own.
     private mutating func apply(_ control: ANSIParser.ControlSequence) -> Bool {
         switch control.finalByte {
         case "m":
@@ -152,8 +150,7 @@ public struct TerminalLineAssembler: Sendable {
         case "K":
             return eraseInLine(mode: Self.parameter(control, default: 0))
         case "G":
-            // Absolute column, 1-based. Several progress renderers use this where `curl` uses `\r`, so
-            // ignoring it would let a redraw append instead of overwrite.
+            // Absolute column, 1-based. Some progress renderers use this where `curl` uses `\r`.
             move(to: Self.parameter(control, default: 1) - 1)
             return false
         case "C":
@@ -171,7 +168,6 @@ public struct TerminalLineAssembler: Sendable {
         column = min(Self.maxColumn, max(0, target))
     }
 
-    /// The first CSI parameter, or the sequence's documented default when it is absent or unreadable.
     private static func parameter(_ control: ANSIParser.ControlSequence, default fallback: Int) -> Int {
         guard let first = control.parameters.split(separator: ";").first, let value = Int(first) else {
             return fallback
@@ -180,9 +176,8 @@ public struct TerminalLineAssembler: Sendable {
     }
 
     /// Erase to end of line (0, the default), to the start (1), or all of it (2). Erasing to the start
-    /// blanks cells rather than removing them, so the cursor keeps its column. Blanks take the *current*
-    /// style, which is what a terminal erases with — carrying the old one over would leave a stale
-    /// background behind.
+    /// blanks cells rather than removing them, so the cursor keeps its column, and blanks take the
+    /// current style, which is what a terminal erases with.
     private mutating func eraseInLine(mode: Int) -> Bool {
         switch mode {
         case 0:

--- a/Sources/BrewCore/Operations/TerminalLineAssembler.swift
+++ b/Sources/BrewCore/Operations/TerminalLineAssembler.swift
@@ -1,0 +1,225 @@
+//
+//  TerminalLineAssembler.swift
+//  BrewCore
+//
+
+import Foundation
+
+/// One line of terminal output as it currently stands, after every overwrite has been applied.
+public struct TerminalLine: Equatable, Sendable {
+    /// The visible content, split into runs that share a style.
+    public let spans: [ANSISpan]
+
+    public init(spans: [ANSISpan]) {
+        self.spans = spans
+    }
+
+    /// The visible content with styling dropped — for export, parsing, and comparison.
+    public var text: String {
+        spans.map(\.text).joined()
+    }
+}
+
+/// What consuming a chunk of terminal output produced.
+public enum TerminalLineEvent: Equatable, Sendable {
+    /// A line ended with a newline and will not change again.
+    case committed(TerminalLine)
+    /// The line currently being written changed. It may change again, or be committed later.
+    case revised(TerminalLine)
+}
+
+/// Applies terminal overwrite semantics to a byte stream, turning it into lines that settle.
+///
+/// A terminal is not an append-only transcript: a carriage return moves the cursor back to the start of
+/// the line and what follows overwrites what was there. Programs that draw progress use this constantly —
+/// `curl` redraws its bar hundreds of times, every redraw separated by `\r` with no newline between them.
+/// Split that stream on newlines alone and a whole download collapses into one enormous "line" holding
+/// every intermediate state; render it verbatim and every redraw shows up as its own row.
+///
+/// This type keeps the line as a grid of cells with a cursor, exactly as a terminal does, so an overwrite
+/// replaces earlier content instead of accumulating after it. It models what `brew` and the tools it
+/// shells out to actually emit:
+///   - `\r` returns the cursor to column zero
+///   - `\b` steps it back one column
+///   - `\n` commits the line and starts a new one
+///   - `ESC[K` erases from the cursor to the end of the line (`0`), to the start (`1`), or all of it (`2`)
+///   - SGR sequences set the style applied to cells written from then on
+///
+/// Cursor *movement* between lines (`ESC[A` and friends, used for multi-line progress displays) is not
+/// modelled: those sequences are consumed and ignored, which leaves the affected lines as separate rows
+/// rather than a redrawn block. Nothing Homebrew emits needs it today, and doing it properly means a
+/// screen buffer rather than a line — a different data model, and a much bigger change.
+///
+/// Style deliberately carries across lines, matching a real terminal: a colour opened on one line stays
+/// in effect until something resets it.
+public struct TerminalLineAssembler: Sendable {
+    /// A single character cell, carrying the style in effect when it was written.
+    private struct Cell: Equatable {
+        var character: Character
+        var style: ANSIStyle
+    }
+
+    private static let escape: Unicode.Scalar = "\u{1B}"
+
+    private var cells: [Cell] = []
+    private var column = 0
+    private var style = ANSIStyle.default
+
+    public init() {}
+
+    /// Whether anything has been written to the current, uncommitted line.
+    public var hasPendingLine: Bool {
+        !cells.isEmpty
+    }
+
+    /// The current, uncommitted line.
+    public var pendingLine: TerminalLine {
+        TerminalLine(spans: Self.spans(from: cells))
+    }
+
+    /// Consumes a chunk of output, returning the lines it completed and — if the in-progress line changed
+    /// — a final ``TerminalLineEvent/revised(_:)`` carrying its current state.
+    ///
+    /// Coalescing the revision to one event per chunk is deliberate: a progress bar writes far faster than
+    /// a UI needs to repaint, and one chunk is exactly one write as it reached us.
+    public mutating func consume(_ input: String) -> [TerminalLineEvent] {
+        guard !input.isEmpty else {
+            return []
+        }
+
+        var events: [TerminalLineEvent] = []
+        var pendingChanged = false
+        let scalars = Array(input.unicodeScalars)
+        var index = 0
+
+        while index < scalars.count {
+            let scalar = scalars[index]
+
+            switch scalar {
+            case "\n":
+                events.append(.committed(TerminalLine(spans: Self.spans(from: cells))))
+                cells = []
+                column = 0
+                pendingChanged = false
+                index += 1
+            case "\r":
+                column = 0
+                index += 1
+            case "\u{08}":
+                column = max(0, column - 1)
+                index += 1
+            case Self.escape:
+                let (next, control) = ANSIParser.scanEscape(scalars, from: index)
+                if let control {
+                    pendingChanged = apply(control) || pendingChanged
+                }
+                index = next
+            default:
+                // Other C0 controls (bell, tabs we do not expand) carry no visible content.
+                if scalar.value < 0x20 {
+                    index += 1
+                    continue
+                }
+                write(Character(scalar))
+                pendingChanged = true
+                index += 1
+            }
+        }
+
+        if pendingChanged {
+            events.append(.revised(TerminalLine(spans: Self.spans(from: cells))))
+        }
+        return events
+    }
+
+    /// Commits whatever is left in the in-progress line, for use when the stream ends without a trailing
+    /// newline. Returns nil when there is nothing pending.
+    public mutating func flush() -> TerminalLine? {
+        guard !cells.isEmpty else {
+            return nil
+        }
+        let line = TerminalLine(spans: Self.spans(from: cells))
+        cells = []
+        column = 0
+        return line
+    }
+
+    /// Writes one character at the cursor, padding with spaces if the cursor has been moved past the end
+    /// of what is currently there.
+    private mutating func write(_ character: Character) {
+        if column > cells.count {
+            cells.append(contentsOf: repeatElement(Cell(character: " ", style: style), count: column - cells.count))
+        }
+        let cell = Cell(character: character, style: style)
+        if column < cells.count {
+            cells[column] = cell
+        } else {
+            cells.append(cell)
+        }
+        column += 1
+    }
+
+    /// Applies a control sequence, returning whether it changed the visible line.
+    private mutating func apply(_ control: ANSIParser.ControlSequence) -> Bool {
+        switch control.finalByte {
+        case "m":
+            style = ANSIParser.apply(control.parameters, to: style)
+            return false
+        case "K":
+            return eraseInLine(mode: Int(control.parameters) ?? 0)
+        default:
+            return false
+        }
+    }
+
+    /// `ESC[K` — erase to the end of the line (0, the default), to the start (1), or the whole line (2).
+    /// Erasing to the start blanks the cells rather than removing them, so the cursor keeps its column.
+    private mutating func eraseInLine(mode: Int) -> Bool {
+        switch mode {
+        case 0:
+            guard column < cells.count else {
+                return false
+            }
+            cells.removeSubrange(column...)
+            return true
+        case 1:
+            let end = min(column + 1, cells.count)
+            guard end > 0 else {
+                return false
+            }
+            for index in 0 ..< end {
+                cells[index].character = " "
+            }
+            return true
+        case 2:
+            guard !cells.isEmpty else {
+                return false
+            }
+            cells = []
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Merges adjacent cells that share a style into spans.
+    private static func spans(from cells: [Cell]) -> [ANSISpan] {
+        var spans: [ANSISpan] = []
+        var text = ""
+        var currentStyle: ANSIStyle?
+
+        for cell in cells {
+            if let currentStyle, currentStyle != cell.style {
+                spans.append(ANSISpan(text: text, style: currentStyle))
+                text = ""
+            }
+            currentStyle = cell.style
+            text.append(cell.character)
+        }
+
+        if let currentStyle, !text.isEmpty {
+            spans.append(ANSISpan(text: text, style: currentStyle))
+        }
+        return spans
+    }
+}

--- a/Sources/BrewFeatureConsole/Views/ANSIConsoleText.swift
+++ b/Sources/BrewFeatureConsole/Views/ANSIConsoleText.swift
@@ -11,9 +11,11 @@ import SwiftUI
 /// as it did before ANSI support. Bold spans get a bold monospaced font; every other run is left
 /// fontless so it inherits the `Text`'s base font — setting a font on all runs would defeat that.
 enum ANSIConsoleText {
+    /// Renders the line's already-resolved spans. Resolution happens where the line is built — off the
+    /// main actor, once — rather than being re-parsed on every render pass.
     static func attributed(for line: BrewCommandOutputLine, defaultColor: Color) -> AttributedString {
         var result = AttributedString()
-        for span in ANSIParser.parse(line.text) {
+        for span in line.spans {
             var piece = AttributedString(span.text)
             piece.foregroundColor = span.style.foreground.map(color(for:)) ?? defaultColor
             if span.style.bold {

--- a/Sources/BrewFeatureConsole/Views/ANSIConsoleText.swift
+++ b/Sources/BrewFeatureConsole/Views/ANSIConsoleText.swift
@@ -11,8 +11,7 @@ import SwiftUI
 /// as it did before ANSI support. Bold spans get a bold monospaced font; every other run is left
 /// fontless so it inherits the `Text`'s base font — setting a font on all runs would defeat that.
 enum ANSIConsoleText {
-    /// Renders the line's already-resolved spans. Resolution happens where the line is built — off the
-    /// main actor, once — rather than being re-parsed on every render pass.
+    /// Spans are resolved once where the line is built, off the main actor.
     static func attributed(for line: BrewCommandOutputLine, defaultColor: Color) -> AttributedString {
         var result = AttributedString()
         for span in line.spans {

--- a/Sources/BrewRepositoryInterfaces/CommandJob.swift
+++ b/Sources/BrewRepositoryInterfaces/CommandJob.swift
@@ -81,12 +81,8 @@ public final class CommandJob: Identifiable {
         }
     }
 
-    /// Appends a line, or replaces the trailing one when it was still being drawn.
-    ///
-    /// A terminal-backed run reports a line repeatedly while a progress bar redraws it, marking it
-    /// incomplete until a newline settles it. Those revisions replace the row in place — keeping its
-    /// identity, so anything keyed on `id` treats it as the same row changing rather than a new one —
-    /// which is what makes a progress bar animate instead of accumulating hundreds of rows.
+    /// Appends, or replaces the trailing row when it was still being drawn. Revisions keep the row's
+    /// identity, so a redrawing progress bar animates rather than accumulating hundreds of rows.
     public func appendOutput(_ line: BrewCommandOutputLine) {
         if let last = output.last, !last.isComplete {
             output[output.count - 1] = line.adoptingIdentity(of: last)

--- a/Sources/BrewRepositoryInterfaces/CommandJob.swift
+++ b/Sources/BrewRepositoryInterfaces/CommandJob.swift
@@ -81,8 +81,18 @@ public final class CommandJob: Identifiable {
         }
     }
 
+    /// Appends a line, or replaces the trailing one when it was still being drawn.
+    ///
+    /// A terminal-backed run reports a line repeatedly while a progress bar redraws it, marking it
+    /// incomplete until a newline settles it. Those revisions replace the row in place — keeping its
+    /// identity, so anything keyed on `id` treats it as the same row changing rather than a new one —
+    /// which is what makes a progress bar animate instead of accumulating hundreds of rows.
     public func appendOutput(_ line: BrewCommandOutputLine) {
-        output.append(line)
+        if let last = output.last, !last.isComplete {
+            output[output.count - 1] = line.adoptingIdentity(of: last)
+        } else {
+            output.append(line)
+        }
         if output.count > maxOutputLines {
             output.removeFirst(output.count - maxOutputLines)
         }

--- a/Tests/BrewCLITests/BrewCommandServicePseudoTerminalTests.swift
+++ b/Tests/BrewCLITests/BrewCommandServicePseudoTerminalTests.swift
@@ -59,6 +59,14 @@ struct BrewCommandServicePseudoTerminalTests {
         #expect(output.standardError.isEmpty)
     }
 
+    @Test func `a child reading stdin gets EOF instead of blocking on the terminal`() async throws {
+        // The hang worth guarding against: an interactive rc file that reads stdin would block forever if
+        // stdin were wired to the pty, since nothing ever writes to it. It stays on /dev/null instead.
+        let output = try await run(script: "read line; printf 'survived'", usesPseudoTerminal: true)
+
+        #expect(output.standardOutput.contains("survived"))
+    }
+
     @Test func `pseudo-terminal run reports a non-zero exit code`() async throws {
         let output = try await run(script: "exit 7", usesPseudoTerminal: true)
 

--- a/Tests/BrewCLITests/BrewCommandServicePseudoTerminalTests.swift
+++ b/Tests/BrewCLITests/BrewCommandServicePseudoTerminalTests.swift
@@ -1,0 +1,204 @@
+//
+//  BrewCommandServicePseudoTerminalTests.swift
+//  BrewTests
+//
+
+@testable import BrewCLI
+import BrewCore
+import Foundation
+import Testing
+
+struct BrewCommandServicePseudoTerminalTests {
+    @Test func `pseudo-terminal run gives the child a tty on stdout`() async throws {
+        let output = try await run(script: "test -t 1 && printf 'tty' || printf 'not-tty'", usesPseudoTerminal: true)
+
+        #expect(output.standardOutput == "tty")
+    }
+
+    @Test func `pipe run leaves the child without a tty`() async throws {
+        // The contrast that justifies the whole feature: same command, same runner, no terminal.
+        let output = try await run(script: "test -t 1 && printf 'tty' || printf 'not-tty'", usesPseudoTerminal: false)
+
+        #expect(output.standardOutput == "not-tty")
+    }
+
+    @Test func `pseudo-terminal run sets TERM for the child`() async throws {
+        // A GUI process launched from Finder inherits no TERM; without one, tools treat the terminal as
+        // capability-less and suppress exactly the colour and progress output the pty was allocated for.
+        let output = try await run(script: "printf '%s' \"$TERM\"", usesPseudoTerminal: true)
+
+        #expect(output.standardOutput == "xterm-256color")
+    }
+
+    @Test func `pseudo-terminal run streams each line as it arrives`() async throws {
+        let collector = OutputCollector()
+
+        _ = try await run(
+            script: "printf 'one\\ntwo\\nthree\\n'",
+            usesPseudoTerminal: true,
+            lineObserver: { collector.append($0) },
+        )
+
+        #expect(collector.allLines().map(\.text) == ["one", "two", "three"])
+    }
+
+    @Test func `pseudo-terminal run merges stderr into the stdout stream`() async throws {
+        // Documents the trade-off rather than a preference: one terminal device carries both streams, so
+        // stderr cannot be told apart. Runs whose output is parsed stay on pipes for this reason.
+        let output = try await run(
+            script: "printf 'out\\n'; printf 'err\\n' >&2",
+            usesPseudoTerminal: true,
+        )
+
+        #expect(output.standardOutput.contains("out") && output.standardOutput.contains("err"))
+    }
+
+    @Test func `pseudo-terminal run leaves standardError empty`() async throws {
+        let output = try await run(script: "printf 'err\\n' >&2", usesPseudoTerminal: true)
+
+        #expect(output.standardError.isEmpty)
+    }
+
+    @Test func `pseudo-terminal run reports a non-zero exit code`() async throws {
+        let output = try await run(script: "exit 7", usesPseudoTerminal: true)
+
+        #expect(output.terminationStatus == 7)
+    }
+
+    @Test func `pseudo-terminal run reports a signalled child as 128 plus the signal`() async throws {
+        let output = try await run(script: "kill -TERM $$", usesPseudoTerminal: true)
+
+        #expect(output.terminationStatus == 128 + SIGTERM)
+    }
+
+    @Test func `pseudo-terminal run preserves carriage-return progress redraws`() async throws {
+        // The payoff case: a progress meter rewriting one line arrives byte-for-byte, ready for a console
+        // that interprets \r. The kernel's own \n → \r\n rewrite stays off, so the only \r is the child's.
+        let output = try await run(script: "printf '10%%\\r50%%\\r100%%\\n'", usesPseudoTerminal: true)
+
+        #expect(output.standardOutput == "10%\r50%\r100%\n")
+    }
+
+    @Test func `pseudo-terminal run flushes a trailing line lacking a newline`() async throws {
+        let collector = OutputCollector()
+
+        _ = try await run(
+            script: "printf 'no-newline'",
+            usesPseudoTerminal: true,
+            lineObserver: { collector.append($0) },
+        )
+
+        #expect(collector.allLines().map(\.text) == ["no-newline"])
+    }
+
+    @Test func `pseudo-terminal run survives output larger than the terminal buffer`() async throws {
+        // A pty's kernel buffer is far smaller than a pipe's, so a stalled drain would deadlock here.
+        let output = try await run(
+            script: "for i in $(seq 1 5000); do printf 'line %d\\n' $i; done",
+            usesPseudoTerminal: true,
+        )
+
+        #expect(output.standardOutput.split(separator: "\n").count == 5000)
+    }
+
+    @Test func `cancelling a pseudo-terminal run stops the child`() async throws {
+        let service = BrewCommandService()
+        let task = Task {
+            try await service.run(
+                executableURL: URL(fileURLWithPath: "/bin/zsh"),
+                arguments: ["-c", "sleep 30"],
+                options: BrewRunOptions(usesPseudoTerminal: true),
+            )
+        }
+
+        // Give the spawn a moment to get as far as the child before cancelling it.
+        try await Task.sleep(for: .milliseconds(200))
+        task.cancel()
+
+        // The assertion is that this returns at all: an unreaped drain or an un-signalled child would
+        // leave the await hanging for the full 30 seconds.
+        let result = await task.result
+        #expect(throws: Never.self) { try Self.assertCompleted(result) }
+    }
+
+    @Test func `cancelling a pseudo-terminal run also stops what the child spawned`() async throws {
+        // The reason the run creates its own session: teardown signals the whole process group, so a
+        // cancelled install stops the curl or git it was waiting on instead of orphaning it.
+        let service = BrewCommandService()
+        let task = Task {
+            try await service.run(
+                executableURL: URL(fileURLWithPath: "/bin/zsh"),
+                arguments: ["-c", "sleep \(Self.grandchildMarker) & wait"],
+                options: BrewRunOptions(usesPseudoTerminal: true),
+            )
+        }
+
+        try await Task.sleep(for: .milliseconds(500))
+        let spawned = Self.grandchildCount()
+        task.cancel()
+        _ = await task.result
+        try await Task.sleep(for: .milliseconds(1500))
+
+        #expect(spawned > 0 && Self.grandchildCount() == 0)
+    }
+}
+
+private extension BrewCommandServicePseudoTerminalTests {
+    func run(
+        script: String,
+        usesPseudoTerminal: Bool,
+        lineObserver: (@Sendable (BrewCommandOutputLine) -> Void)? = nil,
+    ) async throws -> CommandOutput {
+        let service = BrewCommandService()
+        return try await service.run(
+            executableURL: URL(fileURLWithPath: "/bin/zsh"),
+            arguments: ["-c", script],
+            options: BrewRunOptions(lineObserver: lineObserver, usesPseudoTerminal: usesPseudoTerminal),
+        )
+    }
+
+    /// A cancelled run may either throw or return a signalled status; both are "it stopped". Only a hang
+    /// would fail the test, by never producing a result at all.
+    static func assertCompleted(_ result: Result<CommandOutput, any Error>) throws {
+        if case let .failure(error) = result, !(error is CancellationError) {
+            throw error
+        }
+    }
+
+    /// An implausible sleep duration, used purely as a unique needle for `pgrep`.
+    static let grandchildMarker = "31337"
+
+    /// How many grandchildren carrying the marker are currently alive.
+    static func grandchildCount() -> Int {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
+        process.arguments = ["-f", "sleep \(grandchildMarker)"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        try? process.run()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return (String(bytes: data, encoding: .utf8) ?? "").split(separator: "\n").count
+    }
+}
+
+/// Thread-safe collector for streamed lines. Appends synchronously (under a lock) inside the sink, so that
+/// — because `BrewCommandService.run` only returns after every sink call has been made — all lines are
+/// recorded by the time a test reads them.
+// swiftlint:disable:next unchecked_sendable
+private final class OutputCollector: @unchecked Sendable {
+    private let lock = NSLock()
+    private var lines: [BrewCommandOutputLine] = []
+
+    func append(_ line: BrewCommandOutputLine) {
+        lock.lock()
+        defer { lock.unlock() }
+        lines.append(line)
+    }
+
+    func allLines() -> [BrewCommandOutputLine] {
+        lock.lock()
+        defer { lock.unlock() }
+        return lines
+    }
+}

--- a/Tests/BrewCLITests/BrewCommandServicePseudoTerminalTests.swift
+++ b/Tests/BrewCLITests/BrewCommandServicePseudoTerminalTests.swift
@@ -87,7 +87,7 @@ struct BrewCommandServicePseudoTerminalTests {
         #expect(output.standardOutput == "10%\r50%\r100%\n")
     }
 
-    @Test func `pseudo-terminal run flushes a trailing line lacking a newline`() async throws {
+    @Test func `pseudo-terminal run settles a trailing line lacking a newline`() async throws {
         let collector = OutputCollector()
 
         _ = try await run(
@@ -96,7 +96,38 @@ struct BrewCommandServicePseudoTerminalTests {
             lineObserver: { collector.append($0) },
         )
 
-        #expect(collector.allLines().map(\.text) == ["no-newline"])
+        // Reported first as an in-progress revision, then settled when the stream ends.
+        let last = collector.allLines().last
+        #expect(last?.text == "no-newline" && last?.isComplete == true)
+    }
+
+    @Test func `a progress redraw settles into one complete line`() async throws {
+        // The reported bug, end to end: many carriage-return redraws must leave one settled line, with
+        // the intermediate states reported as revisions of it rather than as separate lines.
+        let collector = OutputCollector()
+
+        _ = try await run(
+            script: "printf '10%%\\r50%%\\r100%%\\n'",
+            usesPseudoTerminal: true,
+            lineObserver: { collector.append($0) },
+        )
+
+        let settled = collector.allLines().filter(\.isComplete).map(\.text)
+        #expect(settled == ["100%"])
+    }
+
+    @Test func `intermediate redraw states are reported as revisions`() async throws {
+        let collector = OutputCollector()
+
+        _ = try await run(
+            script: "printf '10%%\\r'; sleep 0.1; printf '50%%\\r'; sleep 0.1; printf '100%%\\n'",
+            usesPseudoTerminal: true,
+            lineObserver: { collector.append($0) },
+        )
+
+        // Separated by sleeps so they arrive as distinct reads, which is what a real download looks like.
+        let revisions = collector.allLines().filter { !$0.isComplete }.map(\.text)
+        #expect(revisions == ["10%", "50%"])
     }
 
     @Test func `pseudo-terminal run survives output larger than the terminal buffer`() async throws {

--- a/Tests/BrewCLITests/BrewCommandServicePseudoTerminalTests.swift
+++ b/Tests/BrewCLITests/BrewCommandServicePseudoTerminalTests.swift
@@ -11,20 +11,20 @@ import Testing
 @Suite(.serialized)
 struct BrewCommandServicePseudoTerminalTests {
     @Test func `pseudo-terminal run gives the child a tty on stdout`() async throws {
-        let output = try await run(script: "test -t 1 && printf 'tty' || printf 'not-tty'", usesPseudoTerminal: true)
+        let output = try await run(script: "test -t 1 && printf 'tty' || printf 'not-tty'", channel: .pseudoTerminal)
 
         #expect(output.standardOutput == "tty")
     }
 
     @Test func `pipe run leaves the child without a tty`() async throws {
-        let output = try await run(script: "test -t 1 && printf 'tty' || printf 'not-tty'", usesPseudoTerminal: false)
+        let output = try await run(script: "test -t 1 && printf 'tty' || printf 'not-tty'", channel: .pipes(forceColor: false))
 
         #expect(output.standardOutput == "not-tty")
     }
 
     @Test func `pseudo-terminal run sets TERM for the child`() async throws {
         // A GUI process launched from Finder inherits no TERM, and tools then suppress colour.
-        let output = try await run(script: "printf '%s' \"$TERM\"", usesPseudoTerminal: true)
+        let output = try await run(script: "printf '%s' \"$TERM\"", channel: .pseudoTerminal)
 
         #expect(output.standardOutput == "xterm-256color")
     }
@@ -34,7 +34,7 @@ struct BrewCommandServicePseudoTerminalTests {
 
         _ = try await run(
             script: "printf 'one\\ntwo\\nthree\\n'",
-            usesPseudoTerminal: true,
+            channel: .pseudoTerminal,
             lineObserver: { collector.append($0) },
         )
 
@@ -45,42 +45,54 @@ struct BrewCommandServicePseudoTerminalTests {
         // One device carries both streams, so stderr cannot be told apart.
         let output = try await run(
             script: "printf 'out\\n'; printf 'err\\n' >&2",
-            usesPseudoTerminal: true,
+            channel: .pseudoTerminal,
         )
 
         #expect(output.standardOutput.contains("out") && output.standardOutput.contains("err"))
     }
 
     @Test func `pseudo-terminal run leaves standardError empty`() async throws {
-        let output = try await run(script: "printf 'err\\n' >&2", usesPseudoTerminal: true)
+        let output = try await run(script: "printf 'err\\n' >&2", channel: .pseudoTerminal)
 
         #expect(output.standardError.isEmpty)
     }
 
     @Test func `a child reading stdin gets EOF instead of blocking on the terminal`() async throws {
         // An rc file reading stdin would block forever if stdin were the pty; it stays on /dev/null.
-        let output = try await run(script: "read line; printf 'survived'", usesPseudoTerminal: true)
+        let output = try await run(script: "read line; printf 'survived'", channel: .pseudoTerminal)
 
         #expect(output.standardOutput.contains("survived"))
     }
 
     @Test func `pseudo-terminal run reports a non-zero exit code`() async throws {
-        let output = try await run(script: "exit 7", usesPseudoTerminal: true)
+        let output = try await run(script: "exit 7", channel: .pseudoTerminal)
 
         #expect(output.terminationStatus == 7)
     }
 
     @Test func `pseudo-terminal run reports a signalled child as 128 plus the signal`() async throws {
-        let output = try await run(script: "kill -TERM $$", usesPseudoTerminal: true)
+        let output = try await run(script: "kill -TERM $$", channel: .pseudoTerminal)
 
         #expect(output.terminationStatus == 128 + SIGTERM)
     }
 
-    @Test func `pseudo-terminal run preserves carriage-return progress redraws`() async throws {
-        // The kernel's own \n to \r\n rewrite stays off, so the only \r here is the child's.
-        let output = try await run(script: "printf '10%%\\r50%%\\r100%%\\n'", usesPseudoTerminal: true)
+    @Test func `pseudo-terminal run resolves carriage-return redraws into settled text`() async throws {
+        // The returned output is the assembled transcript, not the cursor script that produced it — the
+        // raw bytes are asserted at the device level in PseudoTerminalTests.
+        let output = try await run(script: "printf '10%%\\r50%%\\r100%%\\n'", channel: .pseudoTerminal)
 
-        #expect(output.standardOutput == "10%\r50%\r100%\n")
+        #expect(output.standardOutput == "100%\n")
+    }
+
+    @Test func `pseudo-terminal output is the diagnostic a failed run reports`() async throws {
+        // The merged device leaves standardError empty, so this is the only account of the failure.
+        let output = try await run(
+            script: "printf 'Downloading\\n'; printf 'Error: no such cask\\n' >&2; exit 1",
+            channel: .pseudoTerminal,
+        )
+
+        #expect(output.terminationStatus == 1)
+        #expect(CommandFailureDetail.detail(from: output).contains("Error: no such cask"))
     }
 
     @Test func `pseudo-terminal run settles a trailing line lacking a newline`() async throws {
@@ -88,7 +100,7 @@ struct BrewCommandServicePseudoTerminalTests {
 
         _ = try await run(
             script: "printf 'no-newline'",
-            usesPseudoTerminal: true,
+            channel: .pseudoTerminal,
             lineObserver: { collector.append($0) },
         )
 
@@ -101,7 +113,7 @@ struct BrewCommandServicePseudoTerminalTests {
 
         _ = try await run(
             script: "printf '10%%\\r50%%\\r100%%\\n'",
-            usesPseudoTerminal: true,
+            channel: .pseudoTerminal,
             lineObserver: { collector.append($0) },
         )
 
@@ -114,7 +126,7 @@ struct BrewCommandServicePseudoTerminalTests {
 
         _ = try await run(
             script: "printf '10%%\\r'; sleep 0.1; printf '50%%\\r'; sleep 0.1; printf '100%%\\n'",
-            usesPseudoTerminal: true,
+            channel: .pseudoTerminal,
             lineObserver: { collector.append($0) },
         )
 
@@ -126,7 +138,7 @@ struct BrewCommandServicePseudoTerminalTests {
     @Test func `pseudo-terminal run survives output larger than the terminal buffer`() async throws {
         let output = try await run(
             script: "for i in $(seq 1 5000); do printf 'line %d\\n' $i; done",
-            usesPseudoTerminal: true,
+            channel: .pseudoTerminal,
         )
 
         #expect(output.standardOutput.split(separator: "\n").count == 5000)
@@ -138,7 +150,7 @@ struct BrewCommandServicePseudoTerminalTests {
             try await service.run(
                 executableURL: URL(fileURLWithPath: "/bin/zsh"),
                 arguments: ["-c", "sleep 30"],
-                options: BrewRunOptions(usesPseudoTerminal: true),
+                options: BrewRunOptions(output: .pseudoTerminal),
             )
         }
 
@@ -157,7 +169,7 @@ struct BrewCommandServicePseudoTerminalTests {
             try await service.run(
                 executableURL: URL(fileURLWithPath: "/bin/zsh"),
                 arguments: ["-c", "sleep \(Self.grandchildMarker) & wait"],
-                options: BrewRunOptions(usesPseudoTerminal: true),
+                options: BrewRunOptions(output: .pseudoTerminal),
             )
         }
 
@@ -174,14 +186,14 @@ struct BrewCommandServicePseudoTerminalTests {
 private extension BrewCommandServicePseudoTerminalTests {
     func run(
         script: String,
-        usesPseudoTerminal: Bool,
+        channel: BrewRunOptions.OutputChannel,
         lineObserver: (@Sendable (BrewCommandOutputLine) -> Void)? = nil,
     ) async throws -> CommandOutput {
         let service = BrewCommandService()
         return try await service.run(
             executableURL: URL(fileURLWithPath: "/bin/zsh"),
             arguments: ["-c", script],
-            options: BrewRunOptions(lineObserver: lineObserver, usesPseudoTerminal: usesPseudoTerminal),
+            options: BrewRunOptions(lineObserver: lineObserver, output: channel),
         )
     }
 
@@ -194,7 +206,6 @@ private extension BrewCommandServicePseudoTerminalTests {
 
     /// A unique needle for `pgrep`.
     static let grandchildMarker = "31337"
-
 
     static func grandchildCount() -> Int {
         let process = Process()

--- a/Tests/BrewCLITests/BrewCommandServicePseudoTerminalTests.swift
+++ b/Tests/BrewCLITests/BrewCommandServicePseudoTerminalTests.swift
@@ -17,15 +17,13 @@ struct BrewCommandServicePseudoTerminalTests {
     }
 
     @Test func `pipe run leaves the child without a tty`() async throws {
-        // The contrast that justifies the whole feature: same command, same runner, no terminal.
         let output = try await run(script: "test -t 1 && printf 'tty' || printf 'not-tty'", usesPseudoTerminal: false)
 
         #expect(output.standardOutput == "not-tty")
     }
 
     @Test func `pseudo-terminal run sets TERM for the child`() async throws {
-        // A GUI process launched from Finder inherits no TERM; without one, tools treat the terminal as
-        // capability-less and suppress exactly the colour and progress output the pty was allocated for.
+        // A GUI process launched from Finder inherits no TERM, and tools then suppress colour.
         let output = try await run(script: "printf '%s' \"$TERM\"", usesPseudoTerminal: true)
 
         #expect(output.standardOutput == "xterm-256color")
@@ -44,8 +42,7 @@ struct BrewCommandServicePseudoTerminalTests {
     }
 
     @Test func `pseudo-terminal run merges stderr into the stdout stream`() async throws {
-        // Documents the trade-off rather than a preference: one terminal device carries both streams, so
-        // stderr cannot be told apart. Runs whose output is parsed stay on pipes for this reason.
+        // One device carries both streams, so stderr cannot be told apart.
         let output = try await run(
             script: "printf 'out\\n'; printf 'err\\n' >&2",
             usesPseudoTerminal: true,
@@ -61,8 +58,7 @@ struct BrewCommandServicePseudoTerminalTests {
     }
 
     @Test func `a child reading stdin gets EOF instead of blocking on the terminal`() async throws {
-        // The hang worth guarding against: an interactive rc file that reads stdin would block forever if
-        // stdin were wired to the pty, since nothing ever writes to it. It stays on /dev/null instead.
+        // An rc file reading stdin would block forever if stdin were the pty; it stays on /dev/null.
         let output = try await run(script: "read line; printf 'survived'", usesPseudoTerminal: true)
 
         #expect(output.standardOutput.contains("survived"))
@@ -81,8 +77,7 @@ struct BrewCommandServicePseudoTerminalTests {
     }
 
     @Test func `pseudo-terminal run preserves carriage-return progress redraws`() async throws {
-        // The payoff case: a progress meter rewriting one line arrives byte-for-byte, ready for a console
-        // that interprets \r. The kernel's own \n → \r\n rewrite stays off, so the only \r is the child's.
+        // The kernel's own \n to \r\n rewrite stays off, so the only \r here is the child's.
         let output = try await run(script: "printf '10%%\\r50%%\\r100%%\\n'", usesPseudoTerminal: true)
 
         #expect(output.standardOutput == "10%\r50%\r100%\n")
@@ -97,14 +92,11 @@ struct BrewCommandServicePseudoTerminalTests {
             lineObserver: { collector.append($0) },
         )
 
-        // Reported first as an in-progress revision, then settled when the stream ends.
         let last = collector.allLines().last
         #expect(last?.text == "no-newline" && last?.isComplete == true)
     }
 
     @Test func `a progress redraw settles into one complete line`() async throws {
-        // The reported bug, end to end: many carriage-return redraws must leave one settled line, with
-        // the intermediate states reported as revisions of it rather than as separate lines.
         let collector = OutputCollector()
 
         _ = try await run(
@@ -126,13 +118,12 @@ struct BrewCommandServicePseudoTerminalTests {
             lineObserver: { collector.append($0) },
         )
 
-        // Separated by sleeps so they arrive as distinct reads, which is what a real download looks like.
+        // Separated by sleeps so they arrive as distinct reads.
         let revisions = collector.allLines().filter { !$0.isComplete }.map(\.text)
         #expect(revisions == ["10%", "50%"])
     }
 
     @Test func `pseudo-terminal run survives output larger than the terminal buffer`() async throws {
-        // A pty's kernel buffer is far smaller than a pipe's, so a stalled drain would deadlock here.
         let output = try await run(
             script: "for i in $(seq 1 5000); do printf 'line %d\\n' $i; done",
             usesPseudoTerminal: true,
@@ -151,19 +142,16 @@ struct BrewCommandServicePseudoTerminalTests {
             )
         }
 
-        // Give the spawn a moment to get as far as the child before cancelling it.
         try await Task.sleep(for: .milliseconds(200))
         task.cancel()
 
-        // The assertion is that this returns at all: an unreaped drain or an un-signalled child would
-        // leave the await hanging for the full 30 seconds.
+        // Returning at all is the assertion: an un-signalled child would hang for the full 30 seconds.
         let result = await task.result
         #expect(throws: Never.self) { try Self.assertCompleted(result) }
     }
 
     @Test func `cancelling a pseudo-terminal run also stops what the child spawned`() async throws {
-        // The reason the run creates its own session: teardown signals the whole process group, so a
-        // cancelled install stops the curl or git it was waiting on instead of orphaning it.
+        // Teardown signals the whole process group, so a cancelled install stops what it spawned.
         let service = BrewCommandService()
         let task = Task {
             try await service.run(
@@ -197,18 +185,17 @@ private extension BrewCommandServicePseudoTerminalTests {
         )
     }
 
-    /// A cancelled run may either throw or return a signalled status; both are "it stopped". Only a hang
-    /// would fail the test, by never producing a result at all.
+    /// A cancelled run may throw or return a signalled status; both mean it stopped. Only a hang fails.
     static func assertCompleted(_ result: Result<CommandOutput, any Error>) throws {
         if case let .failure(error) = result, !(error is CancellationError) {
             throw error
         }
     }
 
-    /// An implausible sleep duration, used purely as a unique needle for `pgrep`.
+    /// A unique needle for `pgrep`.
     static let grandchildMarker = "31337"
 
-    /// How many grandchildren carrying the marker are currently alive.
+
     static func grandchildCount() -> Int {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
@@ -222,9 +209,8 @@ private extension BrewCommandServicePseudoTerminalTests {
     }
 }
 
-/// Thread-safe collector for streamed lines. Appends synchronously (under a lock) inside the sink, so that
-/// — because `BrewCommandService.run` only returns after every sink call has been made — all lines are
-/// recorded by the time a test reads them.
+/// `run` only returns after every sink call has been made, so all lines are recorded by the time a test
+/// reads them.
 // swiftlint:disable:next unchecked_sendable
 private final class OutputCollector: @unchecked Sendable {
     private let lock = NSLock()

--- a/Tests/BrewCLITests/BrewCommandServicePseudoTerminalTests.swift
+++ b/Tests/BrewCLITests/BrewCommandServicePseudoTerminalTests.swift
@@ -8,6 +8,7 @@ import BrewCore
 import Foundation
 import Testing
 
+@Suite(.serialized)
 struct BrewCommandServicePseudoTerminalTests {
     @Test func `pseudo-terminal run gives the child a tty on stdout`() async throws {
         let output = try await run(script: "test -t 1 && printf 'tty' || printf 'not-tty'", usesPseudoTerminal: true)

--- a/Tests/BrewCLITests/BrewCommandServicePseudoTerminalTests.swift
+++ b/Tests/BrewCLITests/BrewCommandServicePseudoTerminalTests.swift
@@ -76,16 +76,14 @@ struct BrewCommandServicePseudoTerminalTests {
         #expect(output.terminationStatus == 128 + SIGTERM)
     }
 
+    /// The raw bytes are asserted at the device level in `PseudoTerminalTests`.
     @Test func `pseudo-terminal run resolves carriage-return redraws into settled text`() async throws {
-        // The returned output is the assembled transcript, not the cursor script that produced it — the
-        // raw bytes are asserted at the device level in PseudoTerminalTests.
         let output = try await run(script: "printf '10%%\\r50%%\\r100%%\\n'", channel: .pseudoTerminal)
 
         #expect(output.standardOutput == "100%\n")
     }
 
     @Test func `pseudo-terminal output is the diagnostic a failed run reports`() async throws {
-        // The merged device leaves standardError empty, so this is the only account of the failure.
         let output = try await run(
             script: "printf 'Downloading\\n'; printf 'Error: no such cask\\n' >&2; exit 1",
             channel: .pseudoTerminal,

--- a/Tests/BrewCLITests/BrewCommandServiceTerminalFallbackTests.swift
+++ b/Tests/BrewCLITests/BrewCommandServiceTerminalFallbackTests.swift
@@ -8,9 +8,9 @@ import BrewCore
 import Foundation
 import Testing
 
-/// A run that asks for a terminal but cannot get one degrades to pipes rather than failing. The pty
-/// device pool is far smaller than `kern.tty.ptmx_max` advertises, so allocation failure is a real
-/// environmental outcome, and losing Homebrew's progress rendering beats losing the install.
+/// A run that asks for a terminal but cannot get one degrades to pipes rather than failing: the device
+/// pool is small, so allocation failure is a real outcome, and losing progress rendering beats losing
+/// the install.
 struct BrewCommandServiceTerminalFallbackTests {
     @Test func `a run whose terminal cannot be allocated still succeeds`() async throws {
         let output = try await runWithUnavailableTerminal(script: "printf 'ran anyway'")
@@ -27,7 +27,6 @@ struct BrewCommandServiceTerminalFallbackTests {
     }
 
     @Test func `the fallback keeps stdout and stderr apart`() async throws {
-        // Pipes carry the two streams separately, unlike the single device a terminal presents.
         let output = try await runWithUnavailableTerminal(
             script: "printf 'out' ; printf 'err' >&2",
         )
@@ -36,8 +35,7 @@ struct BrewCommandServiceTerminalFallbackTests {
     }
 
     @Test func `the fallback still asks Homebrew for colour`() async throws {
-        // The terminal was what supplied colour; without it Homebrew has to be told, or a display run
-        // would silently lose its colouring as well as its progress rendering.
+        // The terminal was what supplied colour, so without it Homebrew has to be told.
         let output = try await runWithUnavailableTerminal(script: "printf '%s' \"$HOMEBREW_COLOR\"")
 
         #expect(output.standardOutput == "1")
@@ -54,7 +52,6 @@ struct BrewCommandServiceTerminalFallbackTests {
     }
 
     @Test func `a genuine launch failure is not swallowed by the fallback`() async throws {
-        // Only allocation failure degrades; a command that cannot run must still fail.
         let service = BrewCommandService(makeTerminal: { throw TerminalUnavailable() })
 
         await #expect(throws: (any Error).self) {
@@ -67,8 +64,8 @@ struct BrewCommandServiceTerminalFallbackTests {
     }
 
     @Test func `the fallback options drop the terminal and force colour`() {
-        // Asserted on the shaping directly rather than by reading HOMEBREW_COLOR out of a child, which
-        // would depend on whatever the developer happens to export.
+        // Asserted on the shaping rather than reading HOMEBREW_COLOR out of a child, which would depend
+        // on whatever the developer exports.
         let fallback = BrewCommandService.colourisedPipeFallback(
             from: BrewRunOptions(forceColor: false, usesPseudoTerminal: true),
         )
@@ -77,7 +74,6 @@ struct BrewCommandServiceTerminalFallbackTests {
     }
 
     @Test func `the fallback options keep the caller's line observer`() {
-        // Losing the observer here would silently stop the console streaming on the degraded path.
         let fallback = BrewCommandService.colourisedPipeFallback(
             from: BrewRunOptions(lineObserver: { _ in }, usesPseudoTerminal: true),
         )

--- a/Tests/BrewCLITests/BrewCommandServiceTerminalFallbackTests.swift
+++ b/Tests/BrewCLITests/BrewCommandServiceTerminalFallbackTests.swift
@@ -58,7 +58,7 @@ struct BrewCommandServiceTerminalFallbackTests {
             try await service.run(
                 executableURL: URL(fileURLWithPath: "/nonexistent/executable"),
                 arguments: [],
-                options: BrewRunOptions(usesPseudoTerminal: true),
+                options: BrewRunOptions(output: .pseudoTerminal),
             )
         }
     }
@@ -66,16 +66,16 @@ struct BrewCommandServiceTerminalFallbackTests {
     @Test func `the fallback options drop the terminal and force colour`() {
         // Asserted on the shaping rather than reading HOMEBREW_COLOR out of a child, which would depend
         // on whatever the developer exports.
-        let fallback = BrewCommandService.colourisedPipeFallback(
-            from: BrewRunOptions(forceColor: false, usesPseudoTerminal: true),
+        let fallback = BrewCommandService.pipeFallback(
+            from: BrewRunOptions(output: .pseudoTerminal),
         )
 
-        #expect(fallback.usesPseudoTerminal == false && fallback.forceColor)
+        #expect(fallback.output == .pipes(forceColor: true))
     }
 
     @Test func `the fallback options keep the caller's line observer`() {
-        let fallback = BrewCommandService.colourisedPipeFallback(
-            from: BrewRunOptions(lineObserver: { _ in }, usesPseudoTerminal: true),
+        let fallback = BrewCommandService.pipeFallback(
+            from: BrewRunOptions(lineObserver: { _ in }, output: .pseudoTerminal),
         )
 
         #expect(fallback.lineObserver != nil)
@@ -91,7 +91,7 @@ private extension BrewCommandServiceTerminalFallbackTests {
         return try await service.run(
             executableURL: URL(fileURLWithPath: "/bin/zsh"),
             arguments: ["-c", script],
-            options: BrewRunOptions(lineObserver: lineObserver, usesPseudoTerminal: true),
+            options: BrewRunOptions(lineObserver: lineObserver, output: .pseudoTerminal),
         )
     }
 }

--- a/Tests/BrewCLITests/BrewCommandServiceTerminalFallbackTests.swift
+++ b/Tests/BrewCLITests/BrewCommandServiceTerminalFallbackTests.swift
@@ -1,0 +1,121 @@
+//
+//  BrewCommandServiceTerminalFallbackTests.swift
+//  BrewTests
+//
+
+@testable import BrewCLI
+import BrewCore
+import Foundation
+import Testing
+
+/// A run that asks for a terminal but cannot get one degrades to pipes rather than failing. The pty
+/// device pool is far smaller than `kern.tty.ptmx_max` advertises, so allocation failure is a real
+/// environmental outcome, and losing Homebrew's progress rendering beats losing the install.
+struct BrewCommandServiceTerminalFallbackTests {
+    @Test func `a run whose terminal cannot be allocated still succeeds`() async throws {
+        let output = try await runWithUnavailableTerminal(script: "printf 'ran anyway'")
+
+        #expect(output.standardOutput == "ran anyway" && output.terminationStatus == 0)
+    }
+
+    @Test func `the fallback runs on pipes, so the child sees no terminal`() async throws {
+        let output = try await runWithUnavailableTerminal(
+            script: "test -t 1 && printf 'tty' || printf 'not-tty'",
+        )
+
+        #expect(output.standardOutput == "not-tty")
+    }
+
+    @Test func `the fallback keeps stdout and stderr apart`() async throws {
+        // Pipes carry the two streams separately, unlike the single device a terminal presents.
+        let output = try await runWithUnavailableTerminal(
+            script: "printf 'out' ; printf 'err' >&2",
+        )
+
+        #expect(output.standardOutput == "out" && output.standardError == "err")
+    }
+
+    @Test func `the fallback still asks Homebrew for colour`() async throws {
+        // The terminal was what supplied colour; without it Homebrew has to be told, or a display run
+        // would silently lose its colouring as well as its progress rendering.
+        let output = try await runWithUnavailableTerminal(script: "printf '%s' \"$HOMEBREW_COLOR\"")
+
+        #expect(output.standardOutput == "1")
+    }
+
+    @Test func `the fallback still streams lines`() async throws {
+        let collector = FallbackCollector()
+        _ = try await runWithUnavailableTerminal(
+            script: "printf 'one\\ntwo\\n'",
+            lineObserver: { collector.append($0) },
+        )
+
+        #expect(collector.allLines().map(\.text) == ["one", "two"])
+    }
+
+    @Test func `a genuine launch failure is not swallowed by the fallback`() async throws {
+        // Only allocation failure degrades; a command that cannot run must still fail.
+        let service = BrewCommandService(makeTerminal: { throw TerminalUnavailable() })
+
+        await #expect(throws: (any Error).self) {
+            try await service.run(
+                executableURL: URL(fileURLWithPath: "/nonexistent/executable"),
+                arguments: [],
+                options: BrewRunOptions(usesPseudoTerminal: true),
+            )
+        }
+    }
+
+    @Test func `the fallback options drop the terminal and force colour`() {
+        // Asserted on the shaping directly rather than by reading HOMEBREW_COLOR out of a child, which
+        // would depend on whatever the developer happens to export.
+        let fallback = BrewCommandService.colourisedPipeFallback(
+            from: BrewRunOptions(forceColor: false, usesPseudoTerminal: true),
+        )
+
+        #expect(fallback.usesPseudoTerminal == false && fallback.forceColor)
+    }
+
+    @Test func `the fallback options keep the caller's line observer`() {
+        // Losing the observer here would silently stop the console streaming on the degraded path.
+        let fallback = BrewCommandService.colourisedPipeFallback(
+            from: BrewRunOptions(lineObserver: { _ in }, usesPseudoTerminal: true),
+        )
+
+        #expect(fallback.lineObserver != nil)
+    }
+}
+
+private extension BrewCommandServiceTerminalFallbackTests {
+    func runWithUnavailableTerminal(
+        script: String,
+        lineObserver: (@Sendable (BrewCommandOutputLine) -> Void)? = nil,
+    ) async throws -> CommandOutput {
+        let service = BrewCommandService(makeTerminal: { throw TerminalUnavailable() })
+        return try await service.run(
+            executableURL: URL(fileURLWithPath: "/bin/zsh"),
+            arguments: ["-c", script],
+            options: BrewRunOptions(lineObserver: lineObserver, usesPseudoTerminal: true),
+        )
+    }
+}
+
+private struct TerminalUnavailable: Error {}
+
+// swiftlint:disable:next unchecked_sendable
+private final class FallbackCollector: @unchecked Sendable {
+    private let lock = NSLock()
+    private var lines: [BrewCommandOutputLine] = []
+
+    func append(_ line: BrewCommandOutputLine) {
+        lock.lock()
+        defer { lock.unlock() }
+        lines.append(line)
+    }
+
+    func allLines() -> [BrewCommandOutputLine] {
+        lock.lock()
+        defer { lock.unlock() }
+        return lines
+    }
+}

--- a/Tests/BrewCLITests/CommandFailureDetailTests.swift
+++ b/Tests/BrewCLITests/CommandFailureDetailTests.swift
@@ -1,0 +1,58 @@
+//
+//  CommandFailureDetailTests.swift
+//  BrewTests
+//
+
+@testable import BrewCLI
+import BrewCore
+import Foundation
+import Testing
+
+/// The regression these guard: display work runs on a terminal, which merges the streams and so leaves
+/// `standardError` empty. Reading only stderr reduced every failed install to a bare exit code.
+struct CommandFailureDetailTests {
+    @Test func `stderr is preferred when the run kept the streams apart`() {
+        let output = makeOutput(standardOutput: "progress noise", standardError: "Error: pipe failure")
+
+        #expect(CommandFailureDetail.detail(from: output) == "Error: pipe failure")
+    }
+
+    @Test func `the transcript is used when stderr is empty`() {
+        let output = makeOutput(standardOutput: "==> Downloading\nError: no such cask\n", standardError: "")
+
+        #expect(CommandFailureDetail.detail(from: output) == "==> Downloading\nError: no such cask")
+    }
+
+    @Test func `whitespace-only stderr counts as empty`() {
+        let output = makeOutput(standardOutput: "Error: the real one", standardError: "\n  \n")
+
+        #expect(CommandFailureDetail.detail(from: output) == "Error: the real one")
+    }
+
+    @Test func `an empty run yields empty detail rather than a crash`() {
+        #expect(CommandFailureDetail.detail(from: makeOutput(standardOutput: "", standardError: "")).isEmpty)
+    }
+
+    @Test func `only the tail of a long transcript is carried`() {
+        let transcript = (1 ... 500).map { "line \($0)" }.joined(separator: "\n")
+
+        let detail = CommandFailureDetail.detail(from: makeOutput(standardOutput: transcript, standardError: ""))
+
+        #expect(detail.split(separator: "\n").count == CommandFailureDetail.maxTranscriptLines)
+        #expect(detail.hasSuffix("line 500"))
+    }
+
+    @Test func `a trailing newline does not cost a line of the tail`() {
+        let transcript = (1 ... 5).map { "line \($0)" }.joined(separator: "\n") + "\n"
+
+        #expect(CommandFailureDetail.tail(of: transcript, lines: 2) == "line 4\nline 5")
+    }
+
+    @Test func `a transcript shorter than the limit is carried whole`() {
+        #expect(CommandFailureDetail.tail(of: "one\ntwo", lines: 20) == "one\ntwo")
+    }
+}
+
+private func makeOutput(standardOutput: String, standardError: String) -> CommandOutput {
+    CommandOutput(standardOutput: standardOutput, standardError: standardError, terminationStatus: 1)
+}

--- a/Tests/BrewCLITests/CommandFailureDetailTests.swift
+++ b/Tests/BrewCLITests/CommandFailureDetailTests.swift
@@ -8,8 +8,8 @@ import BrewCore
 import Foundation
 import Testing
 
-/// The regression these guard: display work runs on a terminal, which merges the streams and so leaves
-/// `standardError` empty. Reading only stderr reduced every failed install to a bare exit code.
+/// A terminal merges the streams, so `standardError` is empty; reading only stderr reduced every failed
+/// install to a bare exit code.
 struct CommandFailureDetailTests {
     @Test func `stderr is preferred when the run kept the streams apart`() {
         let output = makeOutput(standardOutput: "progress noise", standardError: "Error: pipe failure")

--- a/Tests/BrewCLITests/PseudoTerminalTests.swift
+++ b/Tests/BrewCLITests/PseudoTerminalTests.swift
@@ -7,10 +7,8 @@
 import Foundation
 import Testing
 
-/// Serialized: this suite allocates real pty devices, and the pool is small — measured at ~36 on a
-/// development machine, well below what `kern.tty.ptmx_max` advertises. Left to run in parallel with
-/// each other, these tests exhaust it and fail with ENXIO. Nothing in the app contends this way, since
-/// the command center runs one subprocess at a time.
+/// Serialized: the pty device pool is small (~36 concurrent, far below what `kern.tty.ptmx_max`
+/// advertises), so running these in parallel exhausts it and fails with ENXIO.
 @Suite(.serialized)
 struct PseudoTerminalTests {
     @Test func `child spawned on the replica sees a terminal on stdout`() throws {
@@ -26,24 +24,19 @@ struct PseudoTerminalTests {
     }
 
     @Test func `clearing OPOST leaves newlines untranslated`() throws {
-        // With `OPOST`/`ONLCR` left on — the pty default — this would arrive as "one\r\ntwo\r\n".
         let output = try runOnPseudoTerminal(script: "printf 'one\\ntwo\\n'")
 
         #expect(output == "one\ntwo\n")
     }
 
     @Test func `carriage returns written by the child are preserved`() throws {
-        // The distinction that makes progress redraws work: clearing `OPOST` suppresses the kernel's
-        // own `\n` → `\r\n` rewrite without touching `\r` bytes the child emitted deliberately.
         let output = try runOnPseudoTerminal(script: "printf 'first\\rsecond\\n'")
 
         #expect(output == "first\rsecond\n")
     }
 
     @Test func `window size is reported to the child`() throws {
-        // `stty` reads stdin, which stays on /dev/null by design (see `BrewCommandService`), so the query
-        // is pointed at fd 1 — the pty. Tools that size their output do the same thing via `TIOCGWINSZ`
-        // on stdout, so this is the path that actually matters.
+        // `stty` reads stdin, which stays on /dev/null by design, so the query is pointed at fd 1.
         let output = try runOnPseudoTerminal(
             columns: 100,
             rows: 30,
@@ -62,14 +55,13 @@ struct PseudoTerminalTests {
         process.waitUntilExit()
         terminal.closePrimary()
 
-        // The drain terminating at all is the assertion: a leaked replica descriptor would hang it forever.
+        // Terminating at all is the assertion: a leaked replica descriptor would hang this forever.
         #expect(output == "done\n")
     }
 
     @Test func `read times out rather than blocking while the terminal is idle`() throws {
         let terminal = try PseudoTerminal()
-        // No child at all, and the replica is still held open here — so there is nothing to read and no
-        // end-of-input either. An unbounded read would park forever; this must come back promptly.
+        // Nothing to read and no end-of-input either, so an unbounded read would park forever.
         defer {
             terminal.closeReplica()
             terminal.closePrimary()
@@ -85,7 +77,6 @@ struct PseudoTerminalTests {
         terminal.closeReplica()
         defer { terminal.closePrimary() }
 
-        // Never spawned a child, so closing the replica leaves no writers at all.
         let outcome = terminal.read(timeout: .milliseconds(50))
 
         #expect(outcome == .endOfInput)
@@ -99,14 +90,13 @@ struct PseudoTerminalTests {
         terminal.closePrimary()
         terminal.closePrimary()
 
-        // Reaching here without a double-close fault (which would abort the process) is the assertion.
+        // Reaching here without a double-close fault is the assertion.
         #expect(Bool(true))
     }
 }
 
 private extension PseudoTerminalTests {
-    /// Spawns `/bin/zsh -c script` with the terminal's replica as stdout+stderr, drains the primary to
-    /// end-of-input, and returns the decoded output.
+    /// Runs `script` with the replica as stdout+stderr and drains the primary to end-of-input.
     func runOnPseudoTerminal(
         columns: UInt16 = PseudoTerminal.defaultColumns,
         rows: UInt16 = PseudoTerminal.defaultRows,
@@ -123,8 +113,7 @@ private extension PseudoTerminalTests {
         return output
     }
 
-    /// Reads until end-of-input, ignoring idle timeouts. Safe here because every script under test
-    /// terminates on its own; production drains additionally stop once the child has exited.
+    /// Ignores idle timeouts; safe because every script under test terminates on its own.
     func drainToEndOfInput(_ terminal: PseudoTerminal) -> String {
         var data = Data()
         loop: while true {
@@ -140,8 +129,7 @@ private extension PseudoTerminalTests {
         return String(bytes: data, encoding: .utf8) ?? ""
     }
 
-    /// Uses `Foundation.Process` deliberately: this exercises ``PseudoTerminal`` on its own, independent
-    /// of how ``BrewCommandService`` spawns.
+    /// `Foundation.Process` deliberately, to exercise ``PseudoTerminal`` independently of the runner.
     func startProcess(script: String, terminal: PseudoTerminal) throws -> Process {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/zsh")

--- a/Tests/BrewCLITests/PseudoTerminalTests.swift
+++ b/Tests/BrewCLITests/PseudoTerminalTests.swift
@@ -1,0 +1,115 @@
+//
+//  PseudoTerminalTests.swift
+//  BrewTests
+//
+
+@testable import BrewCLI
+import Foundation
+import Testing
+
+struct PseudoTerminalTests {
+    @Test func `child spawned on the replica sees a terminal on stdout`() throws {
+        let output = try runOnPseudoTerminal(script: "test -t 1 && printf 'tty' || printf 'not-tty'")
+
+        #expect(output == "tty")
+    }
+
+    @Test func `child spawned on the replica sees a terminal on stderr`() throws {
+        let output = try runOnPseudoTerminal(script: "test -t 2 && printf 'tty' || printf 'not-tty'")
+
+        #expect(output == "tty")
+    }
+
+    @Test func `clearing OPOST leaves newlines untranslated`() throws {
+        // With `OPOST`/`ONLCR` left on — the pty default — this would arrive as "one\r\ntwo\r\n".
+        let output = try runOnPseudoTerminal(script: "printf 'one\\ntwo\\n'")
+
+        #expect(output == "one\ntwo\n")
+    }
+
+    @Test func `carriage returns written by the child are preserved`() throws {
+        // The distinction that makes progress redraws work: clearing `OPOST` suppresses the kernel's
+        // own `\n` → `\r\n` rewrite without touching `\r` bytes the child emitted deliberately.
+        let output = try runOnPseudoTerminal(script: "printf 'first\\rsecond\\n'")
+
+        #expect(output == "first\rsecond\n")
+    }
+
+    @Test func `window size is reported to the child`() throws {
+        // `stty` reads stdin, which stays on /dev/null by design (see `BrewCommandService`), so the query
+        // is pointed at fd 1 — the pty. Tools that size their output do the same thing via `TIOCGWINSZ`
+        // on stdout, so this is the path that actually matters.
+        let output = try runOnPseudoTerminal(
+            columns: 100,
+            rows: 30,
+            script: "stty size <&1",
+        )
+
+        #expect(output.trimmingCharacters(in: .whitespacesAndNewlines) == "30 100")
+    }
+
+    @Test func `read returns nil once the child and the local replica are gone`() throws {
+        let terminal = try PseudoTerminal()
+        let process = try startProcess(script: "printf 'done\\n'", terminal: terminal)
+        terminal.closeReplica()
+
+        var chunks: [Data] = []
+        while let chunk = terminal.read() {
+            chunks.append(chunk)
+        }
+        process.waitUntilExit()
+        terminal.closePrimary()
+
+        // The loop terminating at all is the assertion: a leaked replica descriptor would hang it forever.
+        #expect(chunks.map { String(bytes: $0, encoding: .utf8) ?? "" }.joined() == "done\n")
+    }
+
+    @Test func `closing twice is harmless`() throws {
+        let terminal = try PseudoTerminal()
+
+        terminal.closeReplica()
+        terminal.closeReplica()
+        terminal.closePrimary()
+        terminal.closePrimary()
+
+        // Reaching here without a double-close fault (which would abort the process) is the assertion.
+        #expect(Bool(true))
+    }
+}
+
+private extension PseudoTerminalTests {
+    /// Spawns `/bin/zsh -c script` with the terminal's replica as stdout+stderr, drains the primary to
+    /// end-of-input, and returns the decoded output.
+    func runOnPseudoTerminal(
+        columns: UInt16 = PseudoTerminal.defaultColumns,
+        rows: UInt16 = PseudoTerminal.defaultRows,
+        script: String,
+    ) throws -> String {
+        let terminal = try PseudoTerminal(columns: columns, rows: rows)
+        let process = try startProcess(script: script, terminal: terminal)
+        terminal.closeReplica()
+
+        var data = Data()
+        while let chunk = terminal.read() {
+            data.append(chunk)
+        }
+        process.waitUntilExit()
+        terminal.closePrimary()
+
+        return String(bytes: data, encoding: .utf8) ?? ""
+    }
+
+    /// Uses `Foundation.Process` deliberately: this exercises ``PseudoTerminal`` on its own, independent
+    /// of how ``BrewCommandService`` spawns.
+    func startProcess(script: String, terminal: PseudoTerminal) throws -> Process {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = ["-c", script]
+        let replica = FileHandle(fileDescriptor: terminal.replicaDescriptor.rawValue, closeOnDealloc: false)
+        process.standardOutput = replica
+        process.standardError = replica
+        process.standardInput = FileHandle.nullDevice
+        try process.run()
+        return process
+    }
+}

--- a/Tests/BrewCLITests/PseudoTerminalTests.swift
+++ b/Tests/BrewCLITests/PseudoTerminalTests.swift
@@ -124,9 +124,12 @@ private extension PseudoTerminalTests {
                 continue
             case .endOfInput:
                 break loop
+            case let .failed(code):
+                Issue.record("reading the terminal failed: \(PseudoTerminal.describe(errno: code))")
+                break loop
             }
         }
-        return String(bytes: data, encoding: .utf8) ?? ""
+        return UTF8StreamDecoder.lossyString(data)
     }
 
     /// `Foundation.Process` deliberately, to exercise ``PseudoTerminal`` independently of the runner.

--- a/Tests/BrewCLITests/PseudoTerminalTests.swift
+++ b/Tests/BrewCLITests/PseudoTerminalTests.swift
@@ -7,6 +7,11 @@
 import Foundation
 import Testing
 
+/// Serialized: this suite allocates real pty devices, and the pool is small — measured at ~36 on a
+/// development machine, well below what `kern.tty.ptmx_max` advertises. Left to run in parallel with
+/// each other, these tests exhaust it and fail with ENXIO. Nothing in the app contends this way, since
+/// the command center runs one subprocess at a time.
+@Suite(.serialized)
 struct PseudoTerminalTests {
     @Test func `child spawned on the replica sees a terminal on stdout`() throws {
         let output = try runOnPseudoTerminal(script: "test -t 1 && printf 'tty' || printf 'not-tty'")

--- a/Tests/BrewCLITests/PseudoTerminalTests.swift
+++ b/Tests/BrewCLITests/PseudoTerminalTests.swift
@@ -48,20 +48,42 @@ struct PseudoTerminalTests {
         #expect(output.trimmingCharacters(in: .whitespacesAndNewlines) == "30 100")
     }
 
-    @Test func `read returns nil once the child and the local replica are gone`() throws {
+    @Test func `read reports end of input once the child and the local replica are gone`() throws {
         let terminal = try PseudoTerminal()
         let process = try startProcess(script: "printf 'done\\n'", terminal: terminal)
         terminal.closeReplica()
 
-        var chunks: [Data] = []
-        while let chunk = terminal.read() {
-            chunks.append(chunk)
-        }
+        let output = drainToEndOfInput(terminal)
         process.waitUntilExit()
         terminal.closePrimary()
 
-        // The loop terminating at all is the assertion: a leaked replica descriptor would hang it forever.
-        #expect(chunks.map { String(bytes: $0, encoding: .utf8) ?? "" }.joined() == "done\n")
+        // The drain terminating at all is the assertion: a leaked replica descriptor would hang it forever.
+        #expect(output == "done\n")
+    }
+
+    @Test func `read times out rather than blocking while the terminal is idle`() throws {
+        let terminal = try PseudoTerminal()
+        // No child at all, and the replica is still held open here — so there is nothing to read and no
+        // end-of-input either. An unbounded read would park forever; this must come back promptly.
+        defer {
+            terminal.closeReplica()
+            terminal.closePrimary()
+        }
+
+        let outcome = terminal.read(timeout: .milliseconds(50))
+
+        #expect(outcome == .timedOut)
+    }
+
+    @Test func `read reports end of input when only the local replica is closed`() throws {
+        let terminal = try PseudoTerminal()
+        terminal.closeReplica()
+        defer { terminal.closePrimary() }
+
+        // Never spawned a child, so closing the replica leaves no writers at all.
+        let outcome = terminal.read(timeout: .milliseconds(50))
+
+        #expect(outcome == .endOfInput)
     }
 
     @Test func `closing twice is harmless`() throws {
@@ -89,13 +111,27 @@ private extension PseudoTerminalTests {
         let process = try startProcess(script: script, terminal: terminal)
         terminal.closeReplica()
 
-        var data = Data()
-        while let chunk = terminal.read() {
-            data.append(chunk)
-        }
+        let output = drainToEndOfInput(terminal)
         process.waitUntilExit()
         terminal.closePrimary()
 
+        return output
+    }
+
+    /// Reads until end-of-input, ignoring idle timeouts. Safe here because every script under test
+    /// terminates on its own; production drains additionally stop once the child has exited.
+    func drainToEndOfInput(_ terminal: PseudoTerminal) -> String {
+        var data = Data()
+        loop: while true {
+            switch terminal.read() {
+            case let .data(chunk):
+                data.append(chunk)
+            case .timedOut:
+                continue
+            case .endOfInput:
+                break loop
+            }
+        }
         return String(bytes: data, encoding: .utf8) ?? ""
     }
 

--- a/Tests/BrewCLITests/SerialBrewCommandCenterFailureTests.swift
+++ b/Tests/BrewCLITests/SerialBrewCommandCenterFailureTests.swift
@@ -1,0 +1,79 @@
+//
+//  SerialBrewCommandCenterFailureTests.swift
+//  BrewTests
+//
+
+@testable import BrewCLI
+import BrewCore
+import Foundation
+import Testing
+
+/// Display work runs on a terminal, which merges the streams and leaves `standardError` empty. These pin
+/// the consequence: what the user is told when an install fails has to come from the merged transcript.
+struct SerialBrewCommandCenterFailureTests {
+    @Test func `a failed display run reports brew's own message`() async throws {
+        let center = makeCenter(
+            FixedOutputRunner(standardOutput: "==> Downloading\nError: wget is not installed\n", exitCode: 1),
+        )
+
+        await #expect(throws: BrewCommandError.self) {
+            try await center.perform(
+                BrewCommands.install("wget", kind: .formula),
+                id: .maintenance(token: "install", displayCommand: "brew install wget"),
+            )
+        }
+        #expect(await failureMessage(from: center).contains("Error: wget is not installed"))
+    }
+
+    @Test func `the reported failure is not the generic fallback`() async {
+        let center = makeCenter(FixedOutputRunner(standardOutput: "Error: disk full\n", exitCode: 1))
+
+        try? await center.perform(
+            BrewCommands.install("wget", kind: .formula),
+            id: .maintenance(token: "install", displayCommand: "brew install wget"),
+        )
+
+        // `OperationFailure` falls back to a generic string only when it is handed nothing to say.
+        #expect(await failureMessage(from: center) == "Error: disk full")
+    }
+
+    @Test func `a successful display run reports no failure`() async throws {
+        let center = makeCenter(FixedOutputRunner(standardOutput: "==> Poured\n", exitCode: 0))
+
+        try await center.perform(
+            BrewCommands.install("wget", kind: .formula),
+            id: .maintenance(token: "install", displayCommand: "brew install wget"),
+        )
+
+        if case .failed = await center.phase(for: .maintenance(token: "install", displayCommand: "brew install wget")) {
+            Issue.record("a zero exit should not be reported as a failure")
+        }
+    }
+}
+
+private func failureMessage(from center: SerialBrewCommandCenter) async -> String {
+    let phase = await center.phase(for: .maintenance(token: "install", displayCommand: "brew install wget"))
+    guard case let .failed(reason) = phase else {
+        return ""
+    }
+    return reason.userFacingMessage
+}
+
+private func makeCenter(_ runner: FixedOutputRunner) -> SerialBrewCommandCenter {
+    SerialBrewCommandCenter(
+        executionContext: BrewCommandExecutionContext(
+            commandRunner: runner,
+            locator: BrewExecutableLocator(overrideURL: URL(fileURLWithPath: "/fake/brew")),
+        ),
+    )
+}
+
+/// Stands in for a terminal-backed run: everything on stdout, nothing on stderr.
+private struct FixedOutputRunner: BrewCommandRunning {
+    let standardOutput: String
+    let exitCode: Int32
+
+    func run(executableURL _: URL, arguments _: [String], options _: BrewRunOptions) async throws -> CommandOutput {
+        CommandOutput(standardOutput: standardOutput, standardError: "", terminationStatus: exitCode)
+    }
+}

--- a/Tests/BrewCLITests/SerialBrewCommandCenterFailureTests.swift
+++ b/Tests/BrewCLITests/SerialBrewCommandCenterFailureTests.swift
@@ -8,8 +8,8 @@ import BrewCore
 import Foundation
 import Testing
 
-/// Display work runs on a terminal, which merges the streams and leaves `standardError` empty. These pin
-/// the consequence: what the user is told when an install fails has to come from the merged transcript.
+/// A terminal-backed run leaves `standardError` empty, so what the user is told when an install fails
+/// has to come from the merged transcript.
 struct SerialBrewCommandCenterFailureTests {
     @Test func `a failed display run reports brew's own message`() async throws {
         let center = makeCenter(
@@ -33,7 +33,6 @@ struct SerialBrewCommandCenterFailureTests {
             id: .maintenance(token: "install", displayCommand: "brew install wget"),
         )
 
-        // `OperationFailure` falls back to a generic string only when it is handed nothing to say.
         #expect(await failureMessage(from: center) == "Error: disk full")
     }
 

--- a/Tests/BrewCLITests/SerialBrewCommandCenterRunOptionsTests.swift
+++ b/Tests/BrewCLITests/SerialBrewCommandCenterRunOptionsTests.swift
@@ -20,7 +20,7 @@ struct SerialBrewCommandCenterRunOptionsTests {
             id: .maintenance(token: "install", displayCommand: "brew install wget"),
         )
 
-        #expect(recorder.recorded()?.usesPseudoTerminal == true)
+        #expect(recorder.recorded()?.output == .pseudoTerminal)
     }
 
     @Test func `capture work stays on pipes`() async throws {
@@ -32,7 +32,7 @@ struct SerialBrewCommandCenterRunOptionsTests {
             id: .maintenance(token: "doctor", displayCommand: "brew doctor"),
         )
 
-        #expect(recorder.recorded()?.usesPseudoTerminal == false)
+        #expect(recorder.recorded()?.output == .pipes(forceColor: true))
     }
 
     @Test func `capture work still forces colour, which a pipe would otherwise strip`() async throws {
@@ -44,7 +44,7 @@ struct SerialBrewCommandCenterRunOptionsTests {
             id: .maintenance(token: "doctor", displayCommand: "brew doctor"),
         )
 
-        #expect(recorder.recorded()?.forceColor == true)
+        #expect(recorder.recorded()?.output == .pipes(forceColor: true))
     }
 
     @Test func `display work does not force colour, because a terminal already supplies it`() async throws {
@@ -56,7 +56,7 @@ struct SerialBrewCommandCenterRunOptionsTests {
             id: .maintenance(token: "install", displayCommand: "brew install wget"),
         )
 
-        #expect(recorder.recorded()?.forceColor == false)
+        #expect(recorder.recorded()?.output == .pseudoTerminal)
     }
 }
 

--- a/Tests/BrewCLITests/SerialBrewCommandCenterRunOptionsTests.swift
+++ b/Tests/BrewCLITests/SerialBrewCommandCenterRunOptionsTests.swift
@@ -8,8 +8,8 @@ import BrewCore
 import Foundation
 import Testing
 
-/// The mode → run-options mapping is the safety property behind the pty work: output that gets parsed must
-/// keep stdout and stderr apart, which only the pipe path does.
+/// The safety property behind the pty work: output that gets parsed must keep stdout and stderr apart,
+/// which only the pipe path does.
 struct SerialBrewCommandCenterRunOptionsTests {
     @Test func `display work runs against a pseudo-terminal`() async throws {
         let recorder = RunOptionsRecorder()
@@ -68,7 +68,7 @@ private func makeCenter(_ recorder: RunOptionsRecorder) -> SerialBrewCommandCent
     return SerialBrewCommandCenter(executionContext: context)
 }
 
-/// Captures the ``BrewRunOptions`` the center hands down, without spawning anything.
+/// Captures the options the center hands down, without spawning anything.
 private struct RecordingRunner: BrewCommandRunning {
     let recorder: RunOptionsRecorder
 

--- a/Tests/BrewCLITests/SerialBrewCommandCenterRunOptionsTests.swift
+++ b/Tests/BrewCLITests/SerialBrewCommandCenterRunOptionsTests.swift
@@ -1,0 +1,97 @@
+//
+//  SerialBrewCommandCenterRunOptionsTests.swift
+//  BrewTests
+//
+
+@testable import BrewCLI
+import BrewCore
+import Foundation
+import Testing
+
+/// The mode → run-options mapping is the safety property behind the pty work: output that gets parsed must
+/// keep stdout and stderr apart, which only the pipe path does.
+struct SerialBrewCommandCenterRunOptionsTests {
+    @Test func `display work runs against a pseudo-terminal`() async throws {
+        let recorder = RunOptionsRecorder()
+        let center = makeCenter(recorder)
+
+        try await center.perform(
+            BrewCommands.install("wget", kind: .formula),
+            id: .maintenance(token: "install", displayCommand: "brew install wget"),
+        )
+
+        #expect(recorder.recorded()?.usesPseudoTerminal == true)
+    }
+
+    @Test func `capture work stays on pipes`() async throws {
+        let recorder = RunOptionsRecorder()
+        let center = makeCenter(recorder)
+
+        _ = try await center.capture(
+            BrewCommands.doctorRead(),
+            id: .maintenance(token: "doctor", displayCommand: "brew doctor"),
+        )
+
+        #expect(recorder.recorded()?.usesPseudoTerminal == false)
+    }
+
+    @Test func `capture work still forces colour, which a pipe would otherwise strip`() async throws {
+        let recorder = RunOptionsRecorder()
+        let center = makeCenter(recorder)
+
+        _ = try await center.capture(
+            BrewCommands.doctorRead(),
+            id: .maintenance(token: "doctor", displayCommand: "brew doctor"),
+        )
+
+        #expect(recorder.recorded()?.forceColor == true)
+    }
+
+    @Test func `display work does not force colour, because a terminal already supplies it`() async throws {
+        let recorder = RunOptionsRecorder()
+        let center = makeCenter(recorder)
+
+        try await center.perform(
+            BrewCommands.install("wget", kind: .formula),
+            id: .maintenance(token: "install", displayCommand: "brew install wget"),
+        )
+
+        #expect(recorder.recorded()?.forceColor == false)
+    }
+}
+
+private func makeCenter(_ recorder: RunOptionsRecorder) -> SerialBrewCommandCenter {
+    let context = BrewCommandExecutionContext(
+        commandRunner: RecordingRunner(recorder: recorder),
+        locator: BrewExecutableLocator(overrideURL: URL(fileURLWithPath: "/fake/brew")),
+    )
+    return SerialBrewCommandCenter(executionContext: context)
+}
+
+/// Captures the ``BrewRunOptions`` the center hands down, without spawning anything.
+private struct RecordingRunner: BrewCommandRunning {
+    let recorder: RunOptionsRecorder
+
+    func run(executableURL _: URL, arguments _: [String], options: BrewRunOptions) async throws -> CommandOutput {
+        recorder.record(options)
+        return CommandOutput(standardOutput: "", standardError: "", terminationStatus: 0)
+    }
+}
+
+// swiftlint:disable:next unchecked_sendable
+private final class RunOptionsRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var options: BrewRunOptions?
+
+    func record(_ newOptions: BrewRunOptions) {
+        lock.lock()
+        defer { lock.unlock() }
+        options = newOptions
+    }
+
+    func recorded() -> BrewRunOptions? {
+        lock.lock()
+        defer { lock.unlock() }
+        return options
+    }
+}

--- a/Tests/BrewCLITests/TerminalProgressIntegrationTests.swift
+++ b/Tests/BrewCLITests/TerminalProgressIntegrationTests.swift
@@ -1,0 +1,97 @@
+//
+//  TerminalProgressIntegrationTests.swift
+//  BrewTests
+//
+
+@testable import BrewCLI
+import BrewCore
+import BrewRepositoryInterfaces
+import Foundation
+import Testing
+
+/// End to end across the boundary the bug actually spanned: a real subprocess writing terminal redraws,
+/// through the drain and the assembler, into the console's job buffer.
+struct TerminalProgressIntegrationTests {
+    /// Mimics a Homebrew download: plain lines around a `curl`-style bar that redraws hundreds of times,
+    /// padded to width, with no newline until it finishes.
+    private static let downloadScript = """
+    printf '==> Downloading https://ghcr.io/v2/homebrew/core/go/manifests/1.26.5\\n'
+    for i in $(seq 1 600); do
+      printf '######################   %s.0 pct\\r' $i
+    done
+    printf '#########################  100.0 pct\\n'
+    printf 'Downloaded to: /Users/x/Library/Caches/Homebrew/downloads/go.tar.gz\\n'
+    printf '==> Pouring go--1.26.5.arm64_tahoe.bottle.tar.gz\\n'
+    """
+
+    @Test func `a download's redraws settle into the rows a terminal would show`() async throws {
+        let rows = try await runIntoJob(script: Self.downloadScript).map(\.text)
+
+        #expect(rows == [
+            "==> Downloading https://ghcr.io/v2/homebrew/core/go/manifests/1.26.5",
+            "#########################  100.0 pct",
+            "Downloaded to: /Users/x/Library/Caches/Homebrew/downloads/go.tar.gz",
+            "==> Pouring go--1.26.5.arm64_tahoe.bottle.tar.gz",
+        ])
+    }
+
+    @Test func `every row in a finished job is settled`() async throws {
+        let rows = try await runIntoJob(script: Self.downloadScript)
+
+        #expect(rows.filter { !$0.isComplete }.isEmpty)
+    }
+
+    @Test func `a bar still being drawn occupies exactly one row`() async throws {
+        // Mid-download rather than after it: the row exists, is not settled, and has not multiplied.
+        let script = "for i in $(seq 1 50); do printf '#### %s pct\\r' $i; done; sleep 0.2"
+        let rows = try await runIntoJob(script: script)
+
+        #expect(rows.count == 1 && rows[0].isComplete)
+    }
+}
+
+private extension TerminalProgressIntegrationTests {
+    /// Runs `script` on a pseudo-terminal and replays the streamed lines into a ``CommandJob``, exactly as
+    /// the console does, returning the rows the user would see.
+    func runIntoJob(script: String) async throws -> [BrewCommandOutputLine] {
+        let collector = LineCollector()
+        let service = BrewCommandService()
+
+        _ = try await service.run(
+            executableURL: URL(fileURLWithPath: "/bin/zsh"),
+            arguments: ["-c", script],
+            options: BrewRunOptions(lineObserver: { collector.append($0) }, usesPseudoTerminal: true),
+        )
+
+        return await MainActor.run {
+            let job = CommandJob(
+                operationID: BrewOperationID(kind: .formula, name: "go"),
+                command: "brew upgrade go",
+                startedAt: Date(),
+                phase: .running(.upgradeFormula),
+            )
+            for line in collector.allLines() {
+                job.appendOutput(line)
+            }
+            return job.output
+        }
+    }
+}
+
+// swiftlint:disable:next unchecked_sendable
+private final class LineCollector: @unchecked Sendable {
+    private let lock = NSLock()
+    private var lines: [BrewCommandOutputLine] = []
+
+    func append(_ line: BrewCommandOutputLine) {
+        lock.lock()
+        defer { lock.unlock() }
+        lines.append(line)
+    }
+
+    func allLines() -> [BrewCommandOutputLine] {
+        lock.lock()
+        defer { lock.unlock() }
+        return lines
+    }
+}

--- a/Tests/BrewCLITests/TerminalProgressIntegrationTests.swift
+++ b/Tests/BrewCLITests/TerminalProgressIntegrationTests.swift
@@ -11,6 +11,7 @@ import Testing
 
 /// End to end across the boundary the bug actually spanned: a real subprocess writing terminal redraws,
 /// through the drain and the assembler, into the console's job buffer.
+@Suite(.serialized)
 struct TerminalProgressIntegrationTests {
     /// Mimics a Homebrew download: plain lines around a `curl`-style bar that redraws hundreds of times,
     /// padded to width, with no newline until it finishes.

--- a/Tests/BrewCLITests/TerminalProgressIntegrationTests.swift
+++ b/Tests/BrewCLITests/TerminalProgressIntegrationTests.swift
@@ -59,7 +59,7 @@ private extension TerminalProgressIntegrationTests {
         _ = try await service.run(
             executableURL: URL(fileURLWithPath: "/bin/zsh"),
             arguments: ["-c", script],
-            options: BrewRunOptions(lineObserver: { collector.append($0) }, usesPseudoTerminal: true),
+            options: BrewRunOptions(lineObserver: { collector.append($0) }, output: .pseudoTerminal),
         )
 
         return await MainActor.run {

--- a/Tests/BrewCLITests/TerminalProgressIntegrationTests.swift
+++ b/Tests/BrewCLITests/TerminalProgressIntegrationTests.swift
@@ -9,12 +9,11 @@ import BrewRepositoryInterfaces
 import Foundation
 import Testing
 
-/// End to end across the boundary the bug actually spanned: a real subprocess writing terminal redraws,
-/// through the drain and the assembler, into the console's job buffer.
+/// End to end: a real subprocess writing terminal redraws, through the drain and assembler, into the
+/// console's job buffer.
 @Suite(.serialized)
 struct TerminalProgressIntegrationTests {
-    /// Mimics a Homebrew download: plain lines around a `curl`-style bar that redraws hundreds of times,
-    /// padded to width, with no newline until it finishes.
+    /// A `curl`-style bar redrawing hundreds of times, padded to width, with no newline until it ends.
     private static let downloadScript = """
     printf '==> Downloading https://ghcr.io/v2/homebrew/core/go/manifests/1.26.5\\n'
     for i in $(seq 1 600); do
@@ -43,7 +42,6 @@ struct TerminalProgressIntegrationTests {
     }
 
     @Test func `a bar still being drawn occupies exactly one row`() async throws {
-        // Mid-download rather than after it: the row exists, is not settled, and has not multiplied.
         let script = "for i in $(seq 1 50); do printf '#### %s pct\\r' $i; done; sleep 0.2"
         let rows = try await runIntoJob(script: script)
 
@@ -52,8 +50,8 @@ struct TerminalProgressIntegrationTests {
 }
 
 private extension TerminalProgressIntegrationTests {
-    /// Runs `script` on a pseudo-terminal and replays the streamed lines into a ``CommandJob``, exactly as
-    /// the console does, returning the rows the user would see.
+    /// Replays the streamed lines into a ``CommandJob`` as the console does, returning the rows a user
+    /// would see.
     func runIntoJob(script: String) async throws -> [BrewCommandOutputLine] {
         let collector = LineCollector()
         let service = BrewCommandService()

--- a/Tests/BrewCLITests/UTF8StreamDecoderTests.swift
+++ b/Tests/BrewCLITests/UTF8StreamDecoderTests.swift
@@ -22,7 +22,6 @@ struct UTF8StreamDecoderTests {
     }
 
     @Test func `a sequence split across reads is held back and then completed`() {
-        // "é" is 0xC3 0xA9; the read ended between its two bytes.
         var buffer = Data([0x61, 0xC3])
 
         #expect(UTF8StreamDecoder.takeDecodablePrefix(&buffer) == "a")
@@ -34,7 +33,6 @@ struct UTF8StreamDecoderTests {
     }
 
     @Test func `a four-byte sequence split at every boundary still reassembles`() {
-        // U+1F600, 0xF0 0x9F 0x98 0x80.
         let emoji: [UInt8] = [0xF0, 0x9F, 0x98, 0x80]
 
         for split in 1 ..< emoji.count {
@@ -46,8 +44,6 @@ struct UTF8StreamDecoderTests {
         }
     }
 
-    /// The bug this replaced held back only trailing bytes, so a bad byte anywhere else made the whole
-    /// chunk undecodable and cost a *leading* byte per read instead.
     @Test func `an invalid byte mid-buffer costs one character, not the text around it`() {
         var buffer = Data([0x41] + [0xFF] + Array("BC".utf8))
 
@@ -57,9 +53,9 @@ struct UTF8StreamDecoderTests {
         #expect(buffer.isEmpty)
     }
 
+    /// Bad bytes arriving faster than they are consumed used to grow the buffer without bound, stalling
+    /// every later line behind them.
     @Test func `invalid bytes never accumulate, however many arrive`() {
-        // The failure mode being guarded: bad bytes arriving faster than they are consumed grew the
-        // buffer without bound and stalled every later line behind it.
         var buffer = Data()
 
         for _ in 0 ..< 100 {
@@ -71,7 +67,6 @@ struct UTF8StreamDecoderTests {
     }
 
     @Test func `an always-invalid lead byte is not mistaken for an incomplete sequence`() {
-        // 0xC0 and 0xF5 can never start a sequence, so waiting for continuations would stall forever.
         for leadByte in [UInt8(0xC0), UInt8(0xC1), UInt8(0xF5), UInt8(0xFF)] {
             #expect(UTF8StreamDecoder.incompleteTrailingSequenceLength(Data([leadByte])) == 0)
         }
@@ -89,7 +84,6 @@ struct UTF8StreamDecoderTests {
     }
 
     @Test func `orphaned continuation bytes are passed through rather than held`() {
-        // No lead byte within reach, so holding them back would stall the stream.
         #expect(UTF8StreamDecoder.incompleteTrailingSequenceLength(Data([0x80, 0x80, 0x80])) == 0)
     }
 }

--- a/Tests/BrewCLITests/UTF8StreamDecoderTests.swift
+++ b/Tests/BrewCLITests/UTF8StreamDecoderTests.swift
@@ -1,0 +1,95 @@
+//
+//  UTF8StreamDecoderTests.swift
+//  BrewTests
+//
+
+@testable import BrewCLI
+import Foundation
+import Testing
+
+struct UTF8StreamDecoderTests {
+    @Test func `plain ASCII is taken whole`() {
+        var buffer = Data("hello".utf8)
+
+        #expect(UTF8StreamDecoder.takeDecodablePrefix(&buffer) == "hello")
+        #expect(buffer.isEmpty)
+    }
+
+    @Test func `an empty buffer yields nothing`() {
+        var buffer = Data()
+
+        #expect(UTF8StreamDecoder.takeDecodablePrefix(&buffer).isEmpty)
+    }
+
+    @Test func `a sequence split across reads is held back and then completed`() {
+        // "é" is 0xC3 0xA9; the read ended between its two bytes.
+        var buffer = Data([0x61, 0xC3])
+
+        #expect(UTF8StreamDecoder.takeDecodablePrefix(&buffer) == "a")
+        #expect(buffer == Data([0xC3]))
+
+        buffer.append(0xA9)
+        #expect(UTF8StreamDecoder.takeDecodablePrefix(&buffer) == "é")
+        #expect(buffer.isEmpty)
+    }
+
+    @Test func `a four-byte sequence split at every boundary still reassembles`() {
+        // U+1F600, 0xF0 0x9F 0x98 0x80.
+        let emoji: [UInt8] = [0xF0, 0x9F, 0x98, 0x80]
+
+        for split in 1 ..< emoji.count {
+            var buffer = Data(emoji.prefix(split))
+            #expect(UTF8StreamDecoder.takeDecodablePrefix(&buffer).isEmpty)
+
+            buffer.append(contentsOf: emoji.dropFirst(split))
+            #expect(UTF8StreamDecoder.takeDecodablePrefix(&buffer) == "😀")
+        }
+    }
+
+    /// The bug this replaced held back only trailing bytes, so a bad byte anywhere else made the whole
+    /// chunk undecodable and cost a *leading* byte per read instead.
+    @Test func `an invalid byte mid-buffer costs one character, not the text around it`() {
+        var buffer = Data([0x41] + [0xFF] + Array("BC".utf8))
+
+        let text = UTF8StreamDecoder.takeDecodablePrefix(&buffer)
+
+        #expect(text.contains("A") && text.contains("BC"))
+        #expect(buffer.isEmpty)
+    }
+
+    @Test func `invalid bytes never accumulate, however many arrive`() {
+        // The failure mode being guarded: bad bytes arriving faster than they are consumed grew the
+        // buffer without bound and stalled every later line behind it.
+        var buffer = Data()
+
+        for _ in 0 ..< 100 {
+            buffer.append(contentsOf: [0xFF, 0xFE] + Array("ok\n".utf8))
+            _ = UTF8StreamDecoder.takeDecodablePrefix(&buffer)
+        }
+
+        #expect(buffer.count <= 3)
+    }
+
+    @Test func `an always-invalid lead byte is not mistaken for an incomplete sequence`() {
+        // 0xC0 and 0xF5 can never start a sequence, so waiting for continuations would stall forever.
+        for leadByte in [UInt8(0xC0), UInt8(0xC1), UInt8(0xF5), UInt8(0xFF)] {
+            #expect(UTF8StreamDecoder.incompleteTrailingSequenceLength(Data([leadByte])) == 0)
+        }
+    }
+
+    @Test func `a complete sequence at the end is not held back`() {
+        #expect(UTF8StreamDecoder.incompleteTrailingSequenceLength(Data("é".utf8)) == 0)
+        #expect(UTF8StreamDecoder.incompleteTrailingSequenceLength(Data("😀".utf8)) == 0)
+    }
+
+    @Test func `an incomplete sequence reports the bytes it is holding`() {
+        #expect(UTF8StreamDecoder.incompleteTrailingSequenceLength(Data([0xF0])) == 1)
+        #expect(UTF8StreamDecoder.incompleteTrailingSequenceLength(Data([0xF0, 0x9F])) == 2)
+        #expect(UTF8StreamDecoder.incompleteTrailingSequenceLength(Data([0xF0, 0x9F, 0x98])) == 3)
+    }
+
+    @Test func `orphaned continuation bytes are passed through rather than held`() {
+        // No lead byte within reach, so holding them back would stall the stream.
+        #expect(UTF8StreamDecoder.incompleteTrailingSequenceLength(Data([0x80, 0x80, 0x80])) == 0)
+    }
+}

--- a/Tests/BrewCoreTests/TerminalLineAssemblerTests.swift
+++ b/Tests/BrewCoreTests/TerminalLineAssemblerTests.swift
@@ -201,7 +201,6 @@ struct TerminalLineAssemblerTests {
     // MARK: - Within-line cursor movement
 
     @Test func `absolute column addressing overwrites like a carriage return`() {
-        // ESC[1G is what several progress renderers use where curl uses \r.
         var assembler = TerminalLineAssembler()
 
         let events = assembler.consume("10%\u{1B}[1G100%\n")
@@ -266,7 +265,6 @@ struct TerminalLineAssemblerTests {
     }
 
     @Test func `an absurd column request cannot blow the line up`() {
-        // A malformed sequence would otherwise have the next write pad every cell up to it.
         var assembler = TerminalLineAssembler()
 
         let events = assembler.consume("a\u{1B}[999999999CX\n")
@@ -284,7 +282,6 @@ struct TerminalLineAssemblerTests {
     // MARK: - Erasing
 
     @Test func `erasing to the start of the line uses the current style, not the old one`() {
-        // A terminal erases with the active attribute; keeping the old one leaves a stale colour behind.
         var assembler = TerminalLineAssembler()
 
         let events = assembler.consume("\u{1B}[31mred\u{1B}[0m\u{1B}[1K\n")
@@ -299,7 +296,7 @@ struct TerminalLineAssemblerTests {
 
         let events = assembler.consume("abcde\r\u{1B}[2C\u{1B}[1KX\n")
 
-        // ESC[1K blanks columns 0 through 2 inclusive; the cursor stays at column 2, where X then lands.
+        // Blanks columns 0-2; the cursor stays at column 2, where X then lands.
         #expect(events.compactMap(\.committedText) == ["  Xde"])
     }
 }

--- a/Tests/BrewCoreTests/TerminalLineAssemblerTests.swift
+++ b/Tests/BrewCoreTests/TerminalLineAssemblerTests.swift
@@ -197,6 +197,111 @@ struct TerminalLineAssemblerTests {
 
         #expect(assembler.consume("").isEmpty)
     }
+
+    // MARK: - Within-line cursor movement
+
+    @Test func `absolute column addressing overwrites like a carriage return`() {
+        // ESC[1G is what several progress renderers use where curl uses \r.
+        var assembler = TerminalLineAssembler()
+
+        let events = assembler.consume("10%\u{1B}[1G100%\n")
+
+        #expect(events.compactMap(\.committedText) == ["100%"])
+    }
+
+    @Test func `absolute column addressing is one-based`() {
+        var assembler = TerminalLineAssembler()
+
+        let events = assembler.consume("abcde\u{1B}[3GX\n")
+
+        #expect(events.compactMap(\.committedText) == ["abXde"])
+    }
+
+    @Test func `a bare column sequence defaults to the first column`() {
+        var assembler = TerminalLineAssembler()
+
+        let events = assembler.consume("abc\u{1B}[GX\n")
+
+        #expect(events.compactMap(\.committedText) == ["Xbc"])
+    }
+
+    @Test func `cursor back steps over written cells`() {
+        var assembler = TerminalLineAssembler()
+
+        let events = assembler.consume("abcde\u{1B}[2DXY\n")
+
+        #expect(events.compactMap(\.committedText) == ["abcXY"])
+    }
+
+    @Test func `cursor forward skips cells without erasing them`() {
+        var assembler = TerminalLineAssembler()
+
+        let events = assembler.consume("abcde\r\u{1B}[2CX\n")
+
+        #expect(events.compactMap(\.committedText) == ["abXde"])
+    }
+
+    @Test func `cursor forward past the end pads with spaces`() {
+        var assembler = TerminalLineAssembler()
+
+        let events = assembler.consume("ab\u{1B}[3CX\n")
+
+        #expect(events.compactMap(\.committedText) == ["ab   X"])
+    }
+
+    @Test func `a bare movement sequence defaults to one column`() {
+        var assembler = TerminalLineAssembler()
+
+        let events = assembler.consume("abcde\r\u{1B}[CX\n")
+
+        #expect(events.compactMap(\.committedText) == ["aXcde"])
+    }
+
+    @Test func `cursor back cannot move past the start of the line`() {
+        var assembler = TerminalLineAssembler()
+
+        let events = assembler.consume("ab\u{1B}[99DX\n")
+
+        #expect(events.compactMap(\.committedText) == ["Xb"])
+    }
+
+    @Test func `an absurd column request cannot blow the line up`() {
+        // A malformed sequence would otherwise have the next write pad every cell up to it.
+        var assembler = TerminalLineAssembler()
+
+        let events = assembler.consume("a\u{1B}[999999999CX\n")
+
+        #expect((events.compactMap(\.committedText).first?.count ?? 0) <= 4097)
+    }
+
+    @Test func `moving the cursor alone does not report a revision`() {
+        var assembler = TerminalLineAssembler()
+        _ = assembler.consume("abc")
+
+        #expect(assembler.consume("\u{1B}[1G").isEmpty)
+    }
+
+    // MARK: - Erasing
+
+    @Test func `erasing to the start of the line uses the current style, not the old one`() {
+        // A terminal erases with the active attribute; keeping the old one leaves a stale colour behind.
+        var assembler = TerminalLineAssembler()
+
+        let events = assembler.consume("\u{1B}[31mred\u{1B}[0m\u{1B}[1K\n")
+
+        #expect(events.compactMap(\.committedLine).first?.spans == [
+            ANSISpan(text: "   ", style: .default),
+        ])
+    }
+
+    @Test func `erasing to the start blanks cells without moving the cursor`() {
+        var assembler = TerminalLineAssembler()
+
+        let events = assembler.consume("abcde\r\u{1B}[2C\u{1B}[1KX\n")
+
+        // ESC[1K blanks columns 0 through 2 inclusive; the cursor stays at column 2, where X then lands.
+        #expect(events.compactMap(\.committedText) == ["  Xde"])
+    }
 }
 
 private func line(_ text: String) -> TerminalLine {

--- a/Tests/BrewCoreTests/TerminalLineAssemblerTests.swift
+++ b/Tests/BrewCoreTests/TerminalLineAssemblerTests.swift
@@ -1,0 +1,225 @@
+//
+//  TerminalLineAssemblerTests.swift
+//  BrewTests
+//
+
+import BrewCore
+import Testing
+
+struct TerminalLineAssemblerTests {
+    // MARK: - Newlines
+
+    @Test func `a newline commits the line`() {
+        var assembler = TerminalLineAssembler()
+
+        // No trailing revision: the line committed, so nothing is left in progress to revise.
+        let events = assembler.consume("hello\n")
+
+        #expect(events == [.committed(line("hello"))])
+    }
+
+    @Test func `several newlines in one chunk commit several lines`() {
+        var assembler = TerminalLineAssembler()
+
+        let committed = assembler.consume("one\ntwo\nthree\n").compactMap(\.committedText)
+
+        #expect(committed == ["one", "two", "three"])
+    }
+
+    @Test func `text without a newline is revised, not committed`() {
+        var assembler = TerminalLineAssembler()
+
+        let events = assembler.consume("partial")
+
+        #expect(events == [.revised(line("partial"))])
+    }
+
+    // MARK: - Carriage returns
+
+    @Test func `a carriage return overwrites from the start of the line`() {
+        var assembler = TerminalLineAssembler()
+
+        let events = assembler.consume("first\rX")
+
+        #expect(events.last == .revised(line("Xirst")))
+    }
+
+    @Test func `a full-width redraw replaces the previous one entirely`() {
+        // What curl actually does: pad each redraw to the terminal width so it covers what came before.
+        var assembler = TerminalLineAssembler()
+
+        let events = assembler.consume("##        6.3%\r######   50.0%")
+
+        #expect(events.last == .revised(line("######   50.0%")))
+    }
+
+    @Test func `a whole progress bar collapses to one committed line`() {
+        // The reported bug in miniature: hundreds of redraws must settle into a single row, not hundreds.
+        var assembler = TerminalLineAssembler()
+
+        var events: [TerminalLineEvent] = []
+        for percent in stride(from: 0, through: 100, by: 10) {
+            events += assembler.consume("#\(percent)%\r")
+        }
+        events += assembler.consume("#100%\n")
+
+        #expect(events.compactMap(\.committedText) == ["#100%"])
+    }
+
+    @Test func `a shorter redraw leaves the tail of the longer line behind`() {
+        // Terminal behaviour, not a quirk: \r only moves the cursor, it does not clear.
+        var assembler = TerminalLineAssembler()
+
+        // "short" covers the first five columns; "r text" from the original survives underneath.
+        let events = assembler.consume("longer text\rshort")
+
+        #expect(events.last == .revised(line("shortr text")))
+    }
+
+    @Test func `a carriage return before a newline still commits the overwritten line`() {
+        var assembler = TerminalLineAssembler()
+
+        let committed = assembler.consume("aaa\rb\n").compactMap(\.committedText)
+
+        #expect(committed == ["baa"])
+    }
+
+    // MARK: - Erase in line
+
+    @Test func `erase to end of line clears the tail a shorter redraw left behind`() {
+        var assembler = TerminalLineAssembler()
+
+        let events = assembler.consume("longer text\rshort\u{1B}[K")
+
+        #expect(events.last == .revised(line("short")))
+    }
+
+    @Test func `erase whole line empties it`() {
+        var assembler = TerminalLineAssembler()
+
+        let events = assembler.consume("content\u{1B}[2K")
+
+        #expect(events.last == .revised(line("")))
+    }
+
+    @Test func `backspace steps the cursor back one column`() {
+        var assembler = TerminalLineAssembler()
+
+        let events = assembler.consume("abc\u{08}X")
+
+        #expect(events.last == .revised(line("abX")))
+    }
+
+    // MARK: - Styling
+
+    @Test func `styled text becomes spans carrying the style`() {
+        var assembler = TerminalLineAssembler()
+
+        let events = assembler.consume("\u{1B}[31mred\u{1B}[0m\n")
+
+        #expect(events.compactMap(\.committedLine).first?.spans == [
+            ANSISpan(text: "red", style: ANSIStyle(foreground: .red)),
+        ])
+    }
+
+    @Test func `escape sequences do not occupy columns`() {
+        // The reason styling is tracked per cell rather than left in the text: counting escape bytes as
+        // visible columns would land every subsequent overwrite in the wrong place.
+        var assembler = TerminalLineAssembler()
+
+        let events = assembler.consume("\u{1B}[31mabcde\u{1B}[0m\rX")
+
+        #expect(events.last?.revisedText == "Xbcde")
+    }
+
+    @Test func `style carries across a line boundary until reset`() {
+        var assembler = TerminalLineAssembler()
+
+        _ = assembler.consume("\u{1B}[31mfirst\n")
+        let events = assembler.consume("second\n")
+
+        #expect(events.compactMap(\.committedLine).first?.spans == [
+            ANSISpan(text: "second", style: ANSIStyle(foreground: .red)),
+        ])
+    }
+
+    @Test func `unsupported cursor movement is consumed rather than rendered`() {
+        var assembler = TerminalLineAssembler()
+
+        let events = assembler.consume("a\u{1B}[2Ab\n")
+
+        #expect(events.compactMap(\.committedText) == ["ab"])
+    }
+
+    // MARK: - Chunk boundaries
+
+    @Test func `a line split across chunks assembles into one committed line`() {
+        var assembler = TerminalLineAssembler()
+
+        _ = assembler.consume("start ")
+        _ = assembler.consume("middle ")
+        let events = assembler.consume("end\n")
+
+        #expect(events.compactMap(\.committedText) == ["start middle end"])
+    }
+
+    @Test func `a redraw split across chunks still overwrites`() {
+        var assembler = TerminalLineAssembler()
+
+        _ = assembler.consume("aaaa\r")
+        let events = assembler.consume("bb")
+
+        #expect(events.last?.revisedText == "bbaa")
+    }
+
+    @Test func `one revision is emitted per chunk, however much it contains`() {
+        // A progress bar writes faster than any UI needs to repaint; one event per write keeps that bounded.
+        var assembler = TerminalLineAssembler()
+
+        let events = assembler.consume("1%\r2%\r3%\r4%\r5%")
+
+        #expect(events == [.revised(line("5%"))])
+    }
+
+    // MARK: - Flushing
+
+    @Test func `flush commits a trailing line that never got a newline`() {
+        var assembler = TerminalLineAssembler()
+        _ = assembler.consume("no trailing newline")
+
+        #expect(assembler.flush()?.text == "no trailing newline")
+    }
+
+    @Test func `flush returns nil when nothing is pending`() {
+        var assembler = TerminalLineAssembler()
+        _ = assembler.consume("committed\n")
+
+        #expect(assembler.flush() == nil)
+    }
+
+    @Test func `an empty chunk produces no events`() {
+        var assembler = TerminalLineAssembler()
+
+        #expect(assembler.consume("").isEmpty)
+    }
+}
+
+private func line(_ text: String) -> TerminalLine {
+    TerminalLine(spans: text.isEmpty ? [] : [ANSISpan(text: text, style: .default)])
+}
+
+private extension TerminalLineEvent {
+    var committedLine: TerminalLine? {
+        if case let .committed(line) = self { return line }
+        return nil
+    }
+
+    var committedText: String? {
+        committedLine?.text
+    }
+
+    var revisedText: String? {
+        if case let .revised(line) = self { return line.text }
+        return nil
+    }
+}

--- a/Tests/BrewCoreTests/TerminalLineAssemblerTests.swift
+++ b/Tests/BrewCoreTests/TerminalLineAssemblerTests.swift
@@ -12,7 +12,6 @@ struct TerminalLineAssemblerTests {
     @Test func `a newline commits the line`() {
         var assembler = TerminalLineAssembler()
 
-        // No trailing revision: the line committed, so nothing is left in progress to revise.
         let events = assembler.consume("hello\n")
 
         #expect(events == [.committed(line("hello"))])
@@ -45,7 +44,7 @@ struct TerminalLineAssemblerTests {
     }
 
     @Test func `a full-width redraw replaces the previous one entirely`() {
-        // What curl actually does: pad each redraw to the terminal width so it covers what came before.
+        // curl pads each redraw to the terminal width so it covers what came before.
         var assembler = TerminalLineAssembler()
 
         let events = assembler.consume("##        6.3%\r######   50.0%")
@@ -54,7 +53,6 @@ struct TerminalLineAssemblerTests {
     }
 
     @Test func `a whole progress bar collapses to one committed line`() {
-        // The reported bug in miniature: hundreds of redraws must settle into a single row, not hundreds.
         var assembler = TerminalLineAssembler()
 
         var events: [TerminalLineEvent] = []
@@ -67,10 +65,9 @@ struct TerminalLineAssemblerTests {
     }
 
     @Test func `a shorter redraw leaves the tail of the longer line behind`() {
-        // Terminal behaviour, not a quirk: \r only moves the cursor, it does not clear.
+        // `\r` only moves the cursor, it does not clear: "short" covers the first five columns and
+        // "r text" from the original survives underneath.
         var assembler = TerminalLineAssembler()
-
-        // "short" covers the first five columns; "r text" from the original survives underneath.
         let events = assembler.consume("longer text\rshort")
 
         #expect(events.last == .revised(line("shortr text")))
@@ -123,8 +120,7 @@ struct TerminalLineAssemblerTests {
     }
 
     @Test func `escape sequences do not occupy columns`() {
-        // The reason styling is tracked per cell rather than left in the text: counting escape bytes as
-        // visible columns would land every subsequent overwrite in the wrong place.
+        // Why styling is per cell: counting escape bytes as columns would misplace every overwrite.
         var assembler = TerminalLineAssembler()
 
         let events = assembler.consume("\u{1B}[31mabcde\u{1B}[0m\rX")
@@ -173,7 +169,6 @@ struct TerminalLineAssemblerTests {
     }
 
     @Test func `one revision is emitted per chunk, however much it contains`() {
-        // A progress bar writes faster than any UI needs to repaint; one event per write keeps that bounded.
         var assembler = TerminalLineAssembler()
 
         let events = assembler.consume("1%\r2%\r3%\r4%\r5%")

--- a/Tests/BrewFeatureConsoleTests/CommandJobRevisionTests.swift
+++ b/Tests/BrewFeatureConsoleTests/CommandJobRevisionTests.swift
@@ -21,8 +21,6 @@ struct CommandJobRevisionTests {
     }
 
     @Test func `a revision keeps the row's identity`() {
-        // Identity stability is what makes the row animate in place instead of being torn down and
-        // rebuilt by anything keyed on `id`.
         let job = makeJob()
         job.appendOutput(line("10%", isComplete: false))
         let originalID = job.output[0].id
@@ -52,7 +50,6 @@ struct CommandJobRevisionTests {
     }
 
     @Test func `a whole progress bar leaves a single row behind`() {
-        // End to end for the reported bug: many revisions, one settled row.
         let job = makeJob()
 
         for percent in stride(from: 0, through: 100, by: 5) {

--- a/Tests/BrewFeatureConsoleTests/CommandJobRevisionTests.swift
+++ b/Tests/BrewFeatureConsoleTests/CommandJobRevisionTests.swift
@@ -1,0 +1,90 @@
+//
+//  CommandJobRevisionTests.swift
+//  BrewTests
+//
+
+import BrewCore
+import BrewRepositoryInterfaces
+import Foundation
+import Testing
+
+@MainActor
+struct CommandJobRevisionTests {
+    @Test func `an incomplete line is replaced rather than appended`() {
+        let job = makeJob()
+
+        job.appendOutput(line("10%", isComplete: false))
+        job.appendOutput(line("50%", isComplete: false))
+        job.appendOutput(line("100%", isComplete: false))
+
+        #expect(job.output.map(\.text) == ["100%"])
+    }
+
+    @Test func `a revision keeps the row's identity`() {
+        // Identity stability is what makes the row animate in place instead of being torn down and
+        // rebuilt by anything keyed on `id`.
+        let job = makeJob()
+        job.appendOutput(line("10%", isComplete: false))
+        let originalID = job.output[0].id
+
+        job.appendOutput(line("50%", isComplete: false))
+
+        #expect(job.output[0].id == originalID)
+    }
+
+    @Test func `completing a line settles it so the next one appends`() {
+        let job = makeJob()
+
+        job.appendOutput(line("100%", isComplete: false))
+        job.appendOutput(line("100%", isComplete: true))
+        job.appendOutput(line("Downloaded", isComplete: true))
+
+        #expect(job.output.map(\.text) == ["100%", "Downloaded"])
+    }
+
+    @Test func `complete lines always append`() {
+        let job = makeJob()
+
+        job.appendOutput(line("one", isComplete: true))
+        job.appendOutput(line("two", isComplete: true))
+
+        #expect(job.output.map(\.text) == ["one", "two"])
+    }
+
+    @Test func `a whole progress bar leaves a single row behind`() {
+        // End to end for the reported bug: many revisions, one settled row.
+        let job = makeJob()
+
+        for percent in stride(from: 0, through: 100, by: 5) {
+            job.appendOutput(line("#### \(percent)%", isComplete: false))
+        }
+        job.appendOutput(line("#### 100%", isComplete: true))
+
+        #expect(job.output.map(\.text) == ["#### 100%"])
+    }
+
+    @Test func `the line cap still applies once revisions settle`() {
+        let job = makeJob(maxOutputLines: 3)
+
+        for index in 1 ... 5 {
+            job.appendOutput(line("line \(index)", isComplete: true))
+        }
+
+        #expect(job.output.map(\.text) == ["line 3", "line 4", "line 5"])
+    }
+}
+
+@MainActor
+private func makeJob(maxOutputLines: Int = 50000) -> CommandJob {
+    CommandJob(
+        operationID: BrewOperationID(kind: .formula, name: "go"),
+        command: "brew upgrade go",
+        startedAt: Date(),
+        phase: .running(.upgradeFormula),
+        maxOutputLines: maxOutputLines,
+    )
+}
+
+private func line(_ text: String, isComplete: Bool) -> BrewCommandOutputLine {
+    BrewCommandOutputLine(stream: .stdout, text: text, isComplete: isComplete)
+}


### PR DESCRIPTION
# PR: Run brew under a pseudo-terminal

## Summary

Homebrew commands shown in the console now run against a pseudo-terminal instead of pipes. Brew and the tools it shells out to see a real terminal, so they emit their own colour and progress rendering, and output arrives as it is produced rather than in block-buffered bursts. Commands whose output gets parsed stay on pipes, so no parser changes behaviour.

## Changes

- Adds swift-subprocess, pinned at 1.0.0 and scoped to BrewCLI. A controlling terminal needs setsid() between fork and exec, which Foundation.Process cannot express.
- Adds PseudoTerminal, wrapping openpty with termios and window-size setup, descriptor ownership and a bounded read.
- Ports BrewCommandService to Subprocess. Runs create their own session, so teardown signals the whole process group and cancelling an install stops the curl or git it was waiting on.
- Adds TerminalLineAssembler, applying terminal overwrite semantics so a redrawing progress bar settles into one console row instead of several hundred.
- Console lines carry resolved styled spans and a completeness flag; a job revises its trailing row rather than appending.
- Display-mode runs use the pty and return the assembled transcript, which is also what a failed run reports as its diagnostic. Capture-mode runs stay on pipes, where the streams remain distinct.
- Falls back to pipes if allocation fails. Decoding is lossy, so one bad byte costs a character rather than a line or a run.

## Why this split

Screen-level emulation, which the multi-line spinner artifacts need, is a different data model: a grid with a cursor rather than a transcript of rows. It would touch scrollback, selection, copy and export, so it belongs in its own PR.

## Testing

- [x] scripts/test, 757 package tests plus 19 BrewUILint tests
- [x] swiftformat, swiftlint --strict, BrewUILint over the tree
- [x] xcodebuild -scheme Brew, signing disabled
- [x] Suite run 8 times consecutively for the pty flakiness fix
- [x] Real curl and brew fetch through the production path
- [ ] Manual: watch a real brew upgrade in the app console

## PR checklist

- [x] Have you followed this repository's contribution and workflow guidance?
- [x] Have you explained what changed and why this should land now?
- [x] Have you run relevant local checks for the changed scope?
- [x] Are changes scoped and free of unrelated modifications?

-----

- [x] AI was used to generate or assist with generating this PR.
- [x] Claude Code wrote the implementation, tests and description. Teardown, timing and allocation limits are measured, not assumed. A review pass caught a regression where a failed install reported a bare exit code, because a terminal merges the streams and the failure path read only stderr; that and eight smaller findings were fixed and covered. Console animation is the one unmeasured claim, as the GUI could not be run here.

-----

## Follow-ups

- Multi-line spinner redraws leave artifacts, such as a leftover prefix on a rewritten line. Needs the screen buffer above.
- Sizing the pty to the console width, and SIGWINCH on resize.
- Console rows wrap. A terminal does not reflow, so horizontal scrolling would be more faithful.
