### PR TITLE
Search bar escape crash

### DIFF
--- a/BrewUITests/Elements/BrewUISearchField.swift
+++ b/BrewUITests/Elements/BrewUISearchField.swift
@@ -47,6 +47,13 @@ final class BrewUISearchField {
         return self
     }
 
+    /// At the app, so it reaches whoever holds the keyboard — including nobody.
+    @discardableResult
+    func pressEscape() -> Self {
+        app.typeKey(XCUIKeyboardKey.escape, modifierFlags: [])
+        return self
+    }
+
     /// At the app, not the element: `element.typeText` would focus the field first.
     @discardableResult
     func typeAtCursor(_ text: String) -> Self {

--- a/BrewUITests/Tests/SearchDismissUITests.swift
+++ b/BrewUITests/Tests/SearchDismissUITests.swift
@@ -1,0 +1,56 @@
+//
+//  SearchDismissUITests.swift
+//  BrewUITests
+//
+
+import XCTest
+
+/// Escape out of the search field. Unlike ``SearchFocusUITests`` these do click it: dismissal is what
+/// used to wedge the app, and only a click puts the cursor there without going through ⌘F first.
+final class SearchDismissUITests: BrewUITestCase {
+    @MainActor
+    func testEscapeFromSearchFieldLeavesTheAppResponsive() {
+        let installed = launch(.installedBasic)
+
+        installed.searchField.activate()
+        installed.searchField.pressEscape()
+
+        // A wedged app answers no queries at all, so reaching a row is the assertion.
+        installed
+            .assertHasPackage("wget")
+            .assertHasPackage("iterm2")
+    }
+
+    /// The keyboard has to land somewhere on the way out, or arrow-key navigation is dead afterwards.
+    @MainActor
+    func testEscapeHandsTheKeyboardBackToTheList() {
+        let installed = launch(.installedBasic)
+
+        installed.searchField
+            .activate()
+            .typeAtCursor("wget")
+            .assertValue("wget")
+        installed.searchField.pressEscape()
+
+        installed.searchField
+            .pressFindShortcut()
+            .selectAllAtCursor()
+            .typeAtCursor("iterm2")
+            .assertValue("iterm2")
+
+        installed.assertHasPackage("iterm2")
+    }
+
+    @MainActor
+    func testRepeatedEscapesLeaveTheAppResponsive() {
+        let installed = launch(.installedBasic)
+
+        for _ in 0 ..< 3 {
+            installed.searchField.activate()
+            installed.searchField.pressEscape()
+            installed.searchField.pressEscape()
+        }
+
+        installed.assertHasPackage("wget")
+    }
+}

--- a/Sources/BrewCrashReporting/CrashReportFormatter.swift
+++ b/Sources/BrewCrashReporting/CrashReportFormatter.swift
@@ -43,9 +43,26 @@ enum CrashReportFormatter {
         }
 
         lines += "\n\nCall stack:\n"
-        lines += callStack.joined(separator: "\n")
+        lines += clampedCallStack(callStack).joined(separator: "\n")
         return lines
     }
+
+    /// A runaway recursion throws with a call stack hundreds of thousands of frames deep, and every
+    /// frame of it lands in the report. Keeping both ends preserves what the elision costs: the
+    /// repeating cycle at the top, and how the process got there at the bottom.
+    static func clampedCallStack(_ callStack: [String]) -> [String] {
+        guard callStack.count > maximumCallStackFrames else {
+            return callStack
+        }
+
+        let leading = callStack.prefix(maximumCallStackFrames - trailingCallStackFrames)
+        let trailing = callStack.suffix(trailingCallStackFrames)
+        let elided = callStack.count - leading.count - trailing.count
+        return leading + ["… \(elided) more frames elided …"] + trailing
+    }
+
+    static let maximumCallStackFrames = 128
+    private static let trailingCallStackFrames = 32
 
     private static func environmentLines(
         environment: CrashReportEnvironment,

--- a/Sources/BrewCrashReporting/CrashReportStore.swift
+++ b/Sources/BrewCrashReporting/CrashReportStore.swift
@@ -29,12 +29,21 @@ public struct CrashReportStore: Sendable {
         )
     }
 
+    /// The signal path appends to one file per launch and the exception path can be handed an
+    /// unbounded backtrace, so a single report is clamped on the way to disk — and again on the way
+    /// back, because an oversized file written before this limit existed would otherwise still reach
+    /// the sheet, where laying out one string of that size wedges the launch it belongs to.
+    /// The dialog renders a report as one `Text`, which lays out in full: 128 KB of it costs six
+    /// seconds of launch. A capped call stack fits in a fraction of this.
+    public static let maximumReportBytes = 16 * 1024
+
     @discardableResult
     public func save(text: String, date: Date) throws -> CrashReport {
         try ensureDirectoryExists()
         let url = reportFileURL(for: date)
-        try Data(text.utf8).write(to: url, options: .atomic)
-        return CrashReport(id: url.lastPathComponent, capturedAt: date, text: text)
+        let clamped = Self.clamped(text)
+        try Data(clamped.utf8).write(to: url, options: .atomic)
+        return CrashReport(id: url.lastPathComponent, capturedAt: date, text: clamped)
     }
 
     /// All persisted reports, oldest first; unreadable files are skipped so a
@@ -71,7 +80,7 @@ public struct CrashReportStore: Sendable {
         }
 
         let url = directoryURL.appendingPathComponent(name)
-        guard let text = try? String(contentsOf: url, encoding: .utf8) else {
+        guard let text = readClampedText(at: url) else {
             return nil
         }
 
@@ -81,6 +90,42 @@ public struct CrashReportStore: Sendable {
             text: text,
         )
     }
+
+    /// Reads the leading bytes rather than the file, so an oversized report costs a page, not its size.
+    private func readClampedText(at url: URL) -> String? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else {
+            return nil
+        }
+        defer { try? handle.close() }
+
+        guard let data = try? handle.read(upToCount: Self.maximumReportBytes) else {
+            return nil
+        }
+        guard let text = Self.decoded(data) else {
+            return nil
+        }
+        let isTruncated = (try? handle.read(upToCount: 1))??.isEmpty == false
+        return isTruncated ? text + Self.truncationMarker : text
+    }
+
+    /// Cutting at a byte count can split a character, so give back the bytes that make a whole one.
+    private static func decoded(_ data: Data) -> String? {
+        for droppedBytes in 0 ... 3 {
+            if let text = String(data: data.dropLast(droppedBytes), encoding: .utf8) {
+                return text
+            }
+        }
+        return nil
+    }
+
+    private static func clamped(_ text: String) -> String {
+        guard text.utf8.count > maximumReportBytes else {
+            return text
+        }
+        return String(text.prefix(maximumReportBytes)) + truncationMarker
+    }
+
+    private static let truncationMarker = "\n\n… report truncated …\n"
 
     private static func defaultDirectoryURL() -> URL {
         let fileManager = FileManager.default

--- a/Sources/BrewFeatureDiscover/Views/DiscoverPackagesView.swift
+++ b/Sources/BrewFeatureDiscover/Views/DiscoverPackagesView.swift
@@ -39,8 +39,8 @@ struct DiscoverPackagesView: View {
         )
         .searchFocused($focus, equals: .searchField)
         .focusedSceneValue(\.focusSearchField, focusSearchField)
-        .onChange(of: searchFocus.target) { _, target in
-            focus = target
+        .onChange(of: searchFocus.target) { _, _ in
+            moveFocusToTarget()
         }
         .onChange(of: focus) { _, focus in
             searchFocus.focusDidChange(to: focus)
@@ -72,6 +72,18 @@ struct DiscoverPackagesView: View {
                 return
             }
             await viewModel.search()
+        }
+    }
+
+    /// Hopping off this update is load-bearing. `.searchable` reports its dismissal from inside
+    /// AppKit's layout pass, so writing the arbiter's new target straight back into `.searchFocused`
+    /// re-enters that pass, which dismisses again — Escape used to wedge the app until the stack ran out.
+    private func moveFocusToTarget() {
+        Task { @MainActor in
+            guard focus != searchFocus.target else {
+                return
+            }
+            focus = searchFocus.target
         }
     }
 

--- a/Sources/BrewFeatureDiscover/Views/DiscoverPackagesView.swift
+++ b/Sources/BrewFeatureDiscover/Views/DiscoverPackagesView.swift
@@ -44,6 +44,9 @@ struct DiscoverPackagesView: View {
         }
         .onChange(of: focus) { _, focus in
             searchFocus.focusDidChange(to: focus)
+            if focus != .searchField, viewModel.query.isEmpty {
+                searchFocus.emptySearchFieldDidLoseFocus()
+            }
         }
         .onChange(of: searchFocus.isSearchFieldPresented) { _, presented in
             guard presented else {

--- a/Sources/BrewFeatureInstalled/Views/InstalledUpgradesColumns.swift
+++ b/Sources/BrewFeatureInstalled/Views/InstalledUpgradesColumns.swift
@@ -87,8 +87,8 @@ struct InstalledUpgradesContainer: View {
             )
             .searchFocused($focus, equals: .searchField)
             .focusedSceneValue(\.focusSearchField, focusSearchField)
-            .onChange(of: searchFocus.target) { _, target in
-                focus = target
+            .onChange(of: searchFocus.target) { _, _ in
+                moveFocusToTarget()
             }
             .onChange(of: focus) { _, focus in
                 searchFocus.focusDidChange(to: focus)
@@ -115,6 +115,18 @@ struct InstalledUpgradesContainer: View {
                     searchFocus.searchFieldDidPresent()
                 }
             }
+    }
+
+    /// Hopping off this update is load-bearing. `.searchable` reports its dismissal from inside
+    /// AppKit's layout pass, so writing the arbiter's new target straight back into `.searchFocused`
+    /// re-enters that pass, which dismisses again — Escape used to wedge the app until the stack ran out.
+    private func moveFocusToTarget() {
+        Task { @MainActor in
+            guard focus != searchFocus.target else {
+                return
+            }
+            focus = searchFocus.target
+        }
     }
 
     private var focusSearchField: FocusSearchFieldAction {

--- a/Sources/BrewFeatureInstalled/Views/InstalledUpgradesColumns.swift
+++ b/Sources/BrewFeatureInstalled/Views/InstalledUpgradesColumns.swift
@@ -92,6 +92,9 @@ struct InstalledUpgradesContainer: View {
             }
             .onChange(of: focus) { _, focus in
                 searchFocus.focusDidChange(to: focus)
+                if focus != .searchField, activeSearchQuery.wrappedValue.isEmpty {
+                    searchFocus.emptySearchFieldDidLoseFocus()
+                }
             }
             .onChange(of: searchFocus.isSearchFieldPresented) { _, presented in
                 guard presented else {

--- a/Sources/BrewUIComponents/Chrome/SearchFocusArbiter.swift
+++ b/Sources/BrewUIComponents/Chrome/SearchFocusArbiter.swift
@@ -53,6 +53,13 @@ public struct SearchFocusArbiter: Equatable, Sendable {
         }
     }
 
+    public mutating func emptySearchFieldDidLoseFocus() {
+        guard !isSearchFocusPending else {
+            return
+        }
+        searchFieldDidDismiss()
+    }
+
     public mutating func contentDidLoad() {
         guard target == nil, !isSearchFocusPending else {
             return

--- a/Sources/BrewUIComponents/Chrome/SearchFocusArbiter.swift
+++ b/Sources/BrewUIComponents/Chrome/SearchFocusArbiter.swift
@@ -28,7 +28,6 @@ public struct SearchFocusArbiter: Equatable, Sendable {
 
     public mutating func requestSearchFocus() {
         guard isSearchFieldPresented else {
-            // Leave `target` alone: whoever holds the keyboard keeps it until the field can take over.
             isSearchFieldPresented = true
             isSearchFocusPending = true
             return
@@ -62,7 +61,7 @@ public struct SearchFocusArbiter: Equatable, Sendable {
     }
 
     public mutating func focusDidChange(to target: SearchFocusTarget?) {
-        guard !isSearchFocusPending || target != nil else {
+        guard let target else {
             return
         }
         self.target = target

--- a/Tests/BrewCrashReportingTests/CrashReportFormatterTests.swift
+++ b/Tests/BrewCrashReportingTests/CrashReportFormatterTests.swift
@@ -50,4 +50,27 @@ struct CrashReportFormatterTests {
 
         #expect(!text.contains("Reason:"))
     }
+
+    @Test func `a runaway call stack is elided from the middle`() {
+        let callStack = (0 ..< 500_000).map { "\($0) frame" }
+
+        let text = CrashReportFormatter.makeReportText(
+            kind: "Uncaught exception NSInternalInconsistencyException",
+            detail: nil,
+            callStack: callStack,
+            environment: sampleEnvironment,
+            date: Date(timeIntervalSince1970: 0),
+        )
+
+        #expect(text.contains("0 frame"))
+        #expect(text.contains("499999 frame"))
+        #expect(text.contains("more frames elided"))
+        #expect(text.utf8.count < 16 * 1024)
+    }
+
+    @Test func `a call stack within the limit is kept whole`() {
+        let callStack = (0 ..< CrashReportFormatter.maximumCallStackFrames).map { "\($0) frame" }
+
+        #expect(CrashReportFormatter.clampedCallStack(callStack) == callStack)
+    }
 }

--- a/Tests/BrewCrashReportingTests/CrashReportStoreTests.swift
+++ b/Tests/BrewCrashReportingTests/CrashReportStoreTests.swift
@@ -80,4 +80,41 @@ struct CrashReportStoreTests {
 
         #expect(store.pendingReports().isEmpty)
     }
+
+    @Test func `an oversized report is clamped on the way to disk`() throws {
+        let store = makeTemporaryStore()
+
+        let saved = try store.save(
+            text: String(repeating: "x", count: CrashReportStore.maximumReportBytes * 3),
+            date: Date(timeIntervalSince1970: 1000),
+        )
+
+        #expect(saved.text.contains("report truncated"))
+        #expect(saved.text.utf8.count < CrashReportStore.maximumReportBytes * 2)
+        #expect(store.pendingReports() == [saved])
+    }
+
+    /// Reports written before the limit existed still have to reach the sheet in one piece.
+    @Test func `an oversized file already on disk is clamped on the way back`() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CrashReportStoreTests-\(UUID().uuidString)", isDirectory: true)
+        let store = CrashReportStore(directoryURL: directory)
+        try store.ensureDirectoryExists()
+        let oversized = String(repeating: "y", count: CrashReportStore.maximumReportBytes * 3)
+        try Data(oversized.utf8).write(to: directory.appendingPathComponent("crash-1000.log"))
+
+        let report = try #require(store.pendingReports().first)
+
+        #expect(report.text.contains("report truncated"))
+        #expect(report.text.utf8.count < CrashReportStore.maximumReportBytes * 2)
+    }
+
+    @Test func `a report within the limit round-trips untouched`() throws {
+        let store = makeTemporaryStore()
+        let text = String(repeating: "z", count: CrashReportStore.maximumReportBytes)
+
+        try store.save(text: text, date: Date(timeIntervalSince1970: 1000))
+
+        #expect(store.pendingReports().map(\.text) == [text])
+    }
 }

--- a/Tests/BrewUIComponentsTests/SearchFocusArbiterTests.swift
+++ b/Tests/BrewUIComponentsTests/SearchFocusArbiterTests.swift
@@ -194,6 +194,26 @@ struct SearchFocusArbiterTests {
         #expect(arbiter.target == .list)
     }
 
+    @Test func `an empty search field collapses once the keyboard leaves it`() {
+        var arbiter = SearchFocusArbiter(target: .searchField, isSearchFieldPresented: true)
+
+        arbiter.focusDidChange(to: .list)
+        arbiter.emptySearchFieldDidLoseFocus()
+
+        #expect(!arbiter.isSearchFieldPresented)
+        #expect(arbiter.target == .list)
+    }
+
+    @Test func `a pending claim keeps the field it just presented`() {
+        var arbiter = SearchFocusArbiter(target: .list)
+
+        arbiter.requestSearchFocus()
+        arbiter.emptySearchFieldDidLoseFocus()
+
+        #expect(arbiter.isSearchFieldPresented)
+        #expect(arbiter.isSearchFocusPending)
+    }
+
     @Test func `dismissing while the list holds the keyboard leaves it there`() {
         var arbiter = SearchFocusArbiter(target: .list, isSearchFieldPresented: true)
 

--- a/Tests/BrewUIComponentsTests/SearchFocusArbiterTests.swift
+++ b/Tests/BrewUIComponentsTests/SearchFocusArbiterTests.swift
@@ -142,6 +142,17 @@ struct SearchFocusArbiterTests {
         #expect(arbiter.target == .searchField)
     }
 
+    /// SwiftUI resigns the search field on its way out of the toolbar, after `searchFieldDidDismiss`
+    /// has already handed the list back the keyboard. Honouring that nil left the keyboard nowhere.
+    @Test func `losing focus does not clear the target`() {
+        var arbiter = SearchFocusArbiter(target: .searchField, isSearchFieldPresented: true)
+
+        arbiter.searchFieldDidDismiss()
+        arbiter.focusDidChange(to: nil)
+
+        #expect(arbiter.target == .list)
+    }
+
     @Test func `losing focus while a claim is pending does not cancel the claim`() {
         var arbiter = SearchFocusArbiter(target: .list)
 


### PR DESCRIPTION
# PR: Fix the Escape-key freeze in the search field

## Summary

Pressing Escape with the cursor in the toolbar search field hung the app, then killed it with SIGSEGV. This fixes that, stops the resulting crash report wedging the next launch, and collapses an empty search field when focus leaves it.

## Changes

Search focus:

- `DiscoverPackagesView` and `InstalledUpgradesColumns` move `@FocusState` on the next main-actor turn. `.searchable` calls its `isPresented` setter from inside AppKit's layout pass, so writing focus back into `.searchFocused` re-entered that pass, dismissed again, and recursed until the stack guard page.
- `SearchFocusArbiter.focusDidChange(to:)` ignores nil. SwiftUI resigns the field after `searchFieldDidDismiss()` has handed the list the keyboard, so honouring that nil left Escape with focus nowhere.
- New: an empty search field collapses once focus leaves it. Pending Cmd-F claims and fields with a query are exempt.

Crash reporting:

- Call stacks are elided from the middle and reports clamped to 16 KB, on write and on read. The recursion produced an 82 MB report, which the dialog renders as one `Text`, so every later launch froze in CoreText. The read-side clamp repairs machines already holding such a file.

## Testing

- [x] `scripts/test`: 765 unit tests pass, with new arbiter and crash-report coverage.
- [x] SwiftFormat, SwiftLint strict, BrewUILint clean.
- [x] Drove click-field then Escape in the built app: six rounds survive, list keeps focus; unfixed runs hung on the first.
- [x] Launch with a planted 74 MB report: window usable in 1.90s, matching a clean run.
- [ ] UI tests compile but did not run; the sandbox cannot launch an unsigned runner.
- [ ] Manual check needed: clicking a row collapses the field, and Cmd-F still focuses it.

## PR checklist

- [x] Have you followed this repository's contribution and workflow guidance?
- [x] Have you explained what changed and why this should land now?
- [x] Have you run relevant local checks for the changed scope?
- [x] Are changes scoped and free of unrelated modifications?

-----

- [x] AI was used to generate or assist with generating this PR.
- [x] Claude Code reproduced the crash, bisected it by suppressing the suspect focus write, wrote the fixes and tests, and measured launch times either side. Mouse clicks and Cmd-F were not AI-verified.

-----

## Follow-ups

The crash-report dialog renders its text as one `Text`; longer reports would need a virtualising text view.
