### PR TITLE
Search bar click away

### DIFF
--- a/BrewUITests/Tests/ListFocusUITests.swift
+++ b/BrewUITests/Tests/ListFocusUITests.swift
@@ -1,0 +1,33 @@
+//
+//  ListFocusUITests.swift
+//  BrewUITests
+//
+
+import XCTest
+
+/// The list holds the keyboard after a tab switch, asserted through arrow-key navigation because that
+/// is what the focus is for: with the keyboard nowhere, the key press opens no detail.
+final class ListFocusUITests: BrewUITestCase {
+    @MainActor
+    func testUpgradesListTakesTheKeyboardWhenSwitchedTo() {
+        let upgrades = launch(.installedBasic).sidebar.goToUpgrades()
+        upgrades.assertHasPackage("ripgrep")
+
+        upgrades.app.typeKey(.downArrow, modifierFlags: [])
+
+        PackageDetailScreen(app: upgrades.app).waitUntilLoaded()
+    }
+
+    @MainActor
+    func testInstalledListTakesTheKeyboardWhenSwitchedBackTo() {
+        let upgrades = launch(.installedBasic).sidebar.goToUpgrades()
+        upgrades.assertHasPackage("ripgrep")
+
+        let installed = upgrades.sidebar.goToInstalled()
+        installed.assertHasPackage("wget")
+
+        installed.app.typeKey(.downArrow, modifierFlags: [])
+
+        PackageDetailScreen(app: installed.app).waitUntilLoaded()
+    }
+}

--- a/BrewUITests/Tests/SearchDismissUITests.swift
+++ b/BrewUITests/Tests/SearchDismissUITests.swift
@@ -53,4 +53,21 @@ final class SearchDismissUITests: BrewUITestCase {
 
         installed.assertHasPackage("wget")
     }
+
+    /// The click that used to change nothing: focus only moves for some of them, so this asserts on
+    /// where the keystrokes land rather than on the field's own focus.
+    @MainActor
+    func testClickingOutsideTheSearchFieldDefocusesIt() {
+        let installed = launch(.installedBasic)
+
+        installed.searchField
+            .activate()
+            .typeAtCursor("wget")
+            .assertValue("wget")
+
+        installed.list.row("wget").tap()
+        installed.searchField.typeAtCursor("zzz")
+
+        installed.searchField.assertValue("wget")
+    }
 }

--- a/Sources/BrewFeatureDiscover/Views/DiscoverPackagesView.swift
+++ b/Sources/BrewFeatureDiscover/Views/DiscoverPackagesView.swift
@@ -48,6 +48,12 @@ struct DiscoverPackagesView: View {
                 searchFocus.emptySearchFieldDidLoseFocus()
             }
         }
+        .onClickOutsideSearchField {
+            guard focus == .searchField else {
+                return
+            }
+            searchFocus.clickLandedOutsideSearchField(searchFieldIsEmpty: viewModel.query.isEmpty)
+        }
         .onChange(of: searchFocus.isSearchFieldPresented) { _, presented in
             guard presented else {
                 return

--- a/Sources/BrewFeatureInstalled/Views/InstalledUpgradesColumns.swift
+++ b/Sources/BrewFeatureInstalled/Views/InstalledUpgradesColumns.swift
@@ -96,6 +96,14 @@ struct InstalledUpgradesContainer: View {
                     searchFocus.emptySearchFieldDidLoseFocus()
                 }
             }
+            .onClickOutsideSearchField {
+                guard focus == .searchField else {
+                    return
+                }
+                searchFocus.clickLandedOutsideSearchField(
+                    searchFieldIsEmpty: activeSearchQuery.wrappedValue.isEmpty,
+                )
+            }
             .onChange(of: searchFocus.isSearchFieldPresented) { _, presented in
                 guard presented else {
                     return

--- a/Sources/BrewFeatureInstalled/Views/InstalledUpgradesColumns.swift
+++ b/Sources/BrewFeatureInstalled/Views/InstalledUpgradesColumns.swift
@@ -90,6 +90,10 @@ struct InstalledUpgradesContainer: View {
             .onChange(of: searchFocus.target) { _, _ in
                 moveFocusToTarget()
             }
+            .onChange(of: mode) { _, _ in
+                searchFocus.activeListDidChange()
+                moveFocusToTarget()
+            }
             .onChange(of: focus) { _, focus in
                 searchFocus.focusDidChange(to: focus)
                 if focus != .searchField, activeSearchQuery.wrappedValue.isEmpty {

--- a/Sources/BrewUIComponents/Chrome/SearchFieldClickAway.swift
+++ b/Sources/BrewUIComponents/Chrome/SearchFieldClickAway.swift
@@ -1,0 +1,79 @@
+import AppKit
+import SwiftUI
+
+public extension View {
+    /// Runs `action` for a click anywhere in the app that did not land in the toolbar search field.
+    ///
+    /// Focus is not a good enough signal on its own: clicking a list row moves `@FocusState`, but
+    /// clicking a header, a picker or empty space moves nothing, so the field would keep the keyboard
+    /// with no way for the user to see why.
+    func onClickOutsideSearchField(perform action: @escaping @MainActor () -> Void) -> some View {
+        modifier(ClickOutsideSearchFieldModifier(action: action))
+    }
+}
+
+private struct ClickOutsideSearchFieldModifier: ViewModifier {
+    let action: @MainActor () -> Void
+
+    @State private var monitor = OutsideSearchFieldClickMonitor()
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear { monitor.start(action) }
+            .onDisappear { monitor.stop() }
+    }
+}
+
+@MainActor
+private final class OutsideSearchFieldClickMonitor {
+    private var token: Any?
+
+    func start(_ action: @escaping @MainActor () -> Void) {
+        stop()
+        token = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { event in
+            if !SearchFieldClickAway.isInsideSearchField(event) {
+                // AppKit delivers local monitors on the main thread; the closure's type can't say so.
+                // swiftlint:disable:next assume_isolated
+                MainActor.assumeIsolated { action() }
+            }
+            return event
+        }
+    }
+
+    func stop() {
+        if let token {
+            NSEvent.removeMonitor(token)
+        }
+        token = nil
+    }
+}
+
+/// Where a click landed relative to the toolbar search field.
+enum SearchFieldClickAway {
+    static func isInsideSearchField(_ event: NSEvent) -> Bool {
+        isInsideSearchField(clickedView(for: event))
+    }
+
+    /// The field editor and the toolbar item's own chrome both sit under the `NSSearchField`, so the
+    /// ancestor walk covers a click on the text, the magnifier and the cancel button alike.
+    static func isInsideSearchField(_ view: NSView?) -> Bool {
+        var node = view
+        while let current = node {
+            if current is NSSearchField {
+                return true
+            }
+            node = current.superview
+        }
+        return false
+    }
+
+    /// Hit-tested from the theme frame rather than the content view: the search field lives in the
+    /// window's title bar, which is not part of the content view's tree.
+    private static func clickedView(for event: NSEvent) -> NSView? {
+        guard let window = event.window else {
+            return nil
+        }
+        let root = window.contentView?.superview ?? window.contentView
+        return root?.hitTest(event.locationInWindow)
+    }
+}

--- a/Sources/BrewUIComponents/Chrome/SearchFieldClickAway.swift
+++ b/Sources/BrewUIComponents/Chrome/SearchFieldClickAway.swift
@@ -54,8 +54,6 @@ enum SearchFieldClickAway {
         isInsideSearchField(clickedView(for: event))
     }
 
-    /// The field editor and the toolbar item's own chrome both sit under the `NSSearchField`, so the
-    /// ancestor walk covers a click on the text, the magnifier and the cancel button alike.
     static func isInsideSearchField(_ view: NSView?) -> Bool {
         var node = view
         while let current = node {
@@ -67,8 +65,6 @@ enum SearchFieldClickAway {
         return false
     }
 
-    /// Hit-tested from the theme frame rather than the content view: the search field lives in the
-    /// window's title bar, which is not part of the content view's tree.
     private static func clickedView(for event: NSEvent) -> NSView? {
         guard let window = event.window else {
             return nil

--- a/Sources/BrewUIComponents/Chrome/SearchFocusArbiter.swift
+++ b/Sources/BrewUIComponents/Chrome/SearchFocusArbiter.swift
@@ -60,6 +60,19 @@ public struct SearchFocusArbiter: Equatable, Sendable {
         searchFieldDidDismiss()
     }
 
+    /// A field with a query in it keeps its place in the toolbar; collapsing it would hide why the
+    /// list is still filtered. Either way the keyboard goes back to the list the user clicked into.
+    public mutating func clickLandedOutsideSearchField(searchFieldIsEmpty: Bool) {
+        guard !isSearchFocusPending else {
+            return
+        }
+        if searchFieldIsEmpty {
+            searchFieldDidDismiss()
+        } else {
+            target = .list
+        }
+    }
+
     public mutating func contentDidLoad() {
         guard target == nil, !isSearchFocusPending else {
             return

--- a/Sources/BrewUIComponents/Chrome/SearchFocusArbiter.swift
+++ b/Sources/BrewUIComponents/Chrome/SearchFocusArbiter.swift
@@ -73,6 +73,15 @@ public struct SearchFocusArbiter: Equatable, Sendable {
         }
     }
 
+    /// Switching tab rebuilds the list, and a rebuilt list holds no focus. The keyboard only goes back
+    /// to it when the search field is not the one using it.
+    public mutating func activeListDidChange() {
+        guard !isSearchFocusPending, target != .searchField else {
+            return
+        }
+        target = .list
+    }
+
     public mutating func contentDidLoad() {
         guard target == nil, !isSearchFocusPending else {
             return

--- a/Tests/BrewUIComponentsTests/SearchFieldClickAwayTests.swift
+++ b/Tests/BrewUIComponentsTests/SearchFieldClickAwayTests.swift
@@ -1,0 +1,38 @@
+//
+//  SearchFieldClickAwayTests.swift
+//  BrewTests
+//
+
+import AppKit
+@testable import BrewUIComponents
+import Testing
+
+@MainActor
+struct SearchFieldClickAwayTests {
+    @Test func `a click on the field editor counts as inside the field`() {
+        let searchField = NSSearchField()
+        let fieldEditor = NSView()
+        let clip = NSView()
+        searchField.addSubview(clip)
+        clip.addSubview(fieldEditor)
+
+        #expect(SearchFieldClickAway.isInsideSearchField(fieldEditor))
+    }
+
+    @Test func `a click on the field itself counts as inside it`() {
+        #expect(SearchFieldClickAway.isInsideSearchField(NSSearchField()))
+    }
+
+    @Test func `a click on a list row counts as outside the field`() {
+        let column = NSView()
+        let row = NSView()
+        column.addSubview(row)
+
+        #expect(!SearchFieldClickAway.isInsideSearchField(row))
+    }
+
+    /// A click that hit-tests to nothing (window chrome, the desktop) is not in the field either.
+    @Test func `a click on nothing counts as outside the field`() {
+        #expect(!SearchFieldClickAway.isInsideSearchField(nil))
+    }
+}

--- a/Tests/BrewUIComponentsTests/SearchFocusArbiterTests.swift
+++ b/Tests/BrewUIComponentsTests/SearchFocusArbiterTests.swift
@@ -251,4 +251,33 @@ struct SearchFocusArbiterTests {
         #expect(arbiter.isSearchFieldPresented)
         #expect(arbiter.isSearchFocusPending)
     }
+
+    // MARK: - Switching tab
+
+    @Test func `switching tab hands the rebuilt list the keyboard`() {
+        var arbiter = SearchFocusArbiter()
+
+        arbiter.activeListDidChange()
+
+        #expect(arbiter.target == .list)
+    }
+
+    @Test func `switching tab does not take the keyboard from the search field`() {
+        var arbiter = SearchFocusArbiter(target: .searchField, isSearchFieldPresented: true)
+
+        arbiter.activeListDidChange()
+
+        #expect(arbiter.target == .searchField)
+        #expect(arbiter.isSearchFieldPresented)
+    }
+
+    @Test func `switching tab does not cancel a pending claim`() {
+        var arbiter = SearchFocusArbiter(target: .list)
+
+        arbiter.requestSearchFocus()
+        arbiter.activeListDidChange()
+
+        #expect(arbiter.isSearchFocusPending)
+        #expect(arbiter.target == .list)
+    }
 }

--- a/Tests/BrewUIComponentsTests/SearchFocusArbiterTests.swift
+++ b/Tests/BrewUIComponentsTests/SearchFocusArbiterTests.swift
@@ -221,4 +221,34 @@ struct SearchFocusArbiterTests {
 
         #expect(arbiter.target == .list)
     }
+
+    // MARK: - Clicking away from the field
+
+    @Test func `a click outside an empty field collapses it and hands the list the keyboard`() {
+        var arbiter = SearchFocusArbiter(target: .searchField, isSearchFieldPresented: true)
+
+        arbiter.clickLandedOutsideSearchField(searchFieldIsEmpty: true)
+
+        #expect(!arbiter.isSearchFieldPresented)
+        #expect(arbiter.target == .list)
+    }
+
+    @Test func `a click outside a field with a query leaves the field in the toolbar`() {
+        var arbiter = SearchFocusArbiter(target: .searchField, isSearchFieldPresented: true)
+
+        arbiter.clickLandedOutsideSearchField(searchFieldIsEmpty: false)
+
+        #expect(arbiter.isSearchFieldPresented)
+        #expect(arbiter.target == .list)
+    }
+
+    @Test func `a click outside does not cancel a pending claim`() {
+        var arbiter = SearchFocusArbiter(target: .list)
+
+        arbiter.requestSearchFocus()
+        arbiter.clickLandedOutsideSearchField(searchFieldIsEmpty: true)
+
+        #expect(arbiter.isSearchFieldPresented)
+        #expect(arbiter.isSearchFocusPending)
+    }
 }


### PR DESCRIPTION
# PR: Dismiss the search field on any outside click, and keep list focus across tabs

## Summary

Two follow-ups to the search focus work. Clicking outside the field only dismissed it when the click moved focus, and switching between Installed and Upgrades left the keyboard nowhere.

## Changes

Click-away dismissal:

- A local left mouse down monitor decides from the click itself, not from `@FocusState`, which never moves for a click on a header, a picker or empty space.
- The field lives in the title bar, so the hit test runs from the theme frame and walks up for an `NSSearchField`.
- Clicking away hands the keyboard back to the list, and collapses the field only when empty, so a typed query keeps its place.

Tab switching:

- The container is shared, so the target stayed `.list` across a switch and nothing reapplied it to `@FocusState`. SwiftUI had dropped focus rebuilding the column, so arrow keys were dead until a row was clicked.
- `activeListDidChange()` claims the keyboard for the rebuilt list unless the field is using it or a Cmd-F claim is pending. Both guards sit in the arbiter.

## Testing

- [x] `scripts/test`: 775 unit tests pass, 10 of them new.
- [x] SwiftFormat, SwiftLint strict, BrewUILint clean; UI test target builds.
- [x] In the built app: a click on header chrome dismisses an empty field; a click on the list with a query moves the keyboard but keeps the text.
- [x] List holds the keyboard after 12 tab switches across 4 runs, where none held it before. A keyboard switch with the cursor in the field leaves it there.
- [x] Escape rounds and launch time unchanged.
- [ ] Three new UI tests compile but did not run (unsigned runner).

## PR checklist

- [x] Have you followed this repository's contribution and workflow guidance?
- [x] Have you explained what changed and why this should land now?
- [x] Have you run relevant local checks for the changed scope?
- [x] Are changes scoped and free of unrelated modifications?

-----

- [x] AI was used to generate or assist with generating this PR.
- [x] Claude Code probed the view hierarchy to derive the hit test, read the app's focus state to diagnose the tab switch, then wrote and verified the fixes. Mouse clicks and Cmd-F were not AI verified.

