### PR TITLE
Enhance status icon with help text

### DIFF
--- a/Sources/BrewFeatureInstalled/Views/InstalledListRowView.swift
+++ b/Sources/BrewFeatureInstalled/Views/InstalledListRowView.swift
@@ -96,6 +96,7 @@ struct InstalledListRowView: View {
                 .font(.body)
                 .foregroundStyle(statusIconColor(viewModel: viewModel))
                 .accessibilityHidden(true)
+                .help(statusIconHelp(viewModel: viewModel))
 
             Text(viewModel.kind.chrome.badgeLabel)
                 .font(.brewCaption2)
@@ -121,6 +122,10 @@ struct InstalledListRowView: View {
 
     private func statusIconColor(viewModel: InstalledListRowViewModel) -> Color {
         viewModel.showsUpgradeAvailable ? .brewStatusWarning : .brewStatusSuccess
+    }
+
+    private func statusIconHelp(viewModel: InstalledListRowViewModel) -> String {
+        viewModel.showsUpgradeAvailable ? "An upgrade is available" : "Up to date"
     }
 
     @ViewBuilder


### PR DESCRIPTION
# PR: Add help text for status icon based on upgrade availability

## Summary

The exclamation mark is not very clear right now, so adding a help text helps users understand what it means. I just followed the documentation in https://developer.apple.com/documentation/swiftui/view/help(_:)-6oiyb and did not try to build this myself.

## Changes

- Add a help text to the installed/upgrade list item status icon

## Testing

- [ ] None

## PR checklist

- [ ] Have you followed this repository's contribution and workflow guidance?
- [x] Have you explained what changed and why this should land now?
- [ ] Have you run relevant local checks for the changed scope?
- [ ] Are changes scoped and free of unrelated modifications?

-----

- [ ] AI was used to generate or assist with generating this PR.
- [ ] If yes, describe exactly how AI was used and what manual verification was performed.

-----

## Follow-ups (optional)

Anything deliberately out of scope for this PR (e.g. “CI in a follow-up”) or notes for stacked review.
