### PR TITLE
Stop two families of flaky test

### DIFF
--- a/Tests/BrewCLITests/PseudoTerminalTests.swift
+++ b/Tests/BrewCLITests/PseudoTerminalTests.swift
@@ -127,12 +127,33 @@ private extension PseudoTerminalTests {
             }
         }
         process.waitUntilExit()
+        drainPending(terminal, into: &data)
 
         terminal.closeReplica()
         drainToEndOfInput(terminal, into: &data)
         terminal.closePrimary()
 
         return UTF8StreamDecoder.lossyString(data)
+    }
+
+    /// Darwin discards whatever is still queued on the terminal when the last replica descriptor closes,
+    /// so the child's bytes have to be read before ``PseudoTerminal/closeReplica()``. The child has been
+    /// reaped by this point, so what is queued now is all there will ever be.
+    func drainPending(_ terminal: PseudoTerminal, into data: inout Data) {
+        pending: while true {
+            switch terminal.read(timeout: .zero) {
+            case let .data(chunk):
+                data.append(chunk)
+            case .timedOut:
+                break pending
+            case .endOfInput:
+                Issue.record("end of input arrived while this process still held the replica open")
+                break pending
+            case let .failed(code):
+                Issue.record("reading the terminal failed: \(PseudoTerminal.describe(errno: code))")
+                break pending
+            }
+        }
     }
 
     func drainToEndOfInput(_ terminal: PseudoTerminal, into data: inout Data) {

--- a/Tests/BrewCLITests/SerialBrewCommandCenterOutputTests.swift
+++ b/Tests/BrewCLITests/SerialBrewCommandCenterOutputTests.swift
@@ -61,7 +61,7 @@ struct SerialBrewCommandCenterOutputTests {
         defer { collect.cancel() }
 
         try await center.capture(command("go"), id: id)
-        try await Task.sleep(for: .milliseconds(80))
+        try await waitUntil { await collector.events.count == 4 }
 
         let lines = await collector.events.filter { $0.0 == id }.map(\.1)
         #expect(lines.map(\.text) == ["one", "two", "warn", "three"])
@@ -85,7 +85,7 @@ struct SerialBrewCommandCenterOutputTests {
 
         try await center.capture(command("a"), id: idA)
         try await center.capture(command("b"), id: idB)
-        try await Task.sleep(for: .milliseconds(80))
+        try await waitUntil { await collector.events.count == 3 }
 
         let events = await collector.events
         #expect(events.filter { $0.0 == idA }.map(\.1.text) == ["a1", "a2"])
@@ -115,7 +115,11 @@ struct SerialBrewCommandCenterOutputTests {
         }
 
         try await center.capture(command("go"), id: id)
-        try await Task.sleep(for: .milliseconds(80))
+        try await waitUntil {
+            let countA = await collectorA.events.count
+            let countB = await collectorB.events.count
+            return countA == 2 && countB == 2
+        }
 
         let textsA = await collectorA.events.map(\.1.text)
         let textsB = await collectorB.events.map(\.1.text)
@@ -134,10 +138,19 @@ struct SerialBrewCommandCenterOutputTests {
             }
         }
         collect.cancel()
-        try await Task.sleep(for: .milliseconds(20))
+        await collect.value
+
+        let witnessStream = await center.allOutputChanges()
+        let witness = AllOutputCollector()
+        let observe = Task {
+            for await pair in witnessStream {
+                await witness.append(id: pair.0, line: pair.1)
+            }
+        }
+        defer { observe.cancel() }
 
         try await center.capture(command("go"), id: id)
-        try await Task.sleep(for: .milliseconds(80))
+        try await waitUntil { await witness.events.count == 1 }
 
         let events = await collector.events
         #expect(events.isEmpty)

--- a/Tests/BrewCLITests/SerialBrewCommandCenterTests.swift
+++ b/Tests/BrewCLITests/SerialBrewCommandCenterTests.swift
@@ -68,16 +68,24 @@ struct SerialBrewCommandCenterTests {
 
     @Test func `duplicate id coalesces to a single command body`() async throws {
         let counter = InvocationCounter()
+        let gate = TestGate()
         let center = makeCenter(runner: ClosureRunner { _ in
             await counter.increment()
-            try await Task.sleep(for: .milliseconds(30))
+            await gate.wait()
             return successOutput
         })
         let id = BrewOperationID(kind: .formula, name: "git")
 
         let first = Task { try await center.perform(noopCommand, id: id) }
-        try await Task.sleep(for: .milliseconds(5))
-        let second = Task { try await center.perform(noopCommand, id: id) }
+        try await waitUntil { await counter.value == 1 }
+
+        let submitting = InvocationCounter()
+        let second = Task {
+            await submitting.increment()
+            try await center.perform(noopCommand, id: id)
+        }
+        try await waitUntil { await submitting.value == 1 }
+        await gate.open()
 
         try await first.value
         try await second.value
@@ -157,7 +165,7 @@ struct SerialBrewCommandCenterTests {
         defer { collect.cancel() }
 
         try await center.perform(noopCommand, id: id)
-        try await Task.sleep(for: .milliseconds(80))
+        try await waitUntil { await collector.phases.count >= 3 }
         let values = await collector.phases
         #expect(values.count >= 3)
         #expect(values.first == .idle)
@@ -190,7 +198,11 @@ struct SerialBrewCommandCenterTests {
         }
 
         try await center.perform(noopCommand, id: id)
-        try await Task.sleep(for: .milliseconds(80))
+        try await waitUntil {
+            let countA = await collectorA.phases.count
+            let countB = await collectorB.phases.count
+            return countA >= 3 && countB >= 3
+        }
         let countA = await collectorA.phases.count
         let countB = await collectorB.phases.count
         #expect(countA >= 3)
@@ -199,10 +211,11 @@ struct SerialBrewCommandCenterTests {
 
     @Test func `recording wrapper logs each submit while duplicate id coalesces body`() async throws {
         let counter = InvocationCounter()
+        let gate = TestGate()
         let ctx = BrewCommandExecutionContext(
             commandRunner: ClosureRunner { _ in
                 await counter.increment()
-                try await Task.sleep(for: .milliseconds(30))
+                await gate.wait()
                 return successOutput
             },
             locator: BrewExecutableLocator(overrideURL: InstalledPackagesTestSupport.fakeBrewExecutableURL),
@@ -211,8 +224,10 @@ struct SerialBrewCommandCenterTests {
         let id = BrewOperationID(kind: .formula, name: "git")
 
         let first = Task { try await center.perform(noopCommand, id: id) }
-        try await Task.sleep(for: .milliseconds(5))
+        try await waitUntil { await counter.value == 1 }
         let second = Task { try await center.perform(noopCommand, id: id) }
+        try await waitUntil { await center.recordedSubmitEntries.count == 2 }
+        await gate.open()
 
         try await first.value
         try await second.value
@@ -240,7 +255,7 @@ struct SerialBrewAllPhaseStreamTests {
 
         try await center.perform(noopCommand, id: idA)
         try await center.perform(noopCommand, id: idB)
-        try await Task.sleep(for: .milliseconds(80))
+        try await waitUntil { await collector.events.count >= 4 }
         let events = await collector.events
         let eventsForA = events.filter { $0.0 == idA }.map(\.1)
         let eventsForB = events.filter { $0.0 == idB }.map(\.1)
@@ -279,7 +294,11 @@ struct SerialBrewAllPhaseStreamTests {
         }
 
         try await center.perform(noopCommand, id: id)
-        try await Task.sleep(for: .milliseconds(80))
+        try await waitUntil {
+            let countA = await collectorA.events.count
+            let countB = await collectorB.events.count
+            return countA >= 2 && countB >= 2
+        }
         let eventsA = await collectorA.events
         let eventsB = await collectorB.events
         #expect(eventsA.count == eventsB.count)
@@ -301,10 +320,20 @@ struct SerialBrewAllPhaseStreamTests {
             }
         }
         collect.cancel()
-        try await Task.sleep(for: .milliseconds(20))
+        await collect.value
+
+        let witnessStream = await center.allPhaseChanges()
+        let witness = AllPhaseStreamCollector()
+        let observe = Task {
+            for await pair in witnessStream {
+                await witness.append(id: pair.0, phase: pair.1)
+            }
+        }
 
         try await center.perform(noopCommand, id: id)
-        try await Task.sleep(for: .milliseconds(80))
+        try await waitUntil { await witness.events.count >= 2 }
+        observe.cancel()
+
         let eventsAfterCancel = await collector.events
         #expect(eventsAfterCancel.isEmpty)
 
@@ -318,7 +347,7 @@ struct SerialBrewAllPhaseStreamTests {
         defer { collect2.cancel() }
 
         try await center.perform(noopCommand, id: id)
-        try await Task.sleep(for: .milliseconds(80))
+        try await waitUntil { await collector2.events.count >= 2 }
         let eventsFresh = await collector2.events
         #expect(eventsFresh.count >= 2)
         #expect(eventsFresh.first?.0 == id)


### PR DESCRIPTION
# PR: Stop two families of flaky test

## Summary

Two unrelated flakes, both in test timing. Twelve command centre tests slept and then asserted what a stream subscriber had collected. The pty suite lost the child's output to a kernel behaviour the previous fix walked into.

## Changes

**Waiting instead of sleeping.** The sleep was sizing how long delivery should take, a guess in both directions: too short and a loaded runner fails a test that is merely late, too long and every run pays the worst case. Sixteen sleeps across two files now poll the condition through `waitUntil`. The two coalescing tests sized an overlap window rather than a delay, so `TestGate` holds the runner open until the test lets it go. The two cleanup tests assert an absence, so they await the cancelled task and add a live witness subscriber to wait on.

**Reading the terminal dry.** Darwin discards whatever is still queued on a pty when the last replica descriptor closes; writing three bytes and closing leaves the primary with nothing to read. The earlier fix moved that close into the test process, right after a loop that can exit with bytes still queued: a poll times out, the child writes and exits before `isRunning` is read, the loop breaks without polling again, and the close destroys the output. The suite now reads the terminal dry once the child is reaped, before dropping the replica.

## Testing

- [x] `scripts/test`: full package suite green.
- [x] The pty failure reproduces on demand by stalling the gap between the poll timeout and the `isRunning` check: 2ms loses output on a quarter of runs, 60ms on all of them, both matching the signature CI reported. Every stall passes with the drain in place.
- [x] Mutation check on the converted tests: dropping the output broadcast makes them time out at the call site rather than pass vacuously.

## PR checklist

- [x] Have you followed this repository's contribution and workflow guidance?
- [x] Have you explained what changed and why this should land now?
- [x] Have you run relevant local checks for the changed scope?
- [x] Are changes scoped and free of unrelated modifications?

-----

- [x] AI was used to generate or assist with generating this PR.
- [x] Claude diagnosed the pty behaviour and wrote both commits; the `waitUntil` signature was specified by hand.
