### PR TITLE
Let both split-view panes fill a wide window

### DIFF
--- a/Sources/BrewFeatureConfig/Views/ConfigView.swift
+++ b/Sources/BrewFeatureConfig/Views/ConfigView.swift
@@ -44,6 +44,7 @@ struct ConfigView: View {
         }
         .padding(.horizontal, BrewSpacing.lg)
         .padding(.vertical, BrewSpacing.md)
+        .brewPaneContentWidth()
     }
 
     @ViewBuilder
@@ -69,7 +70,7 @@ struct ConfigView: View {
                 }
             }
             .padding(BrewSpacing.lg)
-            .frame(maxWidth: .infinity, alignment: .topLeading)
+            .brewPaneContentWidth()
         }
     }
 

--- a/Sources/BrewFeatureDiscover/Views/DiscoverColumns.swift
+++ b/Sources/BrewFeatureDiscover/Views/DiscoverColumns.swift
@@ -46,7 +46,7 @@ struct DiscoverColumns: View {
                 .frame(
                     minWidth: BrewLayout.installedListColumnMinWidth,
                     idealWidth: BrewLayout.installedListColumnIdealWidth,
-                    maxWidth: BrewLayout.installedListColumnMaxWidth,
+                    maxWidth: .infinity,
                     maxHeight: .infinity,
                     alignment: .topLeading,
                 )
@@ -61,7 +61,7 @@ struct DiscoverColumns: View {
             .frame(
                 minWidth: BrewLayout.inspectorWidth,
                 idealWidth: BrewLayout.installedDetailColumnIdealWidth,
-                maxWidth: BrewLayout.installedDetailColumnMaxWidth,
+                maxWidth: .infinity,
                 maxHeight: .infinity,
                 alignment: .topLeading,
             )

--- a/Sources/BrewFeatureDiscover/Views/DiscoverPackageDetailView.swift
+++ b/Sources/BrewFeatureDiscover/Views/DiscoverPackageDetailView.swift
@@ -60,6 +60,7 @@ struct DiscoverPackageDetailView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(BrewSpacing.xl)
+            .brewPaneContentWidth()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .accessibilityElement(children: .contain)
@@ -308,6 +309,7 @@ struct DiscoverPackageDetailPlaceholder: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .padding(BrewSpacing.xl)
+        .brewPaneContentWidth()
     }
 }
 

--- a/Sources/BrewFeatureDoctor/Views/DoctorColumns.swift
+++ b/Sources/BrewFeatureDoctor/Views/DoctorColumns.swift
@@ -51,7 +51,7 @@ struct DoctorColumns: View {
                 .frame(
                     minWidth: BrewLayout.installedListColumnMinWidth,
                     idealWidth: BrewLayout.installedListColumnIdealWidth,
-                    maxWidth: BrewLayout.installedListColumnMaxWidth,
+                    maxWidth: .infinity,
                     maxHeight: .infinity,
                     alignment: .topLeading,
                 )
@@ -66,7 +66,7 @@ struct DoctorColumns: View {
             .frame(
                 minWidth: BrewLayout.inspectorWidth,
                 idealWidth: BrewLayout.installedDetailColumnIdealWidth,
-                maxWidth: BrewLayout.installedDetailColumnMaxWidth,
+                maxWidth: .infinity,
                 maxHeight: .infinity,
                 alignment: .topLeading,
             )

--- a/Sources/BrewFeatureDoctor/Views/DoctorIssueDetailView.swift
+++ b/Sources/BrewFeatureDoctor/Views/DoctorIssueDetailView.swift
@@ -35,6 +35,7 @@ struct DoctorIssueDetailView: View {
                 }
             }
             .padding(BrewSpacing.xl)
+            .brewPaneContentWidth()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
@@ -231,6 +232,7 @@ struct DoctorDetailPlaceholder: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .padding(BrewSpacing.xl)
+        .brewPaneContentWidth()
     }
 }
 

--- a/Sources/BrewFeatureInstalled/Views/InstalledColumns.swift
+++ b/Sources/BrewFeatureInstalled/Views/InstalledColumns.swift
@@ -18,7 +18,7 @@ struct InstalledColumns: View {
             .frame(
                 minWidth: BrewLayout.installedListColumnMinWidth,
                 idealWidth: BrewLayout.installedListColumnIdealWidth,
-                maxWidth: BrewLayout.installedListColumnMaxWidth,
+                maxWidth: .infinity,
                 maxHeight: .infinity,
                 alignment: .topLeading,
             )
@@ -36,7 +36,7 @@ struct InstalledColumns: View {
             .frame(
                 minWidth: BrewLayout.inspectorWidth,
                 idealWidth: BrewLayout.installedDetailColumnIdealWidth,
-                maxWidth: BrewLayout.installedDetailColumnMaxWidth,
+                maxWidth: .infinity,
                 maxHeight: .infinity,
                 alignment: .topLeading,
             )

--- a/Sources/BrewFeatureInstalled/Views/InstalledPackageDetailView.swift
+++ b/Sources/BrewFeatureInstalled/Views/InstalledPackageDetailView.swift
@@ -90,6 +90,7 @@ struct InstalledPackageDetailView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(BrewSpacing.xl)
+            .brewPaneContentWidth()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
@@ -280,6 +281,7 @@ struct InstalledPackageDetailPlaceholder: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .padding(BrewSpacing.xl)
+        .brewPaneContentWidth()
     }
 }
 

--- a/Sources/BrewFeatureInstalled/Views/UpgradesColumns.swift
+++ b/Sources/BrewFeatureInstalled/Views/UpgradesColumns.swift
@@ -15,7 +15,7 @@ struct UpgradesColumns: View {
                 .frame(
                     minWidth: BrewLayout.installedListColumnMinWidth,
                     idealWidth: BrewLayout.installedListColumnIdealWidth,
-                    maxWidth: BrewLayout.installedListColumnMaxWidth,
+                    maxWidth: .infinity,
                     maxHeight: .infinity,
                     alignment: .topLeading,
                 )
@@ -37,7 +37,7 @@ struct UpgradesColumns: View {
             .frame(
                 minWidth: BrewLayout.inspectorWidth,
                 idealWidth: BrewLayout.installedDetailColumnIdealWidth,
-                maxWidth: BrewLayout.installedDetailColumnMaxWidth,
+                maxWidth: .infinity,
                 maxHeight: .infinity,
                 alignment: .topLeading,
             )

--- a/Sources/BrewUIComponents/Theme/BrewSpacing.swift
+++ b/Sources/BrewUIComponents/Theme/BrewSpacing.swift
@@ -41,12 +41,12 @@ public enum BrewLayout {
     /// Installed list column (middle pane of `NavigationSplitView`).
     public static let installedListColumnMinWidth: CGFloat = 300
     public static let installedListColumnIdealWidth: CGFloat = 400
-    public static let installedListColumnMaxWidth: CGFloat = 800
 
     /// Third column (package detail).
     public static let installedDetailColumnIdealWidth: CGFloat = 400
-    public static let installedDetailColumnMaxWidth: CGFloat = 1200
     public static let installedThreePaneMinWindowWidth: CGFloat = 960
+
+    public static let paneContentMaxWidth: CGFloat = 800
 
     /// Call-to-action row in a pane header. Clears a `.regular` bordered button, so pinning the row to it
     /// leaves the button's own metrics alone while giving anything that stands in for it the same height.

--- a/Sources/BrewUIComponents/Views/PaneContentWidth.swift
+++ b/Sources/BrewUIComponents/Views/PaneContentWidth.swift
@@ -1,0 +1,15 @@
+//
+//  PaneContentWidth.swift
+//  BrewUIComponents
+//
+
+import SwiftUI
+
+public extension View {
+    /// The outer frame keeps the enclosing scroll view full-width, so its scroller stays at the pane's
+    /// trailing edge rather than stopping where the content does.
+    func brewPaneContentWidth() -> some View {
+        frame(maxWidth: BrewLayout.paneContentMaxWidth, alignment: .leading)
+            .frame(maxWidth: .infinity, alignment: .center)
+    }
+}


### PR DESCRIPTION
# PR: Let both split-view panes fill a wide window

## Summary

On a wide display the detail pane's scroll view stopped short of the window's right edge, leaving the
scroller stranded mid-window. Both panes now keep expanding, and pane content caps at a readable
width and centres.

## Changes

- Removed the hard `maxWidth` on both `HSplitView` panes in the Installed, Upgrades, Discover and
  Doctor column views. `HSplitView` splits the extra space 50/50 and preserves the ratio after a
  manual divider drag.
- Added `brewPaneContentWidth()` in `BrewUIComponents/Views/PaneContentWidth.swift`: caps content at
  `BrewLayout.paneContentMaxWidth` (800) and centres it while the scroll view stays full width, so
  the scroller sits at the pane's trailing edge. This file is where the thinking is.
- Applied it to the three detail views and their no-selection placeholders.
- Config tab: cards and the Copy report / Refresh header get the same cap, so the buttons stay over
  the cards' trailing edge.
- Dropped the now-unused `installedListColumnMaxWidth` and `installedDetailColumnMaxWidth`.

Below 800pt of pane width nothing changes: at the default 1000pt window each pane is 500pt, as before.

## Testing

- [x] `xcrun swift build` succeeds.
- [x] `scripts/test`: 899 tests in 106 suites (BrewKit), 19 in 2 suites (BrewUILint), all passing.
- [x] `swiftformat --lint` clean (0/354), `swiftlint --strict` clean (0 violations), BrewUILint exit 0.
- [x] Measured in a standalone AppKit harness. Before: the split view stopped at 2001pt inside a
  3000pt window. After: panes 1499.5pt each, scroller at x=2983, content box 800pt and centred.
- [ ] Not run: the app itself, and the UI tests, neither of which run in this sandbox.

## PR checklist

- [x] Have you followed this repository's contribution and workflow guidance?
- [x] Have you explained what changed and why this should land now?
- [x] Have you run relevant local checks for the changed scope?
- [x] Are changes scoped and free of unrelated modifications?

-----

- [x] AI was used to generate or assist with generating this PR.
- [x] Claude Code diagnosed the cause and wrote the change. Verification was the local gates above
  plus the measurement harness. Nobody has run the built app.

## Follow-ups (optional)

Worth a look on a real wide display to confirm 800pt is the right cap.
