### PR TITLE
Correct documented macOS versions' support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Enable CLI-averse users to safely discover, install, update, and manage Homebrew
 ## 📲 Tech
 
 - **Swift 6.0** with strict concurrency · **SwiftUI** · **Swift Package Manager**
-- **macOS Tahoe 26+** (also supports Sequoia 15, Sonoma 14)
+- **macOS Tahoe 26+**
 - Data from the `brew` CLI and the [Homebrew JSON API](https://formulae.brew.sh/docs/api/)
 
 ## 📦 Installation


### PR DESCRIPTION
# PR: Correct documented macOS versions' support

## Summary

This glaring error has been sat here for a long time and I completely looked past it.

This only supported >=Tahoe from day 1.

## Changes

- Remove Sequoia 15, Sonoma 14 from documented supported versions

## Testing

- [ ] Steps you ran locally to verify (e.g. build, tests, manual checks).
- [ ] Add or remove items to match this PR’s scope.

## PR checklist

- [ ] Have you followed this repository's contribution and workflow guidance?
- [ ] Have you explained what changed and why this should land now?
- [ ] Have you run relevant local checks for the changed scope?
- [ ] Are changes scoped and free of unrelated modifications?

-----

- [ ] AI was used to generate or assist with generating this PR.
- [ ] If yes, describe exactly how AI was used and what manual verification was performed.