### PR TITLE
Handle shell startup output in installed package JSON

### DIFF
--- a/Sources/BrewRepositories/BrewInstalledPackagesRepository.swift
+++ b/Sources/BrewRepositories/BrewInstalledPackagesRepository.swift
@@ -224,17 +224,24 @@ public final class BrewInstalledPackagesRepository: InstalledPackagesRepository 
     }
 
     private func decodeInfoJSON(from standardOutput: String) throws -> BrewInfoJSON {
-        let data = Data(standardOutput.utf8)
-        do {
-            return try JSONDecoder().decode(BrewInfoJSON.self, from: data)
-        } catch {
-            throw BrewCommandError.launchFailed(
-                underlying: String(
-                    localized: "Failed to decode Homebrew JSON output.",
-                    comment: "Installed tab JSON decode failure",
-                ),
-            )
+        let decoder = JSONDecoder()
+        if let payload = try? decoder.decode(BrewInfoJSON.self, from: Data(standardOutput.utf8)) {
+            return payload
         }
+
+        for jsonStart in standardOutput.indices where standardOutput[jsonStart] == "{" {
+            let jsonOutput = standardOutput[jsonStart...]
+            if let payload = try? decoder.decode(BrewInfoJSON.self, from: Data(jsonOutput.utf8)) {
+                return payload
+            }
+        }
+
+        throw BrewCommandError.launchFailed(
+            underlying: String(
+                localized: "Failed to decode Homebrew JSON output.",
+                comment: "Installed tab JSON decode failure",
+            ),
+        )
     }
 }
 

--- a/Tests/BrewRepositoriesTests/BrewInstalledPackagesRepositoryTests.swift
+++ b/Tests/BrewRepositoriesTests/BrewInstalledPackagesRepositoryTests.swift
@@ -13,6 +13,27 @@ import Foundation
 import Testing
 
 struct BrewInstalledPackagesRepositoryTests {
+    @Test @MainActor func `load ignores interactive shell output before installed info json`() async {
+        let runner = MockBrewCommandRunner(
+            responses: InstalledPackagesTestSupport.installedInfoJSONResponse(
+                standardOutput: """
+                \u{1B}]1337;SetUserVar=badge={"theme":"dark"}\u{7}
+                {
+                  "formulae": [
+                    { "name": "wget", "versions": { "stable": "1.0.0" }, "installed": [{ "version": "1.0.0" }] }
+                  ],
+                  "casks": []
+                }
+                """,
+            ),
+        )
+        let repo = InstalledPackagesTestSupport.repository(commandRunner: runner)
+
+        let packages = await InstalledPackagesTestSupport.loadedPackages(from: repo)
+
+        #expect(packages.map(\.name) == ["wget"])
+    }
+
     @Test @MainActor func `load returns sorted packages for mixed formula and cask json payload`() async throws {
         let json = """
         {


### PR DESCRIPTION
Fixes https://github.com/Homebrew/BrewUI/issues/163

## Summary

Allow the Installed repository to decode `brew info --installed --json=v2`
when interactive-shell startup output appears before Homebrew's JSON.

This was reproduced with iTerm2 shell integration emitting OSC 1337 sequences
before an otherwise valid Homebrew JSON payload.

## Changes

- Preserve the existing login/interactive shell behavior.
- Recover the Homebrew JSON payload after leading shell startup output.
- Add a regression test for JSON-like shell output before the real payload.

## Testing

- [x] Syntax-checked the changed Swift files.
- [x] `git diff --check`.
- [ ] Targeted test not run locally due to local toolchain limitations.

## PR checklist

- [x] Have you followed this repository's contribution and workflow guidance?
- [x] Have you explained what changed and why this should land now?
- [x] Have you run relevant local checks for the changed scope?
- [x] Are changes scoped and free of unrelated modifications?

-----

- [x] AI was used to generate or assist with generating this PR.
- [x] ChatGPT and OpenAI Codex assisted with reproducing the failure, reviewing
  the decoding boundary, and drafting the regression and implementation.
  I manually reproduced the issue and reviewed the final diff.