### PR TITLE
Remove title and icon from sidebar

### DIFF
--- a/Homebrew/Views/MainSidebarView.swift
+++ b/Homebrew/Views/MainSidebarView.swift
@@ -13,24 +13,6 @@ struct MainSidebarView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            HStack(alignment: .bottom, spacing: BrewSpacing.sm) {
-                Image("Mark")
-                    .resizable()
-                    .scaledToFit()
-                    .frame(height: 24)
-                Text("Homebrew")
-                    .font(.brewTitle2)
-                    .foregroundStyle(Color.brewTextPrimary)
-            }
-            .padding(.horizontal, BrewSpacing.md)
-            .padding(.vertical, BrewSpacing.md)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .accessibilityElement(children: .combine)
-            .accessibilityLabel("Homebrew")
-
-            Divider()
-                .overlay(Color.brewBorderSeparator)
-
             sidebarRow(
                 title: "Installed",
                 emoji: "📦",


### PR DESCRIPTION
# PR: Remove title and icon from the sidebar

## Summary

This PR removes the "Homebrew" wordmark, the "Mark" icon, and the divider that sat at the top of the main sidebar. The header duplicated branding that is already present in the window and the app itself, and removing it gives the navigation rows more vertical room and a cleaner top edge.

## Changes

- `Homebrew/Views/MainSidebarView.swift`
  - Deleted the header `HStack` containing the `Image("Mark")` logo and the `Text("Homebrew")` title, along with its horizontal and vertical padding and its combined accessibility element and label.
  - Deleted the `Divider` with the `Color.brewBorderSeparator` overlay that separated the header from the navigation rows.
  - The sidebar now starts directly with the "Installed" row, which keeps its existing top padding, so the remaining rows and their spacing are unchanged.

No other files are touched. The `sidebarRow` helper, the selection binding, the accessibility container on the sidebar, and the preview are all unchanged.

## Why this split (optional)

This is intentionally a small, self contained visual change so it can be reviewed and reverted on its own without being entangled with other sidebar or navigation work.

## Testing

- [x] Built the app locally; BrewUILint runs in the build phase and passed.
- [x] Launched the app and confirmed the sidebar renders with no title, icon, or top divider, and that the first row is no longer crowded against the top.
- [x] Checked that selecting each destination still works and that the selected row styling is correct.

## PR checklist

- [x] Have you followed this repository's contribution and workflow guidance?
- [x] Have you explained what changed and why this should land now?
- [x] Have you run relevant local checks for the changed scope?
- [x] Are changes scoped and free of unrelated modifications?

-----

- [ ] AI was used to generate or assist with generating this PR.
- [ ] If yes, describe exactly how AI was used and what manual verification was performed.